### PR TITLE
feat: add automation URL scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,26 @@ This will remove the app from `/Applications`, delete preferences and caches, an
 | Open Cloud Uploads                                      | `⇧⌘L`    |
 | Show shortcuts list                                     | `⇧⌘K`    |
 
+## Automation
+
+Snapzy registers the `snapzy://` URL scheme so launchers and automation tools can trigger capture actions.
+
+| Action                  | URL |
+| ----------------------- | --- |
+| Fullscreen screenshot   | `snapzy://capture/fullscreen` |
+| Area screenshot         | `snapzy://capture/area` |
+| Scrolling screenshot    | `snapzy://capture/scrolling` |
+| OCR text capture        | `snapzy://capture/ocr` |
+| Object cutout capture   | `snapzy://capture/object-cutout` |
+| Screen recording        | `snapzy://record/screen` |
+| Open Annotate           | `snapzy://open/annotate` |
+| Open Video Editor       | `snapzy://open/video-editor` |
+| Open Cloud Uploads      | `snapzy://open/cloud-uploads` |
+| Open Capture History    | `snapzy://open/history` |
+| Show shortcuts list     | `snapzy://show/shortcuts` |
+| Open Settings           | `snapzy://settings` |
+| Open Settings tab       | `snapzy://settings?tab=shortcuts` |
+
 ## Development
 
 For local setup, source builds, and first-time development workflow, start with [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).

--- a/Snapzy/App/AppCoordinator.swift
+++ b/Snapzy/App/AppCoordinator.swift
@@ -78,6 +78,11 @@ final class AppCoordinator {
     observers.removeAll()
   }
 
