### PR TITLE
fix: correct zh Quick Access and capture preference labels

### DIFF
--- a/Snapzy/Resources/Localization/Features/Capture.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Capture.xcstrings
@@ -3991,13 +3991,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "职位"
+            "value" : "位置"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "職位"
+            "value" : "位置"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/QuickAccess.xcstrings
+++ b/Snapzy/Resources/Localization/Features/QuickAccess.xcstrings
@@ -900,13 +900,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "对"
+            "value" : "右"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "對"
+            "value" : "右"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/QuickAccess.xcstrings
+++ b/Snapzy/Resources/Localization/Features/QuickAccess.xcstrings
@@ -1225,13 +1225,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "职位"
+            "value" : "位置"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "職位"
+            "value" : "位置"
           }
         }
       }


### PR DESCRIPTION
## Summary

This PR fixes two Simplified/Traditional Chinese mistranslations in preferences strings where English ambiguously uses short words:

1. **Screen Edge — "Right"** was translated as **对 / 對** (correct / agreement) instead of **右** (right side), which should pair with **左** for "Left".

2. **"Position"** (on-screen placement) was translated as **职位 / 職位** (job title) instead of **位置**, consistent with other locales (e.g. Japanese **位置**) and the UI meaning.

## Changes

- `Snapzy/Resources/Localization/Features/QuickAccess.xcstrings`
  - `preferences-quick-access.right`: `zh-Hans` / `zh-Hant`
  - `preferences-quick-access.section-position`: `zh-Hans` / `zh-Hant`
- `Snapzy/Resources/Localization/Features/Capture.xcstrings`
  - `preferences-capture.position-title`: `zh-Hans` / `zh-Hant`

Assisted-by: Cursor Agent