+  func handleDeepLink(_ url: URL) {
+    SnapzyDeepLinkHandler(screenCaptureViewModel: environment.screenCaptureViewModel)
+      .handle(url)
+  }
+
   private func observeNotifications() {
     let onboardingObserver = NotificationCenter.default.addObserver(
       forName: .showOnboarding,

--- a/Snapzy/App/SnapzyApp.swift
+++ b/Snapzy/App/SnapzyApp.swift
@@ -5,6 +5,7 @@
 //  Main app entry point - Menu Bar App
 //
 
+import Carbon
 import SwiftUI
 
 // MARK: - Notification Names
@@ -36,6 +37,16 @@ struct SnapzyApp: App {
 @MainActor
 class AppDelegate: NSObject, NSApplicationDelegate {
   private var coordinator: AppCoordinator?
+  private var pendingDeepLinkURLs: [URL] = []
+
+  func applicationWillFinishLaunching(_ notification: Notification) {
+    NSAppleEventManager.shared().setEventHandler(
+      self,
+      andSelector: #selector(handleGetURLEvent(_:withReplyEvent:)),
+      forEventClass: AEEventClass(kInternetEventClass),
+      andEventID: AEEventID(kAEGetURL)
+    )
+  }
 
   func applicationDidFinishLaunching(_ notification: Notification) {
     AppIdentityManager.shared.refresh()
@@ -46,9 +57,42 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let coordinator = AppCoordinator(environment: AppEnvironment.live())
     self.coordinator = coordinator
     coordinator.applicationDidFinishLaunching()
+    flushPendingDeepLinks()
   }
 
   func applicationWillTerminate(_ notification: Notification) {
+    NSAppleEventManager.shared().removeEventHandler(
+      forEventClass: AEEventClass(kInternetEventClass),
+      andEventID: AEEventID(kAEGetURL)
+    )
     coordinator?.applicationWillTerminate()
+  }
+
+  @objc private func handleGetURLEvent(
+    _ event: NSAppleEventDescriptor,
+    withReplyEvent replyEvent: NSAppleEventDescriptor
+  ) {
+    guard
+      let urlString = event.paramDescriptor(forKeyword: keyDirectObject)?.stringValue,
+      let url = URL(string: urlString)
+    else {
+      DiagnosticLogger.shared.log(.warning, .action, "Received invalid URL event")
+      return
+    }
+
+    guard let coordinator else {
+      pendingDeepLinkURLs.append(url)
+      return
+    }
+
+    coordinator.handleDeepLink(url)
+  }
+
+  private func flushPendingDeepLinks() {
+    guard let coordinator, !pendingDeepLinkURLs.isEmpty else { return }
+
+    let urls = pendingDeepLinkURLs
+    pendingDeepLinkURLs.removeAll()
+    urls.forEach { coordinator.handleDeepLink($0) }
   }
 }

--- a/Snapzy/App/SnapzyDeepLinkHandler.swift
+++ b/Snapzy/App/SnapzyDeepLinkHandler.swift
@@ -1,0 +1,180 @@
+//
+//  SnapzyDeepLinkHandler.swift
+//  Snapzy
+//
+//  Handles snapzy:// automation URLs for external launchers and workflows.
+//
+
+import AppKit
+import Foundation
+
+@MainActor
+struct SnapzyDeepLinkHandler {
+  private let screenCaptureViewModel: ScreenCaptureViewModel
+
+  init(screenCaptureViewModel: ScreenCaptureViewModel) {
+    self.screenCaptureViewModel = screenCaptureViewModel
+  }
+
+  func handle(_ url: URL) {
+    guard let action = SnapzyDeepLinkAction(url: url) else {
+      DiagnosticLogger.shared.log(
+        .warning,
+        .action,
+        "Ignored unsupported deeplink",
+        context: [
+          "scheme": url.scheme ?? "",
+          "host": url.host ?? "",
+          "path": url.path,
+        ]
+      )
+      return
+    }
+
+    DiagnosticLogger.shared.log(
+      .info,
+      .action,
+      "Handling deeplink",
+      context: ["action": action.logName]
+    )
+
+    switch action {
+    case .captureFullscreen:
+      screenCaptureViewModel.captureFullscreen()
+    case .captureArea:
+      screenCaptureViewModel.captureArea()
+    case .captureScrolling:
+      screenCaptureViewModel.captureScrolling()
+    case .captureOCR:
+      screenCaptureViewModel.captureOCR()
+    case .captureObjectCutout:
+      screenCaptureViewModel.captureObjectCutout()
+    case .recordScreen:
+      screenCaptureViewModel.startRecordingFlow()
+    case .openAnnotate:
+      AnnotateManager.shared.openEmptyAnnotation()
+      NSApp.activate(ignoringOtherApps: true)
+    case .openVideoEditor:
+      VideoEditorManager.shared.openEmptyEditor()
+      NSApp.activate(ignoringOtherApps: true)
+    case .openCloudUploads:
+      if CloudUploadHistoryWindowController.shared.toggleWindow() {
+        NSApp.activate(ignoringOtherApps: true)
+      }
+    case .openHistory:
+      HistoryFloatingManager.shared.toggle()
+    case .showShortcuts:
+      ShortcutOverlayManager.shared.toggle()
+    case .openSettings(let tab):
+      AppStatusBarController.shared.openPreferencesWindow(tab: tab)
+    }
+  }
+}
+
+private enum SnapzyDeepLinkAction {
+  case captureFullscreen
+  case captureArea
+  case captureScrolling
+  case captureOCR
+  case captureObjectCutout
+  case recordScreen
+  case openAnnotate
+  case openVideoEditor
+  case openCloudUploads
+  case openHistory
+  case showShortcuts
+  case openSettings(PreferencesTab?)
+
+  init?(url: URL) {
+    guard url.scheme?.lowercased() == "snapzy" else { return nil }
+
+    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+    let host = url.host?.lowercased()
+    let pathParts = url.path.split(separator: "/").map { $0.lowercased() }
+    let parts = ([host] + pathParts).compactMap { $0 }
+    let command = parts.joined(separator: "/")
+
+    switch command {
+    case "capture/fullscreen", "capture-screen", "capture-fullscreen", "fullscreen", "screenshot/fullscreen":
+      self = .captureFullscreen
+    case "capture/area", "capture-area", "area", "screenshot/area":
+      self = .captureArea
+    case "capture/scrolling", "scrolling-capture", "capture-scrolling", "scrolling", "screenshot/scrolling":
+      self = .captureScrolling
+    case "capture/ocr", "capture/text", "capture-text", "ocr", "text":
+      self = .captureOCR
+    case "capture/object-cutout", "object-cutout", "capture-object-cutout", "cutout":
+      self = .captureObjectCutout
+    case "record/screen", "record-screen", "screen-recording", "recording", "record":
+      self = .recordScreen
+    case "open/annotate", "annotate", "open-annotate":
+      self = .openAnnotate
+    case "open/video-editor", "video-editor", "edit-video", "open-video-editor":
+      self = .openVideoEditor
+    case "open/cloud-uploads", "cloud-uploads", "uploads", "open-uploads":
+      self = .openCloudUploads
+    case "open/history", "history", "capture-history":
+      self = .openHistory
+    case "show/shortcuts", "shortcuts", "keyboard-shortcuts", "show-shortcuts":
+      self = .showShortcuts
+    case "settings", "preferences":
+      self = .openSettings(Self.preferencesTab(from: components, pathParts: pathParts))
+    case let value where value.hasPrefix("settings/"):
+      self = .openSettings(Self.preferencesTab(from: components, pathParts: pathParts))
+    case let value where value.hasPrefix("preferences/"):
+      self = .openSettings(Self.preferencesTab(from: components, pathParts: pathParts))
+    default:
+      return nil
+    }
+  }
+
+  var logName: String {
+    switch self {
+    case .captureFullscreen: return "captureFullscreen"
+    case .captureArea: return "captureArea"
+    case .captureScrolling: return "captureScrolling"
+    case .captureOCR: return "captureOCR"
+    case .captureObjectCutout: return "captureObjectCutout"
+    case .recordScreen: return "recordScreen"
+    case .openAnnotate: return "openAnnotate"
+    case .openVideoEditor: return "openVideoEditor"
+    case .openCloudUploads: return "openCloudUploads"
+    case .openHistory: return "openHistory"
+    case .showShortcuts: return "showShortcuts"
+    case .openSettings(let tab): return "openSettings(\(String(describing: tab)))"
+    }
+  }
+
+  private static func preferencesTab(from components: URLComponents?, pathParts: [String]) -> PreferencesTab? {
+    let queryTab = components?.queryItems?
+      .first(where: { $0.name.lowercased() == "tab" })?
+      .value?
+      .lowercased()
+
+    let pathTab = pathParts.first
+    return preferencesTab(named: queryTab ?? pathTab)
+  }
+
+  private static func preferencesTab(named name: String?) -> PreferencesTab? {
+    switch name {
+    case "general":
+      return .general
+    case "capture", "screenshots", "screenshot":
+      return .capture
+    case "quick-access", "quickaccess":
+      return .quickAccess
+    case "history":
+      return .history
+    case "shortcuts", "keyboard-shortcuts":
+      return .shortcuts
+    case "permissions", "privacy":
+      return .permissions
+    case "cloud", "uploads":
+      return .cloud
+    case "about":
+      return .about
+    default:
+      return nil
+    }
+  }
+}

--- a/Snapzy/Resources/Info.plist
+++ b/Snapzy/Resources/Info.plist
@@ -4,6 +4,17 @@
 <dict>
 	<key>CFBundleIconFile</key>
 	<string>SnapzyIcon</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.trongduong.snapzy</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>snapzy</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Snapzy needs microphone access to record audio with your screen recordings.</string>
 	<key>NSScreenCaptureUsageDescription</key>


### PR DESCRIPTION
## Summary

Adds a `snapzy://` URL scheme so external launchers and automation tools can trigger Snapzy actions directly.

This enables workflows such as:

- Raycast Quicklinks or future Raycast extension commands
- Alfred / launcher workflows
- macOS Shortcuts or shell automation
- Other tools that can open custom URL schemes

## Changes

- Register the `snapzy://` URL scheme in `Info.plist`
- Add a macOS URL event handler during app launch
- Route supported URLs to existing Snapzy actions
- Document the supported automation URLs in the README

Supported examples:

- `snapzy://capture/fullscreen`
- `snapzy://capture/area`
- `snapzy://capture/scrolling`
- `snapzy://capture/ocr`
- `snapzy://capture/object-cutout`
- `snapzy://record/screen`
- `snapzy://open/annotate`
- `snapzy://open/video-editor`
- `snapzy://open/cloud-uploads`
- `snapzy://open/history`
- `snapzy://show/shortcuts`
- `snapzy://settings`
- `snapzy://settings?tab=shortcuts`

## Motivation

Snapzy already exposes capture actions through the menu bar and global shortcuts. A URL scheme gives automation tools a stable integration point without requiring them to simulate keyboard shortcuts or depend on private app behavior.

This also provides the app-side foundation for a future Raycast extension: Raycast commands can open the relevant `snapzy://` URL.

## Testing

- `plutil -lint Snapzy/Resources/Info.plist`
- `git diff --check`
- `swift -module-cache-path build/swift-module-cache tools/localization/CatalogTool.swift verify`
- `xcodebuild -scheme Snapzy -project Snapzy.xcodeproj -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`
- Manually launched the locally built app and verified:
  - `open "snapzy://capture/area"` opens the area capture flow
  - `open "snapzy://capture/fullscreen"` triggers fullscreen capture
