### PR TITLE
l10n: History settings catalog, menu bar strings, zh-Hans/zh-Hant polish

### DIFF
--- a/Snapzy/Features/History/Models/HistoryPanelPosition.swift
+++ b/Snapzy/Features/History/Models/HistoryPanelPosition.swift
@@ -39,7 +39,7 @@ enum HistoryPanelPosition: String, Codable {
     switch self {
     case .topCenter: return L10n.HistoryPanelPosition.topCenter
     case .bottomCenter: return L10n.HistoryPanelPosition.bottomCenter
-    case .center: return "Center"
+    case .center: return L10n.HistoryPanelPosition.center
     }
   }
 }

--- a/Snapzy/Features/Preferences/Components/PreferencesHistorySettingsView.swift
+++ b/Snapzy/Features/Preferences/Components/PreferencesHistorySettingsView.swift
@@ -51,10 +51,10 @@ struct HistorySettingsView: View {
           description: L10n.PreferencesHistory.defaultFilterDescription
         ) {
           Picker("", selection: $manager.defaultFilter) {
-            Text("All").tag(Optional<CaptureHistoryType>.none)
-            Text("Screenshots").tag(Optional<CaptureHistoryType>.some(.screenshot))
-            Text("Videos").tag(Optional<CaptureHistoryType>.some(.video))
-            Text("GIFs").tag(Optional<CaptureHistoryType>.some(.gif))
+            Text(L10n.PreferencesHistory.defaultFilterAll).tag(Optional<CaptureHistoryType>.none)
+            Text(L10n.PreferencesHistory.defaultFilterScreenshots).tag(Optional<CaptureHistoryType>.some(.screenshot))
+            Text(L10n.PreferencesHistory.defaultFilterVideos).tag(Optional<CaptureHistoryType>.some(.video))
+            Text(L10n.PreferencesHistory.defaultFilterGifs).tag(Optional<CaptureHistoryType>.some(.gif))
           }
           .labelsHidden()
           .pickerStyle(.menu)
@@ -77,12 +77,12 @@ struct HistorySettingsView: View {
           description: L10n.PreferencesHistory.panelSizeDescription
         ) {
           HStack(spacing: 8) {
-            Text(verbatim: "S")
+            Text(L10n.PreferencesHistory.panelSizeSmall)
               .font(.caption)
               .foregroundColor(.secondary)
             Slider(value: $manager.panelScale, in: HistoryFloatingLayout.scaleRange, step: 0.05)
               .frame(width: 120)
-            Text(verbatim: "L")
+            Text(L10n.PreferencesHistory.panelSizeLarge)
               .font(.caption)
               .foregroundColor(.secondary)
             Text("\(Int(manager.panelScale * 100))%")

--- a/Snapzy/Resources/Localization/Features/Capture.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Capture.xcstrings
@@ -445,13 +445,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕获后打开注释编辑器"
+            "value" : "截取后打开标注编辑器"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕獲後打開注釋編輯器"
+            "value" : "擷取後開啟標註編輯器"
           }
         }
       }
@@ -770,13 +770,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将捕获内容上传到云端并复制链接"
+            "value" : "将截取的内容上传到云端并复制链接"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "將擷取內容上傳到雲端並複製連結"
+            "value" : "將擷取的內容上傳至雲端並複製連結"
           }
         }
       }
@@ -1030,13 +1030,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在进行捕捉或录制时无法清除缓存。"
+            "value" : "正在截屏或录制时无法清除缓存。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在進行捕捉或錄制時無法清除緩存。"
+            "value" : "截圖或錄製進行中時無法清除快取。"
           }
         }
       }
@@ -2070,13 +2070,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "适用于捕获和注释中的背景去除"
+            "value" : "在截屏与标注中用于去除背景"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "適用於捕獲和注釋中的背景去除"
+            "value" : "在截圖與標註中用來去除背景"
           }
         }
       }
@@ -2135,13 +2135,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自动裁剪主题"
+            "value" : "自动裁切主体"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自動裁剪主題"
+            "value" : "自動裁切主體"
           }
         }
       }
@@ -2655,13 +2655,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在捕获期间暂时隐藏图标"
+            "value" : "截屏或录屏时暂时隐藏桌面图标"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在捕獲期間暫時隱藏圖標"
+            "value" : "截圖或錄製時暫時隱藏桌面圖像"
           }
         }
       }
@@ -2785,13 +2785,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在捕获期间暂时隐藏小部件"
+            "value" : "截屏或录屏时暂时隐藏桌面小组件"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在捕獲期間暫時隱藏小部件"
+            "value" : "截圖或錄製時暫時隱藏桌面小工具"
           }
         }
       }
@@ -3175,13 +3175,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕获的屏幕截图的输出格式"
+            "value" : "屏幕截图的导出格式"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕獲的螢幕截圖的輸出格式"
+            "value" : "螢幕截圖的輸出格式"
           }
         }
       }
@@ -3305,13 +3305,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在录制的视频中显示 Snapzy 窗口，例如注释"
+            "value" : "在屏幕录制画面中显示 Snapzy 窗口（例如标注工具栏）"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在錄制的影片中顯示 Snapzy 窗口，例如注釋"
+            "value" : "在螢幕錄製畫面中顯示 Snapzy 視窗（例如標註工具列）"
           }
         }
       }
@@ -3370,13 +3370,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "包含在录音中"
+            "value" : "在录屏画面中包含"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "包含在錄音中"
+            "value" : "錄製畫面中包含"
           }
         }
       }
@@ -3435,13 +3435,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在捕获的图像中显示 Snapzy 窗口，例如注释"
+            "value" : "在截图画面中显示 Snapzy 窗口（例如标注窗口）"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在捕獲的圖像中顯示 Snapzy 窗口，例如注釋"
+            "value" : "在截圖中顯示 Snapzy 視窗（例如標註視窗）"
           }
         }
       }
@@ -3565,13 +3565,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "对象剪切捕捉需要透明度。即使选择 JPEG，Snapzy 也会将它们保存为 PNG。"
+            "value" : "主体抠图需要透明通道。若选择 JPEG，Snapzy 仍会保存为 PNG。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "對象剪切捕捉需要透明度。即使選擇 JPEG，Snapzy 也會將它們保存為 PNG。"
+            "value" : "主體去背需要透明資訊。即使選擇 JPEG，Snapzy 仍會以 PNG 格式儲存。"
           }
         }
       }
@@ -3630,13 +3630,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕捉你的声音"
+            "value" : "录制麦克风声音"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕捉你的聲音"
+            "value" : "錄製麥克風聲音"
           }
         }
       }
@@ -3926,13 +3926,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "记录区域中的徽章放置"
+            "value" : "提示角标在录制区域内的位置"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "記錄區域中的徽章放置"
+            "value" : "提示徽章在錄製區域中的位置"
           }
         }
       }
@@ -3991,13 +3991,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "职位"
+            "value" : "位置"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "職位"
+            "value" : "位置"
           }
         }
       }
@@ -4381,13 +4381,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "下次捕获时恢复先前的记录区域"
+            "value" : "下次截屏时沿用上次选择的区域"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "下次捕獲時恢復先前的記錄區域"
+            "value" : "下次截圖時沿用上次選擇的區域"
           }
         }
       }
@@ -5031,13 +5031,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕获后"
+            "value" : "截取后"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕獲後"
+            "value" : "擷取後"
           }
         }
       }
@@ -5764,13 +5764,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "滚动捕捉"
+            "value" : "滚动截屏"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "滾動捕捉"
+            "value" : "捲動截圖"
           }
         }
       }
@@ -5829,13 +5829,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在捕获的屏幕截图中包含鼠标指针"
+            "value" : "在截图中包含鼠标指针"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在捕獲的螢幕截圖中包含鼠標指針"
+            "value" : "在截圖中包含滑鼠游標"
           }
         }
       }
@@ -5959,13 +5959,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "启动滚动捕获会话时保持指导可见"
+            "value" : "开始滚动截屏会话时保持操作提示可见"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "啓動滾動捕獲會話時保持指導可見"
+            "value" : "開始捲動截圖工作階段時維持操作提示可見"
           }
         }
       }
@@ -6089,13 +6089,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "从应用程序捕获声音"
+            "value" : "从应用程序录制系统音频"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "從應用程序捕獲聲音"
+            "value" : "從應用程式錄製系統音訊"
           }
         }
       }
@@ -6349,13 +6349,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "WebP 编码比其他格式慢。为了获得更快的捕获速度，请考虑使用 PNG 或 JPEG。"
+            "value" : "WebP 编码比其他格式更慢。若想更快完成保存，建议使用 PNG 或 JPEG。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "WebP 編碼比其他格式慢。為了獲得更快的捕獲速度，請考慮使用 PNG 或 JPEG。"
+            "value" : "WebP 編碼比其他格式更慢。若想更快完成儲存，建議改用 PNG 或 JPEG。"
           }
         }
       }
@@ -6414,13 +6414,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "按 %@ 捕获应用窗口"
+            "value" : "按 %@ 截取应用窗口"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "按 %@ 捕獲應用程式視窗"
+            "value" : "按 %@ 擷取應用程式視窗"
           }
         }
       }
@@ -6479,13 +6479,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕获已取消"
+            "value" : "已取消截取"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕獲已取消"
+            "value" : "已取消擷取"
           }
         }
       }
@@ -6544,13 +6544,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕获失败：%@"
+            "value" : "截取失败：%@"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕獲失敗：%@"
+            "value" : "擷取失敗：%@"
           }
         }
       }
@@ -6739,13 +6739,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法从捕获的帧创建图像"
+            "value" : "无法从已截取的帧生成图像"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "無法從捕獲的幀創建圖像"
+            "value" : "無法從已擷取的畫面建立影像"
           }
         }
       }
@@ -6804,13 +6804,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法裁剪捕获的图像"
+            "value" : "无法裁切截取的图像"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "無法裁剪捕獲的圖像"
+            "value" : "無法裁切擷取的影像"
           }
         }
       }
@@ -6999,13 +6999,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "按 %@ 切回手动区域捕获"
+            "value" : "按 %@ 返回手动框选区域"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "按 %@ 切回手動區域捕獲"
+            "value" : "按 %@ 返回手動框選區域"
           }
         }
       }
@@ -7064,13 +7064,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "的文件写入验证失败找不到可捕获的显示器"
+            "value" : "找不到可用于截屏的显示器"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "的檔案寫入驗證失敗找不到可捕獲的顯示器"
+            "value" : "找不到可用來截圖的顯示器"
           }
         }
       }
@@ -7454,13 +7454,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法捕获所选区域。"
+            "value" : "无法截取所选区域。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "無法捕獲所選區域。"
+            "value" : "無法擷取所選區域。"
           }
         }
       }
@@ -7584,13 +7584,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "调整区域，以便仅移动的内容保留在内部，然后按“开始捕获”。按 Esc 键取消。"
+            "value" : "调整选区，使仅滚动的内容留在框内，然后点按「开始截取」。按 Esc 取消。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "調整區域，以便僅移動的內容保留在內部，然後按“開始捕獲”。按 Esc 鍵取消。"
+            "value" : "調整選區讓會捲動的內容保留在框內，再按「開始擷取」。按 Esc 取消。"
           }
         }
       }
@@ -7649,13 +7649,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕获并对齐最新的可见内容..."
+            "value" : "正在截取并对齐最新可见内容…"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕獲並對齊最新的可見內容..."
+            "value" : "正在擷取並對齊最新的可視內容…"
           }
         }
       }
@@ -7779,13 +7779,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕获第一帧。之后，继续以稳定的速度向下滚动。"
+            "value" : "正在截取第一帧。随后请以稳定的速度向下滚动。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕獲第一幀。之後，繼續以穩定的速度向下滾動。"
+            "value" : "正在擷取第一個畫面。接著請以穩定的速度向下捲動。"
           }
         }
       }
@@ -7909,13 +7909,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法捕捉最后一帧。 Snapzy 将保存当前的拼接结果。"
+            "value" : "无法截取最后一帧。Snapzy 将保存当前拼接结果。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "無法捕捉最後一幀。 Snapzy 將保存當前的拼接結果。"
+            "value" : "無法擷取最後一個畫面；Snapzy 會儲存目前的拼接結果。"
           }
         }
       }
@@ -8234,13 +8234,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "完成当前捕获。 Snapzy 在保存之前锁定最新的缝合结果。"
+            "value" : "正在完成本次截取，保存前 Snapzy 会锁定最新拼接结果。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "完成當前捕獲。 Snapzy 在保存之前鎖定最新的縫合結果。"
+            "value" : "正在完成本次擷取，儲存前會鎖定最新拼接結果。"
           }
         }
       }
@@ -8299,13 +8299,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "锁定当前捕获。 Snapzy 在保存之前正在密封 %d 个缝合帧。"
+            "value" : "正在完成本次截取，保存前 Snapzy 正在处理 %d 帧拼接结果。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "鎖定當前捕獲。 Snapzy 在保存之前正在密封 %d 個縫合幀。"
+            "value" : "正在完成本次擷取，儲存前正在處理 %d 幀拼接結果。"
           }
         }
       }
@@ -8754,13 +8754,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Snapzy 尚无法锁定可保存的拼接图像。您可以继续捕获、重试“完成”或“取消”。"
+            "value" : "尚无可以保存的拼接图像，可继续截取、再次尝试「完成」或「取消」。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Snapzy 尚無法鎖定可保存的拼接圖像。您可以繼續捕獲、重試“完成”或“取消”。"
+            "value" : "尚無可儲存的拼接影像；可繼續擷取、再次按「完成」或「取消」。"
           }
         }
       }
@@ -8884,13 +8884,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "仅选择移动内容，按“开始捕获”，然后以稳定的速度朝一个方向滚动。"
+            "value" : "只框选滚动内容，点按「开始截取」，再以稳定速度沿一个方向滚动。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "僅選擇移動內容，按“開始捕獲”，然後以穩定的速度朝一個方向滾動。"
+            "value" : "只框選會捲動的內容，按「開始擷取」，再以穩定速度往單一向捲動。"
           }
         }
       }
@@ -8949,13 +8949,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "区域已更新。仅保留移动的内容，然后按“开始捕获”。按 Esc 键取消。"
+            "value" : "区域已更新。仅保留会滚动的内容，然后点按「开始截取」。按 Esc 取消。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "區域已更新。僅保留移動的內容，然後按“開始捕獲”。按 Esc 鍵取消。"
+            "value" : "區域已更新；只保留會捲動的內容，再按「開始擷取」。按 Esc 取消。"
           }
         }
       }
@@ -9274,13 +9274,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法捕获所选区域。"
+            "value" : "无法截取所选区域。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "無法捕獲所選區域。"
+            "value" : "無法擷取所選區域。"
           }
         }
       }
@@ -9469,13 +9469,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕获"
+            "value" : "已截取"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕獲"
+            "value" : "已擷取"
           }
         }
       }
@@ -11224,13 +11224,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "继续捕捉"
+            "value" : "继续截取"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "繼續捕捉"
+            "value" : "繼續擷取"
           }
         }
       }
@@ -11744,13 +11744,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "锁定当前捕获"
+            "value" : "锁定本次截取"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "鎖定當前捕獲"
+            "value" : "鎖定本次擷取"
           }
         }
       }
@@ -12784,13 +12784,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "然后按开始捕获"
+            "value" : "然后点按「开始截取」"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "然後按開始捕獲"
+            "value" : "然後按「開始擷取」"
           }
         }
       }
@@ -12979,13 +12979,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "完成 - 保存您的捕获。"
+            "value" : "完成 — 保存本次截取结果"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "完成 - 保存您的捕獲。"
+            "value" : "完成 — 儲存本次擷取結果"
           }
         }
       }
@@ -13044,13 +13044,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "预览与拼接的捕获相匹配。"
+            "value" : "预览与拼接结果一致。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "預覽與拼接的捕獲相匹配。"
+            "value" : "預覽與拼接結果一致。"
           }
         }
       }
@@ -13174,13 +13174,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "按开始捕获开始。"
+            "value" : "点按「开始截取」以开始"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "按開始捕獲開始。"
+            "value" : "按「開始擷取」以開始"
           }
         }
       }
@@ -13239,13 +13239,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "保存您的捕获..."
+            "value" : "正在保存本次截取…"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "保存您的捕獲..."
+            "value" : "正在儲存本次擷取…"
           }
         }
       }
@@ -13304,13 +13304,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "显示最新的拼接捕获。"
+            "value" : "正在显示最新的拼接截取结果"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "顯示最新的拼接捕獲。"
+            "value" : "顯示最新的拼接擷取結果"
           }
         }
       }
@@ -13434,13 +13434,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕获"
+            "value" : "截取中"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕獲"
+            "value" : "擷取中"
           }
         }
       }
@@ -13889,13 +13889,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已捕获 %d 个部分"
+            "value" : "已截取 %d 段"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已捕獲 %d 個部分"
+            "value" : "已擷取 %d 段"
           }
         }
       }
@@ -13954,13 +13954,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "开始捕捉"
+            "value" : "开始截取"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "開始捕捉"
+            "value" : "開始擷取"
           }
         }
       }
@@ -14084,13 +14084,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "滚动捕获保存了拼接图像。"
+            "value" : "滚动截屏已保存拼接图像。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "滾動捕獲保存了拼接圖像。"
+            "value" : "捲動截圖已儲存拼接影像。"
           }
         }
       }
@@ -14149,13 +14149,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "滚动捕获会话已处于活动状态。"
+            "value" : "滚动截屏会话已在进行中。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "滾動捕獲會話已處於活動狀態。"
+            "value" : "捲動截圖工作階段已在進行中。"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/Onboarding.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Onboarding.xcstrings
@@ -445,13 +445,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用 ⇧⌘3、⇧⌘4、⇧⌘5 随时捕捉"
+            "value" : "随时使用 ⇧⌘3、⇧⌘4、⇧⌘5 截取屏幕"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用 ⇧⌘3、⇧⌘4、⇧⌘5 隨時捕捉"
+            "value" : "隨時使用 ⇧⌘3、⇧⌘4、⇧⌘5 擷取螢幕"
           }
         }
       }
@@ -1355,13 +1355,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "选择 Snapzy 捕获的文件夹（默认：Desktop/Snapzy）"
+            "value" : "选择 Snapzy 文件的保存文件夹（默认：桌面/Snapzy）"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "選擇 Snapzy 捕獲的檔案夾（預設：Desktop/Snapzy）"
+            "value" : "選擇儲存 Snapzy 檔案的檔案夾（預設：桌面/Snapzy）"
           }
         }
       }
@@ -2135,13 +2135,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Snapzy 需要捕获、音频和保存位置的权限。"
+            "value" : "Snapzy 需要截屏、麦克风与存储位置等系统权限。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Snapzy 需要捕獲、音頻和保存位置的權限。"
+            "value" : "Snapzy 需要截圖、麥克風與儲存位置等系統權限。"
           }
         }
       }
@@ -3760,13 +3760,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "注释和编辑捕获"
+            "value" : "标注与编辑截取内容"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "注釋和編輯捕獲"
+            "value" : "標註與編輯擷取內容"
           }
         }
       }
@@ -3825,13 +3825,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕获区域或全屏屏幕截图"
+            "value" : "截取区域或全屏画面"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕獲區域或全屏螢幕截圖"
+            "value" : "擷取區域或全螢幕畫面"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/QuickAccess.xcstrings
+++ b/Snapzy/Resources/Localization/Features/QuickAccess.xcstrings
@@ -900,13 +900,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "对"
+            "value" : "右"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "對"
+            "value" : "右"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/QuickAccess.xcstrings
+++ b/Snapzy/Resources/Localization/Features/QuickAccess.xcstrings
@@ -1225,13 +1225,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "职位"
+            "value" : "位置"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "職位"
+            "value" : "位置"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/QuickAccess.xcstrings
+++ b/Snapzy/Resources/Localization/Features/QuickAccess.xcstrings
@@ -250,13 +250,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "将捕获的内容拖动到其他应用程序"
+            "value" : "将截屏或录屏拖到其他应用中"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "將捕獲的內容拖動到其他應用程序"
+            "value" : "將截圖或錄製內容拖到其他 App"
           }
         }
       }
@@ -380,13 +380,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕获后显示预览"
+            "value" : "截取完成后显示预览"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕獲後顯示預覽"
+            "value" : "擷取完成後顯示預覽"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/Recording.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Recording.xcstrings
@@ -2005,13 +2005,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "区域选择捕获"
+            "value" : "区域截取"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "區域選擇捕獲"
+            "value" : "區域擷取"
           }
         }
       }
@@ -2330,13 +2330,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "禁用注释"
+            "value" : "关闭标注"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "禁用注釋"
+            "value" : "關閉標註"
           }
         }
       }
@@ -2395,13 +2395,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "启用注释"
+            "value" : "开启标注"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "啓用注釋"
+            "value" : "開啟標註"
           }
         }
       }
@@ -2525,13 +2525,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "全屏捕捉"
+            "value" : "全屏截取"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "全屏捕捉"
+            "value" : "全螢幕擷取"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/Settings.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Settings.xcstrings
@@ -1,4880 +1,7351 @@
 {
-  "sourceLanguage" : "en",
-  "strings" : {
-    "history-background-style.glass" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Glass"
+  "sourceLanguage": "en",
+  "strings": {
+    "history-background-style.glass": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Glass"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kính mờ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kính mờ"
           }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Glas"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cristal"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verre"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "グラス"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "글래스"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стекло"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "毛玻璃"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "毛玻璃"
+          }
+        }
+      }
+    },
+    "history-background-style.gradient": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gradient"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chuyển sắc"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Farbverlauf"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Degradado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dégradé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "グラデーション"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "그라데이션"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Градиент"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "渐变"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "漸層"
+          }
+        }
+      }
+    },
+    "history-background-style.hud": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HUD"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HUD"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HUD"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HUD"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HUD"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HUD"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HUD"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HUD"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HUD"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HUD"
+          }
+        }
+      }
+    },
+    "history-background-style.solid": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solid"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Màu trơn"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einfarbig"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sólido"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uni"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ソリッド"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "단색"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сплошной"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "纯色"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "純色"
+          }
+        }
+      }
+    },
+    "history-panel-position.bottom-center": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bottom Center"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giữa phía dưới"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unten mittig"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Centro inferior"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bas centre"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下中央"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "하단 중앙"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Снизу по центру"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "底部居中"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "底部居中"
+          }
+        }
+      }
+    },
+    "history-panel-position.top-center": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Top Center"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giữa phía trên"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oben mittig"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Centro superior"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haut centre"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上中央"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "상단 중앙"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сверху по центру"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顶部居中"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "頂部居中"
+          }
+        }
+      }
+    },
+    "preferences-about.app-subtitle": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Screenshot und Aufnahme für macOS"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Screenshot & Recording for macOS"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Captura de pantalla y grabación para macOS"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture d'écran et enregistrement pour macOS"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS のスクリーンショットと記録"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS용 스크린샷 및 녹화"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скриншот и запись для macOS"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chụp ảnh & ghi màn hình cho macOS"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS 的屏幕截图和录制"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS 的螢幕截圖和錄制"
+          }
+        }
+      }
+    },
+    "preferences-about.check-for-updates": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach Updates suchen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check for Updates"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar actualizaciones"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher les mises à jour"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートをチェックする"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "업데이트 확인"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверить наличие обновлений"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kiểm tra cập nhật"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "檢查更新"
+          }
+        }
+      }
+    },
+    "preferences-about.checked-label": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geprüft"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Checked"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifié"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "チェック済み"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "확인함"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверено"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã kiểm tra"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已检查"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已檢查"
+          }
+        }
+      }
+    },
+    "preferences-about.github": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Гитхаб"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        }
+      }
+    },
+    "preferences-about.report-bug": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einen Fehler melden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Report a Bug"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informar un error"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signaler un bug"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バグを報告する"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "버그 신고"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сообщить об ошибке"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Báo lỗi"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "报告错误"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "報告錯誤"
+          }
+        }
+      }
+    },
+    "preferences-about.report-problem": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Problem melden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Report a Problem"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informar de un problema"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signaler un problème"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "問題を報告"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "문제 신고"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сообщить о проблеме"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Báo vấn đề"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "报告问题"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "回報問題"
+          }
+        }
+      }
+    },
+    "preferences-about.support-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy ist Open Source. Fördern Sie die fortlaufende Weiterentwicklung, wenn dies Ihrem Arbeitsablauf hilft."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy is open-source. Sponsor ongoing development if it helps your workflow."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy es de código abierto. Patrocine el desarrollo continuo si ayuda a su flujo de trabajo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy est open source. Parrainez le développement continu si cela facilite votre flux de travail."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy はオープンソースです。ワークフローに役立つ場合は、進行中の開発を支援します。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy는 오픈 소스입니다. 귀하의 작업 흐름에 도움이 된다면 지속적인 개발을 후원하십시오."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy имеет открытый исходный код. Спонсируйте постоянное развитие, если оно помогает вашему рабочему процессу."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy là mã nguồn mở. Hãy ủng hộ việc phát triển nếu nó hữu ích cho công việc của bạn."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy 是开源的。如果它有助于您的工作流程，请赞助正在进行的开发。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy 是開源的。如果它有助於您的工作流程，請贊助正在進行的開發。"
+          }
+        }
+      }
+    },
+    "preferences-about.support-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unterstützen Sie Snapzy"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Support Snapzy"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apoya a Snapzy"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Soutenir Snapzy"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy をサポート"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy 지원"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поддержите Snapzy"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ủng hộ Snapzy"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "支持 Snapzy"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "支持 Snapzy"
+          }
+        }
+      }
+    },
+    "preferences-about.version": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versión %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バージョン %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "버전 %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Версия %@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phiên bản %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "版本%@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "版本%@"
+          }
+        }
+      }
+    },
+    "preferences-about.website": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Website"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Website"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitio web"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Site Web"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウェブサイト"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "웹사이트"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Веб-сайт"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trang web"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "网站"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "網站"
+          }
+        }
+      }
+    },
+    "preferences-general.access-not-granted": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (Zugriff nicht gewährt)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (Access not granted)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (Acceso no concedido)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (Accès non accordé)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (アクセスは許可されていません)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@(액세스 권한이 부여되지 않음)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (Доступ не предоставлен)"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (Chưa được cấp quyền)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@（未授予访问权限）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@（未授予訪問權限）"
+          }
+        }
+      }
+    },
+    "preferences-general.calculating": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Berechnen..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calculating..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calculando..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calcul..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "計算中..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "계산 중..."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вычисление..."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang tính..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在计算..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在計算..."
+          }
+        }
+      }
+    },
+    "preferences-general.check-automatically-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suchen Sie beim Start nach Updates"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Look for updates on launch"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Busque actualizaciones sobre el lanzamiento"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recherchez des mises à jour au lancement"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "発売時に最新情報を確認してください"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "출시 시 업데이트를 찾아보세요"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Следите за обновлениями при запуске"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kiểm tra cập nhật khi khởi chạy"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "寻找发布更新"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尋找發佈更新"
+          }
+        }
+      }
+    },
+    "preferences-general.check-automatically-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch prüfen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check automatically"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobar automáticamente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifiez automatiquement"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動的にチェックします"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자동으로 확인"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверка автоматически"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tự kiểm tra"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动检查"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動檢查"
+          }
+        }
+      }
+    },
+    "preferences-general.choose-button": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択してください..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택하세요..."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выбирайте..."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chọn..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇..."
+          }
         }
       }
     },
-    "history-background-style.gradient" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gradient"
+    "preferences-general.choose-save-location-message": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie, wo Snapzy Aufnahmen speichert"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose where Snapzy saves captures"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige dónde Snapzy guarda las capturas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez où Snapzy enregistre les captures"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy がキャプチャを保存する場所を選択します"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy가 캡처를 저장할 위치를 선택하세요"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите, где Snapzy сохраняет снимки"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chọn nơi Snapzy lưu ảnh và video"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择 Snapzy 保存捕获的位置"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇 Snapzy 保存捕獲的位置"
+          }
+        }
+      }
+    },
+    "preferences-general.crash-logging-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokale Protokolle für App-, Aufnahme-, Bildschirmaufzeichnungs- und Absturzdiagnosen speichern"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save local logs for app, capture, recording, and crash diagnostics"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar registros locales para diagnósticos de la app, capturas, grabaciones y fallos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrer des journaux locaux pour diagnostiquer l’app, les captures, les enregistrements et les incidents"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリ、キャプチャ、録画、クラッシュの診断用にローカルログを保存します"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "앱, 캡처, 녹화, 충돌 진단을 위해 로컬 로그를 저장합니다"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохранять локальные журналы для диагностики приложения, снимков, записей и сбоев"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lưu log cục bộ cho chẩn đoán app, chụp, quay màn hình và sự cố"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存用于应用、截图、录制和崩溃诊断的本地日志"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "儲存用於 App、截圖、錄影和崩潰診斷的本機日誌"
+          }
+        }
+      }
+    },
+    "preferences-general.crash-logging-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnoseprotokollierung"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnostic Logging"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Registro de diagnóstico"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Journalisation des diagnostics"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "診断ログ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "진단 로깅"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Журналирование диагностики"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghi log chẩn đoán"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "诊断日志"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "診斷日誌"
+          }
+        }
+      }
+    },
+    "preferences-general.default-save-location": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desktop/Snapzy"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desktop/Snapzy"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escritorio/Snapzy"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bureau/Snapzy"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デスクトップ/スナップジー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "데스크탑/Snapzy"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Рабочий стол / Snapzy"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desktop/Snapzy"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "桌面/Snapzy"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "桌面/Snapzy"
+          }
+        }
+      }
+    },
+    "preferences-general.download-automatically-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updates im Hintergrund herunterladen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download updates in background"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargar actualizaciones en segundo plano"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Télécharger les mises à jour en arrière-plan"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バックグラウンドでアップデートをダウンロード"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "백그라운드에서 업데이트 다운로드"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Загрузка обновлений в фоновом режиме"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tải cập nhật trong nền"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在后台下载更新"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在後台下載更新"
+          }
+        }
+      }
+    },
+    "preferences-general.download-automatically-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch herunterladen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download automatically"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargar automáticamente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Télécharger automatiquement"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動的にダウンロード"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자동으로 다운로드"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Загружать автоматически"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tự tải xuống"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动下载"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動下載"
+          }
+        }
+      }
+    },
+    "preferences-general.language-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie die in Snapzy verwendete Sprache"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose the language used across Snapzy"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige el idioma que usa Snapzy"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez la langue utilisée dans Snapzy"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy 全体で使用する言語を選択"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy 전체에서 사용할 언어를 선택하세요"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите язык, используемый в Snapzy"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chọn ngôn ngữ dùng trong toàn bộ Snapzy"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择 Snapzy 中使用的语言"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇 Snapzy 使用的語言"
+          }
+        }
+      }
+    },
+    "preferences-general.language-relaunch-confirmation-action": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy neu starten"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relaunch Snapzy"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reiniciar Snapzy"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relancer Snapzy"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy を再起動"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy 다시 실행"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перезапустить Snapzy"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở lại Snapzy"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新启动 Snapzy"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新啟動 Snapzy"
+          }
+        }
+      }
+    },
+    "preferences-general.language-relaunch-confirmation-message": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy muss beendet und erneut geöffnet werden, damit diese Sprachänderung in der ganzen App angewendet wird."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy needs to quit and reopen to apply this language change everywhere."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy debe cerrarse y volver a abrirse para aplicar este cambio de idioma en toda la app."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy doit se fermer puis se rouvrir pour appliquer ce changement de langue dans toute l’app."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この言語変更をアプリ全体に反映するには、Snapzy を終了して再度開く必要があります。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 언어 변경을 앱 전체에 적용하려면 Snapzy를 종료한 뒤 다시 열어야 합니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Чтобы применить это изменение языка во всем приложении, Snapzy нужно закрыть и открыть снова."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy cần thoát và mở lại để áp dụng thay đổi ngôn ngữ ở toàn bộ ứng dụng."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy 需要退出并重新打开，才能在整个应用中应用此语言更改。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy 需要先結束並重新開啟，才能在整個應用程式中套用這次語言變更。"
+          }
+        }
+      }
+    },
+    "preferences-general.language-relaunch-confirmation-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy neu starten?"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relaunch Snapzy?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Reiniciar Snapzy?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relancer Snapzy ?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy を再起動しますか？"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy를 다시 실행할까요?"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перезапустить Snapzy?"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở lại Snapzy?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新启动 Snapzy？"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新啟動 Snapzy？"
+          }
+        }
+      }
+    },
+    "preferences-general.language-relaunch-error-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy konnte nicht neu gestartet werden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could Not Relaunch Snapzy"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo reiniciar Snapzy"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de relancer Snapzy"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy を再起動できませんでした"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy를 다시 실행할 수 없습니다"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось перезапустить Snapzy"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không thể mở lại Snapzy"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法重新启动 Snapzy"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法重新啟動 Snapzy"
+          }
+        }
+      }
+    },
+    "preferences-general.language-restart-hint": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprachänderungen werden nach einem Neustart angewendet"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Language changes apply after relaunch"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los cambios de idioma se aplican después de reiniciar la app"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les changements de langue s’appliqueront après le redémarrage"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "言語の変更は再起動後に反映されます"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "언어 변경은 다시 실행한 후 적용됩니다"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Изменения языка вступят в силу после перезапуска"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thay đổi ngôn ngữ sẽ áp dụng sau khi mở lại ứng dụng"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语言更改将在重新启动后生效"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chuyển sắc"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "語言變更會在重新啟動後生效"
           }
         }
       }
     },
-    "history-background-style.hud" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HUD"
+    "preferences-general.language-system": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systemstandard"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HUD"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System Default"
           }
-        }
-      }
-    },
-    "history-background-style.solid" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Solid"
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predeterminado del sistema"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Màu trơn"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Langue du système"
           }
-        }
-      }
-    },
-    "history-panel-position.bottom-center" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bottom Center"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システム設定"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giữa phía dưới"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 기본값"
           }
-        }
-      }
-    },
-    "history-panel-position.top-center" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Top Center"
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Системный язык"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mặc định hệ thống"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跟随系统"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giữa phía trên"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跟隨系統"
           }
         }
       }
     },
-    "preferences-about.app-subtitle" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Screenshot und Aufnahme für macOS"
+    "preferences-general.language-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App-Sprache"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Screenshot & Recording for macOS"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Language"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Captura de pantalla y grabación para macOS"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idioma de la app"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Capture d'écran et enregistrement pour macOS"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Langue de l’app"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macOS のスクリーンショットと記録"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリの言語"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macOS용 스크린샷 및 녹화"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "앱 언어"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Скриншот и запись для macOS"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Язык приложения"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chụp ảnh & ghi màn hình cho macOS"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ngôn ngữ ứng dụng"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macOS 的屏幕截图和录制"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用语言"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macOS 的螢幕截圖和錄制"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "應用程式語言"
           }
         }
       }
     },
-    "preferences-about.check-for-updates" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nach Updates suchen"
+    "preferences-general.last-checked-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zuletzt überprüft"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check for Updates"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last checked"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar actualizaciones"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Última comprobación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechercher les mises à jour"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dernière vérification"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アップデートをチェックする"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最終チェック日"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "업데이트 확인"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마지막 확인"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Проверить наличие обновлений"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Последняя проверка"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kiểm tra cập nhật"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lần kiểm tra gần nhất"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "检查更新"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最后检查"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "檢查更新"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最後檢查"
           }
         }
       }
     },
-    "preferences-about.checked-label" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geprüft"
+    "preferences-general.log-files-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protokolldateien"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Checked"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Log Files"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comprobado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Archivos de registro"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vérifié"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fichiers journaux"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "チェック済み"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ログ ファイル"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "확인함"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그 파일"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Проверено"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Файлы журналов"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đã kiểm tra"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tệp log"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已检查"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日志文件"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已檢查"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日誌檔案"
           }
         }
       }
     },
-    "preferences-about.github" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+    "preferences-general.log-retention-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine Diagnoseprotokolldatei pro Tag für %d Tage behalten"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep one diagnostic log file per day for %d days"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conservar un archivo de registro de diagnóstico por día durante %d días"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conserver un fichier journal de diagnostic par jour pendant %d jours"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d日間、1日につき1つの診断ログファイルを保持します"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d일 동안 하루에 하나의 진단 로그 파일을 보관합니다"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Гитхаб"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Хранить по одному файлу журнала диагностики в день в течение %d дней"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giữ mỗi ngày 1 tệp log chẩn đoán trong %d ngày"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保留 %d 天，每天一个诊断日志文件"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保留 %d 天，每天一個診斷日誌檔案"
           }
         }
       }
     },
-    "preferences-about.report-bug" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einen Fehler melden"
+    "preferences-general.log-retention-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protokolle behalten für"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Report a Bug"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep Logs For"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informar un error"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conservar registros durante"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Signaler un bug"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conserver les journaux pendant"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "バグを報告する"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ログの保持期間"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "버그 신고"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그 보관 기간"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сообщить об ошибке"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Хранить журналы"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Báo lỗi"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giữ log trong"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "报告错误"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日志保留时间"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "報告錯誤"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日誌保留時間"
           }
         }
       }
     },
-    "preferences-about.report-problem" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Problem melden"
+    "preferences-general.never": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Niemals"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Report a Problem"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Never"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informar de un problema"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nunca"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Signaler un problème"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jamais"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "問題を報告"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "決して"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "문제 신고"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "절대로"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сообщить о проблеме"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Никогда"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Báo vấn đề"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chưa từng"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "报告问题"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从来没有"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "回報問題"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "從來沒有"
           }
         }
       }
     },
-    "preferences-about.support-description" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy ist Open Source. Fördern Sie die fortlaufende Weiterentwicklung, wenn dies Ihrem Arbeitsablauf hilft."
+    "preferences-general.no-logs": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Protokolle"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy is open-source. Sponsor ongoing development if it helps your workflow."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No logs"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy es de código abierto. Patrocine el desarrollo continuo si ayuda a su flujo de trabajo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin registros"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy est open source. Parrainez le développement continu si cela facilite votre flux de travail."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun journal"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy はオープンソースです。ワークフローに役立つ場合は、進行中の開発を支援します。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ログがありません"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy는 오픈 소스입니다. 귀하의 작업 흐름에 도움이 된다면 지속적인 개발을 후원하십시오."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그 없음"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy имеет открытый исходный код. Спонсируйте постоянное развитие, если оно помогает вашему рабочему процессу."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет журналов"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy là mã nguồn mở. Hãy ủng hộ việc phát triển nếu nó hữu ích cho công việc của bạn."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không có log"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy 是开源的。如果它有助于您的工作流程，请赞助正在进行的开发。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有日志"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy 是開源的。如果它有助於您的工作流程，請贊助正在進行的開發。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有日誌"
           }
         }
       }
     },
-    "preferences-about.support-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unterstützen Sie Snapzy"
+    "preferences-general.open-folder-button": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffnen Sie den Ordner"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Support Snapzy"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Folder"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apoya a Snapzy"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir carpeta"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Soutenir Snapzy"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir le dossier"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy をサポート"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォルダーを開く"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy 지원"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "폴더 열기"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Поддержите Snapzy"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть папку"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ủng hộ Snapzy"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở thư mục"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "支持 Snapzy"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开文件夹"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "支持 Snapzy"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打開檔案夾"
           }
         }
       }
     },
-    "preferences-about.version" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version %@"
+    "preferences-general.open-report-page-button": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Berichtsseite öffnen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Report Page"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versión %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir página de informe"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir la page de rapport"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "バージョン %@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "報告ページを開く"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "버전 %@"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "신고 페이지 열기"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Версия %@"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть страницу отчета"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Phiên bản %@"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở trang báo lỗi"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "版本%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开报告页面"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "版本%@"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟回報頁面"
           }
         }
       }
     },
-    "preferences-about.website" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Website"
+    "preferences-general.play-sounds-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio-Feedback für Aufnahmen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Website"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audio feedback for captures"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitio web"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comentarios de audio para capturas"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Site Web"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retour audio pour les captures"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ウェブサイト"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャプチャの音声フィードバック"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "웹사이트"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "캡처에 대한 오디오 피드백"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Веб-сайт"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Звуковая обратная связь для снимков"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trang web"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phản hồi âm thanh khi chụp và ghi"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "网站"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捕获的音频反馈"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "網站"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捕獲的音頻反饋"
           }
         }
       }
     },
-    "preferences-general.access-not-granted" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ (Zugriff nicht gewährt)"
+    "preferences-general.play-sounds-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Töne abspielen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ (Access not granted)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Play sounds"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ (Acceso no concedido)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reproducir sonidos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ (Accès non accordé)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jouer des sons"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ (アクセスは許可されていません)"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サウンドを再生する"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@(액세스 권한이 부여되지 않음)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "소리 재생"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ (Доступ не предоставлен)"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Воспроизвести звуки"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ (Chưa được cấp quyền)"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phát âm thanh"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@（未授予访问权限）"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "播放声音"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@（未授予訪問權限）"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "播放聲音"
           }
         }
       }
     },
-    "preferences-general.calculating" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Berechnen..."
+    "preferences-general.report-issue-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bei Problemen ein Diagnose-Log-Bundle über %@ senden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Calculating..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send a diagnostic log bundle at %@ when something goes wrong"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Calculando..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envía un paquete de logs de diagnóstico en %@ cuando algo vaya mal"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Calcul..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Envoyez un lot de journaux de diagnostic sur %@ en cas de problème"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "計算中..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "問題が発生したら %@ で診断ログバンドルを送信します"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "계산 중..."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "문제가 생기면 %@에서 진단 로그 묶음을 보내세요"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Вычисление..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "При проблемах отправляйте пакет журналов диагностики на %@"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đang tính..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gửi gói log chẩn đoán tại %@ khi gặp vấn đề"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在计算..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "遇到问题时在 %@ 发送诊断日志包"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在計算..."
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "遇到問題時在 %@ 傳送診斷日誌包"
           }
         }
       }
     },
-    "preferences-general.check-automatically-description" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suchen Sie beim Start nach Updates"
+    "preferences-general.report-issue-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Problem melden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Look for updates on launch"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Report a Problem"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Busque actualizaciones sobre el lanzamiento"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informar de un problema"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recherchez des mises à jour au lancement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signaler un problème"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "発売時に最新情報を確認してください"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "問題を報告"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "출시 시 업데이트를 찾아보세요"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "문제 신고"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Следите за обновлениями при запуске"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сообщить о проблеме"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kiểm tra cập nhật khi khởi chạy"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Báo vấn đề"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "寻找发布更新"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "报告问题"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "尋找發佈更新"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "回報問題"
           }
         }
       }
     },
-    "preferences-general.check-automatically-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatisch prüfen"
+    "preferences-general.restart-button": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starten Sie"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check automatically"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restart"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comprobar automáticamente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reiniciar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vérifiez automatiquement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redémarrer"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動的にチェックします"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再起動"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "자동으로 확인"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다시 시작"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Проверка автоматически"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перезапустить"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tự kiểm tra"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Khởi động lại"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自动检查"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新启动"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動檢查"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新啓動"
           }
         }
       }
     },
-    "preferences-general.choose-button" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie..."
+    "preferences-general.restart-onboarding-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Willkommen-Tutorial erneut anzeigen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choose..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show the welcome tutorial again"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elige..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar nuevamente el tutorial de bienvenida"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choisissez..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher à nouveau le tutoriel de bienvenue"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選択してください..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ようこそチュートリアルを再度表示します"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "선택하세요..."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "환영 튜토리얼을 다시 보여주세요"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выбирайте..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать приветственное руководство еще раз"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chọn..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiện lại hướng dẫn chào mừng"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再次显示欢迎教程"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選擇..."
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再次顯示歡迎教程"
           }
         }
       }
     },
-    "preferences-general.choose-save-location-message" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie, wo Snapzy Aufnahmen speichert"
+    "preferences-general.restart-onboarding-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Onboarding neu starten"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choose where Snapzy saves captures"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restart Onboarding"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elige dónde Snapzy guarda las capturas"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reiniciar la incorporación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choisissez où Snapzy enregistre les captures"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redémarrer l'intégration"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy がキャプチャを保存する場所を選択します"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オンボーディングを再開"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy가 캡처를 저장할 위치를 선택하세요"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "온보딩 다시 시작"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выберите, где Snapzy сохраняет снимки"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перезапустить регистрацию"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chọn nơi Snapzy lưu ảnh và video"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Khởi động lại onboarding"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择 Snapzy 保存捕获的位置"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新启动入职"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選擇 Snapzy 保存捕獲的位置"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新啓動入職"
           }
         }
       }
     },
-    "preferences-general.crash-logging-description" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokale Protokolle für App-, Aufnahme-, Bildschirmaufzeichnungs- und Absturzdiagnosen speichern"
+    "preferences-general.save-here-button": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hier speichern"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save local logs for app, capture, recording, and crash diagnostics"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save Here"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Guardar registros locales para diagnósticos de la app, capturas, grabaciones y fallos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar aquí"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enregistrer des journaux locaux pour diagnostiquer l’app, les captures, les enregistrements et les incidents"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrez ici"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アプリ、キャプチャ、録画、クラッシュの診断用にローカルログを保存します"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ここに保存"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "앱, 캡처, 녹화, 충돌 진단을 위해 로컬 로그를 저장합니다"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "여기에 저장"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сохранять локальные журналы для диагностики приложения, снимков, записей и сбоев"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохранить здесь"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lưu log cục bộ cho chẩn đoán app, chụp, quay màn hình và sự cố"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lưu tại đây"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保存用于应用、截图、录制和崩溃诊断的本地日志"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存在这里"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "儲存用於 App、截圖、錄影和崩潰診斷的本機日誌"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存在這裡"
           }
         }
       }
     },
-    "preferences-general.crash-logging-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diagnoseprotokollierung"
+    "preferences-general.save-location-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wo Snapzy Aufnahmen speichert"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diagnostic Logging"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Where Snapzy stores captures"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Registro de diagnóstico"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dónde almacena Snapzy las capturas"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Journalisation des diagnostics"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Où Snapzy stocke les captures"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "診断ログ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy がキャプチャを保存する場所"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "진단 로깅"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy 매장이 캡처하는 곳"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Журналирование диагностики"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Где Snapzy хранит снимки"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ghi log chẩn đoán"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nơi Snapzy lưu ảnh và video"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "诊断日志"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy 商店捕获"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "診斷日誌"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapzy 商店捕獲"
           }
         }
       }
     },
-    "preferences-general.default-save-location" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desktop/Snapzy"
+    "preferences-general.save-location-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standort speichern"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desktop/Snapzy"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save location"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escritorio/Snapzy"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardar ubicación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bureau/Snapzy"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrer l'emplacement"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "デスクトップ/スナップジー"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "場所を保存"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "데스크탑/Snapzy"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "위치 저장"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Рабочий стол / Snapzy"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохранить местоположение"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desktop/Snapzy"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vị trí lưu"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "桌面/Snapzy"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存位置"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "桌面/Snapzy"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存位置"
           }
         }
       }
     },
-    "preferences-general.download-automatically-description" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Updates im Hintergrund herunterladen"
+    "preferences-general.section-appearance": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aussehen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download updates in background"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appearance"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descargar actualizaciones en segundo plano"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apariencia"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Télécharger les mises à jour en arrière-plan"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apparence"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "バックグラウンドでアップデートをダウンロード"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外観"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "백그라운드에서 업데이트 다운로드"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "외모"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Загрузка обновлений в фоновом режиме"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Внешний вид"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tải cập nhật trong nền"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giao diện"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在后台下载更新"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外观"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在後台下載更新"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外觀"
           }
         }
       }
     },
-    "preferences-general.download-automatically-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatisch herunterladen"
+    "preferences-general.section-diagnostics": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnose"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download automatically"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnostics"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descargar automáticamente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnóstico"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Télécharger automatiquement"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnostic"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動的にダウンロード"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "診断"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "자동으로 다운로드"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "진단"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Загружать автоматически"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Диагностика"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tự tải xuống"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chẩn đoán"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自动下载"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "诊断"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動下載"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "診斷"
           }
         }
       }
     },
-    "preferences-general.language-description" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie die in Snapzy verwendete Sprache"
+    "preferences-general.section-help": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hilfe"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choose the language used across Snapzy"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Help"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elige el idioma que usa Snapzy"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ayuda"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choisissez la langue utilisée dans Snapzy"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aide"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy 全体で使用する言語を選択"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルプ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy 전체에서 사용할 언어를 선택하세요"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도움말"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выберите язык, используемый в Snapzy"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помогите"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chọn ngôn ngữ dùng trong toàn bộ Snapzy"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trợ giúp"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择 Snapzy 中使用的语言"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "帮助"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選擇 Snapzy 使用的語言"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "幫助"
           }
         }
       }
     },
-    "preferences-general.language-relaunch-confirmation-action" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy neu starten"
+    "preferences-general.section-startup": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Relaunch Snapzy"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Startup"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reiniciar Snapzy"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicio"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Relancer Snapzy"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Démarrage"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy を再起動"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スタートアップ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy 다시 실행"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시작"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перезапустить Snapzy"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стартап"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mở lại Snapzy"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Khởi động"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新启动 Snapzy"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启动"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新啟動 Snapzy"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啓動"
           }
         }
       }
     },
-    "preferences-general.language-relaunch-confirmation-message" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy muss beendet und erneut geöffnet werden, damit diese Sprachänderung in der ganzen App angewendet wird."
+    "preferences-general.section-storage": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lagerung"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy needs to quit and reopen to apply this language change everywhere."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Storage"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy debe cerrarse y volver a abrirse para aplicar este cambio de idioma en toda la app."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Almacenamiento"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy doit se fermer puis se rouvrir pour appliquer ce changement de langue dans toute l’app."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stockage"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "この言語変更をアプリ全体に反映するには、Snapzy を終了して再度開く必要があります。"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ストレージ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이 언어 변경을 앱 전체에 적용하려면 Snapzy를 종료한 뒤 다시 열어야 합니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장공간"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Чтобы применить это изменение языка во всем приложении, Snapzy нужно закрыть и открыть снова."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Хранение"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy cần thoát và mở lại để áp dụng thay đổi ngôn ngữ ở toàn bộ ứng dụng."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lưu trữ"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy 需要退出并重新打开，才能在整个应用中应用此语言更改。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "存储"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy 需要先結束並重新開啟，才能在整個應用程式中套用這次語言變更。"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "存儲"
           }
         }
       }
     },
-    "preferences-general.language-relaunch-confirmation-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy neu starten?"
+    "preferences-general.section-updates": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Software-Updates"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Relaunch Snapzy?"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Software Updates"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Reiniciar Snapzy?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizaciones de software"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Relancer Snapzy ?"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mises à jour logicielles"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy を再起動しますか？"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ソフトウェアのアップデート"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy를 다시 실행할까요?"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "소프트웨어 업데이트"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перезапустить Snapzy?"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновления программного обеспечения"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mở lại Snapzy?"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cập nhật phần mềm"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新启动 Snapzy？"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "软件更新"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新啟動 Snapzy？"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "軟件更新"
           }
         }
       }
     },
-    "preferences-general.language-relaunch-error-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy konnte nicht neu gestartet werden"
+    "preferences-general.start-at-login-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starten Sie Snapzy, wenn Sie sich anmelden"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Could Not Relaunch Snapzy"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Launch Snapzy when you log in"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo reiniciar Snapzy"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicie Snapzy cuando inicie sesión"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible de relancer Snapzy"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lancez Snapzy lorsque vous vous connectez"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy を再起動できませんでした"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ログイン時にSnapzyを起動する"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy를 다시 실행할 수 없습니다"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그인 후 Snapzy를 실행하세요"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось перезапустить Snapzy"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запустите Snapzy при входе в систему"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không thể mở lại Snapzy"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở Snapzy khi bạn đăng nhập"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法重新启动 Snapzy"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "登录时启动 Snapzy"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無法重新啟動 Snapzy"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "登錄時啓動 Snapzy"
           }
         }
       }
     },
-    "preferences-general.language-restart-hint" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprachänderungen werden nach einem Neustart angewendet"
+    "preferences-general.start-at-login-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beim Anmelden starten"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Language changes apply after relaunch"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start at login"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Los cambios de idioma se aplican después de reiniciar la app"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comenzar al iniciar sesión"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les changements de langue s’appliqueront après le redémarrage"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commencez par la connexion"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "言語の変更は再起動後に反映されます"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ログイン時に起動"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "언어 변경은 다시 실행한 후 적용됩니다"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그인 시 시작"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Изменения языка вступят в силу после перезапуска"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Начать при входе в систему"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thay đổi ngôn ngữ sẽ áp dụng sau khi mở lại ứng dụng"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Khởi động khi đăng nhập"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "语言更改将在重新启动后生效"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从登录开始"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "語言變更會在重新啟動後生效"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "從登錄開始"
           }
         }
       }
     },
-    "preferences-general.language-system" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Systemstandard"
+    "preferences-general.theme-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie Ihr bevorzugtes Erscheinungsbild"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "System Default"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose your preferred appearance"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Predeterminado del sistema"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige tu apariencia preferida"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Langue du système"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez votre apparence préférée"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "システム設定"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "お好みの外観を選択してください"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "시스템 기본값"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선호하는 외모를 선택하세요"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Системный язык"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите предпочитаемый внешний вид"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mặc định hệ thống"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chọn giao diện ưa thích"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "跟随系统"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择您喜欢的外观"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "跟隨系統"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇您喜歡的外觀"
           }
         }
       }
     },
-    "preferences-general.language-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App-Sprache"
+    "preferences-general.theme-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Design"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App Language"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Theme"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Idioma de la app"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tema"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Langue de l’app"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thème"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アプリの言語"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テーマ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "앱 언어"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테마"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Язык приложения"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тема"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ngôn ngữ ứng dụng"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giao diện"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "应用语言"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主题"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "應用程式語言"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主題"
           }
         }
       }
     },
-    "preferences-general.last-checked-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zuletzt überprüft"
+    "preferences-history.background-style-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applies to the History window and floating panel"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Last checked"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Áp dụng cho cửa sổ History và bảng nổi"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Última comprobación"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gilt für das Verlaufsfenster und das schwebende Panel"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dernière vérification"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se aplica a la ventana del historial y al panel flotante"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "最終チェック日"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "S’applique à la fenêtre Historique et au volet flottant"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "마지막 확인"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "履歴ウインドウとフローティングパネルに適用されます"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Последняя проверка"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기록 창과 플로팅 패널에 적용됩니다"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lần kiểm tra gần nhất"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Применяется к окну «История» и плавающей панели"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "最后检查"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "适用于历史记录窗口和悬浮面板"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "最後檢查"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "適用於歷史記錄視窗與浮動面板"
           }
         }
       }
     },
-    "preferences-general.log-files-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Protokolldateien"
+    "preferences-history.background-style-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Background Style"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Log Files"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kiểu nền"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Archivos de registro"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hintergrundstil"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fichiers journaux"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estilo de fondo"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ログ ファイル"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Style d’arrière-plan"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "로그 파일"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "背景スタイル"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Файлы журналов"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "배경 스타일"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tệp log"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стиль фона"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日志文件"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "背景样式"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日誌檔案"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "背景樣式"
           }
         }
       }
     },
-    "preferences-general.log-retention-description" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eine Diagnoseprotokolldatei pro Tag für %d Tage behalten"
+    "preferences-history.capture-storage-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture Storage"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keep one diagnostic log file per day for %d days"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lưu trữ ảnh/video"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conservar un archivo de registro de diagnóstico por día durante %d días"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahmespeicher"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conserver un fichier journal de diagnostic par jour pendant %d jours"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Almacenamiento de capturas"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%d日間、1日につき1つの診断ログファイルを保持します"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stockage des captures"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%d일 동안 하루에 하나의 진단 로그 파일을 보관합니다"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャプチャの保存場所"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Хранить по одному файлу журнала диагностики в день в течение %d дней"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "캡처 저장 위치"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giữ mỗi ngày 1 tệp log chẩn đoán trong %d ngày"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Папка записей"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保留 %d 天，每天一个诊断日志文件"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "截屏与录屏存储"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保留 %d 天，每天一個診斷日誌檔案"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "截圖與錄製儲存位置"
           }
         }
       }
     },
-    "preferences-general.log-retention-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Protokolle behalten für"
+    "preferences-history.clear-history-alert-message": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This will move all capture files to Trash and remove them from History. This action cannot be undone in Snapzy."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keep Logs For"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thao tác này sẽ chuyển toàn bộ file capture vào Thùng rác và xóa khỏi History. Không thể hoàn tác trong Snapzy."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conservar registros durante"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Aufnahmedateien werden in den Papierkorb gelegt und aus dem Verlauf entfernt. Dies kann in Snapzy nicht rückgängig gemacht werden."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conserver les journaux pendant"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se moverán todos los archivos de captura a la papelera y se quitarán del historial. Esta acción no se puede deshacer en Snapzy."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ログの保持期間"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tous les fichiers de capture seront déplacés vers la corbeille et retirés de l’historique. Cette action est irréversible dans Snapzy."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "로그 보관 기간"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてのキャプチャファイルがゴミ箱に移動され、履歴から削除されます。この操作は Snapzy では取り消せません。"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Хранить журналы"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 캡처 파일이 휴지통으로 이동되고 기록에서 제거됩니다. 이 작업은 Snapzy에서 되돌릴 수 없습니다."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giữ log trong"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Все файлы записей будут перемещены в корзину и удалены из истории. Это действие нельзя отменить в Snapzy."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日志保留时间"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所有截屏和录屏文件将被移到废纸篓并从历史中移除。此操作在 Snapzy 中无法撤销。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日誌保留時間"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所有截圖與錄製檔案將移到垃圾桶並從歷史記錄中移除。此操作在 Snapzy 中無法還原。"
           }
         }
       }
     },
-    "preferences-general.never" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Niemals"
+    "preferences-history.clear-history-alert-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear All History?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Never"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xóa toàn bộ lịch sử?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nunca"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gesamten Verlauf leeren?"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jamais"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Borrar todo el historial?"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "決して"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer tout l’historique ?"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "절대로"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "履歴をすべて消去しますか？"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Никогда"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기록을 모두 지울까요?"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chưa từng"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Очистить всю историю?"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "从来没有"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确定清除全部历史？"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "從來沒有"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確定清除全部歷史記錄？"
           }
         }
       }
     },
-    "preferences-general.no-logs" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Protokolle"
+    "preferences-history.clear-history-button": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear History"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No logs"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xóa lịch sử"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sin registros"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verlauf leeren"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucun journal"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar historial"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ログがありません"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer l’historique"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "로그 없음"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "履歴を消去"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Нет журналов"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기록 지우기"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không có log"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Очистить историю"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "没有日志"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除历史"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "沒有日誌"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除歷史記錄"
           }
         }
       }
     },
-    "preferences-general.open-folder-button" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Öffnen Sie den Ordner"
+    "preferences-history.clear-history-confirm": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Folder"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xóa"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir carpeta"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leeren"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvrir le dossier"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "フォルダーを開く"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "폴더 열기"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "消去"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Открыть папку"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지우기"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mở thư mục"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Очистить"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开文件夹"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打開檔案夾"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除"
           }
         }
       }
     },
-    "preferences-general.open-report-page-button" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Berichtsseite öffnen"
+    "preferences-history.clear-history-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move all captures to Trash and clear History"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Report Page"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chuyển toàn bộ capture vào Thùng rác và xóa History"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir página de informe"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Aufnahmen in den Papierkorb legen und Verlauf leeren"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvrir la page de rapport"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover todas las capturas a la papelera y borrar el historial"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "報告ページを開く"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déplacer toutes les captures vers la corbeille et effacer l’historique"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "신고 페이지 열기"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてのキャプチャをゴミ箱に移動して履歴を消去"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Открыть страницу отчета"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 캡처를 휴지통으로 옮기고 기록을 비웁니다"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mở trang báo lỗi"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переместить все записи в корзину и очистить историю"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开报告页面"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将所有截屏和录屏移到废纸篓并清空历史"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "開啟回報頁面"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將所有截圖與錄製移到垃圾桶並清空歷史記錄"
           }
         }
       }
     },
-    "preferences-general.play-sounds-description" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio-Feedback für Aufnahmen"
+    "preferences-history.clear-history-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear All History"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Audio feedback for captures"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xóa toàn bộ lịch sử"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comentarios de audio para capturas"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gesamten Verlauf leeren"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retour audio pour les captures"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar todo el historial"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "キャプチャの音声フィードバック"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer tout l’historique"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "캡처에 대한 오디오 피드백"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "履歴をすべて消去"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Звуковая обратная связь для снимков"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기록 전체 지우기"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Phản hồi âm thanh khi chụp và ghi"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Очистить всю историю"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "捕获的音频反馈"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除全部历史"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "捕獲的音頻反饋"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除全部歷史記錄"
           }
         }
       }
     },
-    "preferences-general.play-sounds-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Töne abspielen"
+    "preferences-history.clear-selection": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Play sounds"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bỏ chọn"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reproducir sonidos"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurücksetzen"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jouer des sons"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "サウンドを再生する"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacer"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "소리 재생"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "解除"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Воспроизвести звуки"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "해제"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Phát âm thanh"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Снять"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "播放声音"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除选择"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "播放聲音"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除選取"
           }
         }
       }
     },
-    "preferences-general.report-issue-description" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bei Problemen ein Diagnose-Log-Bundle über %@ senden"
+    "preferences-history.default-filter-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filter shown when opening the floating panel"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Send a diagnostic log bundle at %@ when something goes wrong"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bộ lọc hiển thị khi mở bảng nổi"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Envía un paquete de logs de diagnóstico en %@ cuando algo vaya mal"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filter beim Öffnen des schwebenden Panels"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Envoyez un lot de journaux de diagnostic sur %@ en cas de problème"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtro mostrado al abrir el panel flotante"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "問題が発生したら %@ で診断ログバンドルを送信します"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtre affiché à l’ouverture du volet flottant"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "문제가 생기면 %@에서 진단 로그 묶음을 보내세요"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フローティングパネルを開いたときに表示するフィルタ"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "При проблемах отправляйте пакет журналов диагностики на %@"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "플로팅 패널을 열 때 표시할 필터"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gửi gói log chẩn đoán tại %@ khi gặp vấn đề"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Фильтр при открытии плавающей панели"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "遇到问题时在 %@ 发送诊断日志包"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开悬浮面板时显示的筛选方式"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "遇到問題時在 %@ 傳送診斷日誌包"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟浮動面板時顯示的篩選方式"
           }
         }
       }
     },
-    "preferences-general.report-issue-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Problem melden"
+    "preferences-history.default-filter-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default Filter"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Report a Problem"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bộ lọc mặc định"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informar de un problema"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standardfilter"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Signaler un problème"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtro predeterminado"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "問題を報告"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtre par défaut"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "문제 신고"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルトのフィルタ"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сообщить о проблеме"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본 필터"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Báo vấn đề"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Фильтр по умолчанию"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "报告问题"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认筛选"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "回報問題"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "預設篩選"
           }
         }
       }
     },
-    "preferences-general.restart-button" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Starten Sie"
+    "preferences-history.delete-after-days": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete captures older than %d days"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restart"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xóa ảnh và video cũ hơn %d ngày"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reiniciar"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahmen löschen, die älter als %d Tage sind"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Redémarrer"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar capturas de más de %d días"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "再起動"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer les captures de plus de %d jours"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "다시 시작"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d 日より古いキャプチャを削除"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перезапустить"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d일이 지난 캡처 삭제"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Khởi động lại"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалять записи старше %d дн."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新启动"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除早于 %d 天的截屏和录屏"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新啓動"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刪除早於 %d 天的截圖與錄製"
           }
         }
       }
     },
-    "preferences-general.restart-onboarding-description" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das Willkommen-Tutorial erneut anzeigen"
+    "preferences-history.delete-selected-alert-message": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move %d selected capture item(s) to Trash and remove them from History."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show the welcome tutorial again"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chuyển %d mục đã chọn vào Thùng rác và xóa khỏi History."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar nuevamente el tutorial de bienvenida"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d ausgewählte Aufnahme(n) in den Papierkorb legen und aus dem Verlauf entfernen."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher à nouveau le tutoriel de bienvenue"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mover %d elemento(s) de captura seleccionado(s) a la papelera y quitarlo(s) del historial."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ようこそチュートリアルを再度表示します"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Déplacer %d capture(s) sélectionnée(s) vers la corbeille et les retirer de l’historique."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "환영 튜토리얼을 다시 보여주세요"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択した %d 件のキャプチャをゴミ箱に移動し、履歴から削除します。"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Показать приветственное руководство еще раз"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택한 캡처 %d개를 휴지통으로 옮기고 기록에서 제거합니다."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hiện lại hướng dẫn chào mừng"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переместить %d выбранных записей в корзину и удалить из истории."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "再次显示欢迎教程"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将已选的 %d 项截屏或录屏移到废纸篓并从历史中移除。"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "再次顯示歡迎教程"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將所選的 %d 項截圖或錄製移到垃圾桶並從歷史記錄中移除。"
           }
         }
       }
     },
-    "preferences-general.restart-onboarding-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Onboarding neu starten"
+    "preferences-history.delete-selected-alert-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete Selected Captures?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restart Onboarding"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xóa các mục đã chọn?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reiniciar la incorporación"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgewählte Aufnahmen löschen?"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Redémarrer l'intégration"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Eliminar capturas seleccionadas?"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オンボーディングを再開"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer les captures sélectionnées ?"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "온보딩 다시 시작"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したキャプチャを削除しますか？"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перезапустить регистрацию"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택한 캡처를 삭제할까요?"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Khởi động lại onboarding"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить выбранные записи?"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新启动入职"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除所选截屏和录屏？"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新啓動入職"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刪除所選截圖與錄製？"
           }
         }
       }
     },
-    "preferences-general.save-here-button" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hier speichern"
+    "preferences-history.deleted-captures": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deleted %d capture item(s)"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save Here"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã xóa %d mục"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Guardar aquí"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d Aufnahme(n) gelöscht"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enregistrez ici"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se eliminaron %d elemento(s) de captura"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ここに保存"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d capture(s) supprimée(s)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "여기에 저장"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャプチャを %d 件削除しました"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сохранить здесь"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "캡처 %d개 삭제됨"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lưu tại đây"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалено записей: %d"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保存在这里"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已删除 %d 项"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保存在這裡"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已刪除 %d 項"
           }
         }
       }
     },
-    "preferences-general.save-location-description" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wo Snapzy Aufnahmen speichert"
+    "preferences-history.display-section": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Display"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Where Snapzy stores captures"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiển thị"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dónde almacena Snapzy las capturas"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Darstellung"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Où Snapzy stocke les captures"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visualización"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy がキャプチャを保存する場所"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Affichage"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy 매장이 캡처하는 곳"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "表示"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Где Snapzy хранит снимки"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "표시"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nơi Snapzy lưu ảnh và video"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отображение"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy 商店捕获"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Snapzy 商店捕獲"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示"
           }
         }
       }
     },
-    "preferences-general.save-location-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Standort speichern"
+    "preferences-history.floating-panel-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show a floating panel for quick access to recent captures"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save location"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hiển thị bảng nổi để truy cập nhanh các lần chụp và quay gần đây"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Guardar ubicación"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeigt ein schwebendes Panel für schnellen Zugriff auf aktuelle Aufnahmen"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enregistrer l'emplacement"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Muestra un panel flotante para acceder rápidamente a las capturas recientes"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "場所を保存"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Affiche un volet flottant pour un accès rapide aux captures récentes"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "위치 저장"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近のキャプチャにすばやくアクセスするフローティングパネルを表示します"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сохранить местоположение"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최근 캡처에 빠르게 접근할 수 있는 플로팅 패널을 표시합니다"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vị trí lưu"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показывать плавающую панель для быстрого доступа к недавним записям"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保存位置"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示悬浮面板，以便快速访问最近的截屏和录屏"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保存位置"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示浮動面板，以便快速存取最近的截圖與錄製"
           }
         }
       }
     },
-    "preferences-general.section-appearance" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aussehen"
+    "preferences-history.floating-panel-section": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Floating Panel"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Appearance"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bảng nổi"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apariencia"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schwebendes Panel"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apparence"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Panel flotante"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "外観"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volet flottant"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "외모"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フローティングパネル"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Внешний вид"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "플로팅 패널"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giao diện"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Плавающая панель"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "外观"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "悬浮面板"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "外觀"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "浮動面板"
           }
         }
       }
     },
-    "preferences-general.section-diagnostics" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diagnose"
+    "preferences-history.floating-panel-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable Floating Panel"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diagnostics"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bật bảng nổi"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diagnóstico"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schwebendes Panel aktivieren"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diagnostic"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar panel flotante"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "診断"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activer le volet flottant"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "진단"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フローティングパネルを有効にする"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Диагностика"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "플로팅 패널 사용"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chẩn đoán"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включить плавающую панель"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "诊断"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用悬浮面板"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "診斷"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用浮動面板"
           }
         }
       }
     },
-    "preferences-general.section-help" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hilfe"
+    "preferences-history.keep-forever": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep captures forever"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Help"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giữ lịch sử mãi mãi"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ayuda"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahmen dauerhaft behalten"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aide"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conservar capturas indefinidamente"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ヘルプ"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conserver les captures indéfiniment"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "도움말"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャプチャをずっと保持"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Помогите"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "캡처를 계속 보관"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trợ giúp"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Хранить записи без ограничения"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "帮助"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "永久保留截屏和录屏"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "幫助"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "永久保留截圖與錄製"
           }
         }
       }
     },
-    "preferences-general.section-startup" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start"
+    "preferences-history.max-count-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maximum number of captures stored in history"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Startup"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Số lượng ảnh và video tối đa được lưu trong lịch sử"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inicio"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maximale Anzahl der Aufnahmen im Verlauf"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Démarrage"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Número máximo de capturas guardadas en el historial"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "スタートアップ"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre maximal de captures enregistrées dans l’historique"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "시작"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "履歴に保存するキャプチャの最大数"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Стартап"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기록에 저장할 캡처의 최대 개수"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Khởi động"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Максимальное число записей в истории"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "启动"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "历史记录中保存的截屏和录屏数量上限"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "啓動"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "歷史記錄中儲存的截圖與錄製數量上限"
           }
         }
       }
     },
-    "preferences-general.section-storage" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lagerung"
+    "preferences-history.max-count-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Max Stored Items"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Storage"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Số mục lưu tối đa"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Almacenamiento"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Max. gespeicherte Einträge"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stockage"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Máx. de elementos almacenados"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ストレージ"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Éléments stockés max."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "저장공간"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存する項目の最大数"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Хранение"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장 항목 최대 개수"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lưu trữ"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Макс. сохраняемых элементов"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "存储"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最大存储条目数"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "存儲"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最大儲存項目數"
           }
         }
       }
     },
-    "preferences-general.section-updates" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Software-Updates"
+    "preferences-history.max-items-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maximum number of items shown in the floating panel"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Software Updates"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Số mục tối đa hiển thị trong bảng nổi"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actualizaciones de software"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maximale Anzahl der Einträge im schwebenden Panel"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mises à jour logicielles"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Número máximo de elementos en el panel flotante"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ソフトウェアのアップデート"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nombre maximal d’éléments dans le volet flottant"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "소프트웨어 업데이트"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フローティングパネルに表示する項目の最大数"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Обновления программного обеспечения"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "플로팅 패널에 표시할 항목의 최대 개수"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cập nhật phần mềm"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Максимальное число элементов на плавающей панели"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "软件更新"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "悬浮面板中显示条目的最大数量"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "軟件更新"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "浮動面板中顯示項目的最大數量"
           }
         }
       }
     },
-    "preferences-general.start-at-login-description" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Starten Sie Snapzy, wenn Sie sich anmelden"
+    "preferences-history.max-items-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Max Displayed Items"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Launch Snapzy when you log in"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Số mục hiển thị tối đa"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inicie Snapzy cuando inicie sesión"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Max. angezeigte Einträge"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lancez Snapzy lorsque vous vous connectez"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Máx. de elementos mostrados"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ログイン時にSnapzyを起動する"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Éléments affichés max."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "로그인 후 Snapzy를 실행하세요"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "表示する項目の最大数"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Запустите Snapzy при входе в систему"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "표시 항목 최대 개수"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mở Snapzy khi bạn đăng nhập"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Макс. отображаемых элементов"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "登录时启动 Snapzy"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最多显示项目数"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "登錄時啓動 Snapzy"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最多顯示項目數"
           }
         }
       }
     },
-    "preferences-general.start-at-login-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beim Anmelden starten"
+    "preferences-history.open-capture-storage-button": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Folder"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start at login"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở thư mục"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comenzar al iniciar sesión"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ordner öffnen"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Commencez par la connexion"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir carpeta"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ログイン時に起動"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir le dossier"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "로그인 시 시작"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォルダを開く"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Начать при входе в систему"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "폴더 열기"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Khởi động khi đăng nhập"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть папку"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "从登录开始"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开文件夹"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "從登錄開始"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打開檔案夾"
           }
         }
       }
     },
-    "preferences-general.theme-description" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie Ihr bevorzugtes Erscheinungsbild"
+    "preferences-history.panel-position-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose where the floating panel appears on screen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choose your preferred appearance"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chọn vị trí hiển thị của bảng nổi trên màn hình"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elige tu apariencia preferida"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Legen Sie fest, wo das schwebende Panel auf dem Bildschirm erscheint"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choisissez votre apparence préférée"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige dónde aparece el panel flotante en pantalla"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "お好みの外観を選択してください"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez où le volet flottant apparaît à l’écran"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "선호하는 외모를 선택하세요"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フローティングパネルを画面上のどこに表示するかを選びます"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выберите предпочитаемый внешний вид"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "화면에서 플로팅 패널이 나타날 위치를 선택합니다"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chọn giao diện ưa thích"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите, где на экране показывать плавающую панель"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择您喜欢的外观"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择悬浮面板在屏幕上的出现位置"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選擇您喜歡的外觀"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇浮動面板在螢幕上的顯示位置"
           }
         }
       }
     },
-    "preferences-general.theme-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Design"
+    "preferences-history.panel-position-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Panel Position"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Theme"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vị trí bảng"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tema"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Panelposition"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thème"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Posición del panel"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "テーマ"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Position du volet"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "테마"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パネルの位置"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Тема"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "패널 위치"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giao diện"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Положение панели"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "主题"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "面板位置"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "主題"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "面板位置"
           }
         }
       }
     },
-    "preferences-history.background-style-description" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Applies to the History window and floating panel"
+    "preferences-history.panel-size-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resize the floating panel and its preview cards"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Áp dụng cho cửa sổ History và bảng nổi"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Điều chỉnh kích thước bảng nổi và các thẻ xem trước"
           }
-        }
-      }
-    },
-    "preferences-history.background-style-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Background Style"
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Größe des schwebenden Panels und der Vorschaubilder anpassen"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kiểu nền"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambia el tamaño del panel flotante y sus tarjetas de vista previa"
           }
-        }
-      }
-    },
-    "preferences-history.capture-storage-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Capture Storage"
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redimensionne le volet flottant et ses cartes d’aperçu"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lưu trữ ảnh/video"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フローティングパネルとプレビューカードのサイズを変更します"
           }
-        }
-      }
-    },
-    "preferences-history.clear-history-alert-message" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This will move all capture files to Trash and remove them from History. This action cannot be undone in Snapzy."
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "플로팅 패널과 미리보기 카드 크기를 조정합니다"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thao tác này sẽ chuyển toàn bộ file capture vào Thùng rác và xóa khỏi History. Không thể hoàn tác trong Snapzy."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Изменить размер плавающей панели и карточек предпросмотра"
           }
-        }
-      }
-    },
-    "preferences-history.clear-history-alert-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear All History?"
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "调整悬浮面板及其预览卡片的大小"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Xóa toàn bộ lịch sử?"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "調整浮動面板與其預覽卡片的大小"
           }
         }
       }
     },
-    "preferences-history.clear-history-button" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear History"
+    "preferences-history.panel-size-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Panel Size"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Xóa lịch sử"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kích thước bảng"
           }
-        }
-      }
-    },
-    "preferences-history.clear-history-confirm" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear"
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Panelgröße"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Xóa"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamaño del panel"
           }
-        }
-      }
-    },
-    "preferences-history.clear-history-description" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Move all captures to Trash and clear History"
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taille du volet"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chuyển toàn bộ capture vào Thùng rác và xóa History"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パネルのサイズ"
           }
-        }
-      }
-    },
-    "preferences-history.clear-history-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear All History"
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "패널 크기"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Xóa toàn bộ lịch sử"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Размер панели"
           }
-        }
-      }
-    },
-    "preferences-history.clear-selection" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clear"
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "面板大小"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bỏ chọn"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "面板大小"
           }
         }
       }
     },
-    "preferences-history.default-filter-description" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Filter shown when opening the floating panel"
+    "preferences-history.retention-days-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-Clear After"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bộ lọc hiển thị khi mở bảng nổi"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tự xóa sau"
           }
-        }
-      }
-    },
-    "preferences-history.default-filter-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Default Filter"
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch löschen nach"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bộ lọc mặc định"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar automáticamente tras"
           }
-        }
-      }
-    },
-    "preferences-history.delete-after-days" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete captures older than %d days"
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effacement automatique après"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Xóa ảnh và video cũ hơn %d ngày"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動削除までの期間"
           }
-        }
-      }
-    },
-    "preferences-history.delete-selected-alert-message" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Move %d selected capture item(s) to Trash and remove them from History."
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자동 삭제 기간"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chuyển %d mục đã chọn vào Thùng rác và xóa khỏi History."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Автоочистка через"
           }
-        }
-      }
-    },
-    "preferences-history.delete-selected-alert-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete Selected Captures?"
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动清理"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Xóa các mục đã chọn?"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動清除"
           }
         }
       }
     },
-    "preferences-history.deleted-captures" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deleted %d capture item(s)"
+    "preferences-history.retention-section": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retention"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đã xóa %d mục"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lưu giữ"
           }
-        }
-      }
-    },
-    "preferences-history.display-section" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Display"
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufbewahrung"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hiển thị"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retención"
           }
-        }
-      }
-    },
-    "preferences-history.floating-panel-description" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show a floating panel for quick access to recent captures"
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rétention"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hiển thị bảng nổi để truy cập nhanh các lần chụp và quay gần đây"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保持"
           }
-        }
-      }
-    },
-    "preferences-history.floating-panel-section" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Floating Panel"
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "보관"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bảng nổi"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Хранение"
           }
-        }
-      }
-    },
-    "preferences-history.floating-panel-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enable Floating Panel"
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保留"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bật bảng nổi"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保留"
           }
         }
       }
     },
-    "preferences-history.keep-forever" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keep captures forever"
+    "preferences-history.select-all": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select All"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giữ lịch sử mãi mãi"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chọn tất cả"
           }
-        }
-      }
-    },
-    "preferences-history.max-count-description" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maximum number of captures stored in history"
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle auswählen"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Số lượng ảnh và video tối đa được lưu trong lịch sử"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccionar todo"
           }
-        }
-      }
-    },
-    "preferences-history.max-count-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Max Stored Items"
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout sélectionner"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Số mục lưu tối đa"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてを選択"
           }
-        }
-      }
-    },
-    "preferences-history.max-items-description" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maximum number of items shown in the floating panel"
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모두 선택"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Số mục tối đa hiển thị trong bảng nổi"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выбрать все"
           }
-        }
-      }
-    },
-    "preferences-history.max-items-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Max Displayed Items"
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全选"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Số mục hiển thị tối đa"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全選"
           }
         }
       }
     },
-    "preferences-history.open-capture-storage-button" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Folder"
+    "preferences-history.selected-captures": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d selected"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mở thư mục"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d đã chọn"
           }
-        }
-      }
-    },
-    "preferences-history.panel-position-description" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choose where the floating panel appears on screen"
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d ausgewählt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d seleccionados"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d sélectionné(s)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d 件を選択"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d개 선택됨"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выбрано: %d"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已选 %d 项"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chọn vị trí hiển thị của bảng nổi trên màn hình"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已選 %d 項"
           }
         }
       }
     },
-    "preferences-history.panel-position-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Panel Position"
+    "preferences-history.storage-section": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Storage"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lưu trữ"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speicher"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Almacenamiento"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stockage"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ストレージ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장공간"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Хранилище"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "存储"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vị trí bảng"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "儲存空間"
           }
         }
       }
     },
-    "preferences-history.panel-size-description" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resize the floating panel and its preview cards"
+    "preferences.tab.about": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Über"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acerca de"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "À propos de"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "情報"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "소개"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "О"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giới thiệu"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关于"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Điều chỉnh kích thước bảng nổi và các thẻ xem trước"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "關於"
           }
         }
       }
     },
-    "preferences-history.panel-size-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Panel Size"
+    "preferences.tab.capture": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erfassen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Captura"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capturer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャプチャ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "캡처"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Захватить"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chụp"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捕捉"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kích thước bảng"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捕捉"
           }
         }
       }
     },
-    "preferences-history.retention-days-title" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auto-Clear After"
+    "preferences.tab.cloud": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wolke"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nube"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nuage"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラウド"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "구름"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Облако"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "云"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tự xóa sau"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "雲"
           }
         }
       }
     },
-    "preferences-history.retention-section" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retention"
+    "preferences.tab.general": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Allgemein"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generalidades"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Général"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一般"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일반"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Общие"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tổng quát"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一般"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lưu giữ"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一般"
           }
         }
       }
     },
-    "preferences-history.select-all" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select All"
+    "preferences.tab.history": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "History"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lịch sử"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verlauf"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Historial"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Historique"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "履歴"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기록"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "История"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "历史"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chọn tất cả"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "歷史"
           }
         }
       }
     },
-    "preferences-history.selected-captures" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%d selected"
+    "preferences.tab.permissions": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Berechtigungen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permissions"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permisos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autorisations"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "権限"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "권한"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разрешения"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quyền"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "权限"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%d đã chọn"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "權限"
           }
         }
       }
     },
-    "preferences-history.storage-section" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Storage"
+    "preferences.tab.quick-access": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schnellzugriff"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quick Access"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acceso rápido"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accès rapide"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クイック アクセス"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "빠른 액세스"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Быстрый доступ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Truy cập nhanh"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快速访问"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lưu trữ"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快速訪問"
           }
         }
       }
     },
-    "preferences.tab.about" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Über"
+    "preferences.tab.shortcuts": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verknüpfungen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "About"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shortcuts"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acerca de"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atajos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "À propos de"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Raccourcis"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "情報"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ショートカット"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "소개"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "단축키"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "О"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ярлыки"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Giới thiệu"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phím tắt"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关于"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快捷方式"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "關於"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快捷方式"
           }
         }
       }
     },
-    "preferences.tab.capture" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erfassen"
+    "preferences-history.default-filter-all": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Capture"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Captura"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Capturer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "キャプチャ"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべて"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "캡처"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모두"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Захватить"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Все"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chụp"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tất cả"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "捕捉"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "捕捉"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部"
           }
         }
       }
     },
-    "preferences.tab.cloud" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wolke"
+    "preferences-history.default-filter-screenshots": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bildschirmfotos"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cloud"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Screenshots"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nube"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capturas de pantalla"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nuage"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Captures d’écran"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "クラウド"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スクリーンショット"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "구름"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "스크린샷"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Облако"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Снимки экрана"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cloud"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ảnh chụp màn hình"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "云"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "屏幕截图"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "雲"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "螢幕截圖"
           }
         }
       }
     },
-    "preferences.tab.general" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Allgemein"
+    "preferences-history.default-filter-videos": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Videos"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "General"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Videos"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Generalidades"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vídeos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Général"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vidéos"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一般"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ビデオ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "일반"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "동영상"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Общие"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видео"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tổng quát"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Video"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一般"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "视频"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一般"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "影片"
           }
         }
       }
     },
-    "preferences.tab.history" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "History"
+    "preferences-history.default-filter-gifs": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIFs"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIFs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lịch sử"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GIF"
           }
         }
       }
     },
-    "preferences.tab.permissions" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Berechtigungen"
+    "preferences-history.panel-size-small": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "K"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permissions"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "S"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permisos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "P"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autorisations"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "P"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "権限"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "小"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "권한"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작게"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Разрешения"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "М"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quyền"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "N"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "权限"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "小"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "權限"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "小"
           }
         }
       }
     },
-    "preferences.tab.quick-access" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schnellzugriff"
+    "preferences-history.panel-size-large": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "G"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quick Access"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acceso rápido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "G"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accès rapide"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "G"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "クイック アクセス"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "大"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "빠른 액세스"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "크게"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Быстрый доступ"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Б"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Truy cập nhanh"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "快速访问"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "大"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "快速訪問"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "大"
           }
         }
       }
     },
-    "preferences.tab.shortcuts" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verknüpfungen"
+    "history-panel-position.center": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mitte"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shortcuts"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Center"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atajos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Centro"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Raccourcis"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Centre"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ショートカット"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中央"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "단축키"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "가운데"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ярлыки"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По центру"
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Phím tắt"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Giữa"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "快捷方式"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "居中"
           }
         },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "快捷方式"
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "居中"
           }
         }
       }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }

--- a/Snapzy/Resources/Localization/Features/Settings.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Settings.xcstrings
@@ -1225,13 +1225,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "寻找发布更新"
+            "value": "启动时检查更新"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "尋找發佈更新"
+            "value": "啟動時檢查更新"
           }
         }
       }
@@ -1420,13 +1420,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "选择 Snapzy 保存捕获的位置"
+            "value": "选择 Snapzy 保存截屏与录屏的位置"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "選擇 Snapzy 保存捕獲的位置"
+            "value": "選擇 Snapzy 儲存截圖與錄製的位置"
           }
         }
       }
@@ -2590,13 +2590,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "从来没有"
+            "value": "从不"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "從來沒有"
+            "value": "永不"
           }
         }
       }
@@ -2850,13 +2850,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "捕获的音频反馈"
+            "value": "截屏与录屏完成时播放提示音"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "捕獲的音頻反饋"
+            "value": "截圖與錄製完成時播放提示音"
           }
         }
       }
@@ -3116,7 +3116,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "重新啓動"
+            "value": "重新啟動"
           }
         }
       }
@@ -3181,7 +3181,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "再次顯示歡迎教程"
+            "value": "再次顯示歡迎教學"
           }
         }
       }
@@ -3240,13 +3240,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "重新启动入职"
+            "value": "重新运行引导"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "重新啓動入職"
+            "value": "重新開始引導"
           }
         }
       }
@@ -3370,13 +3370,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Snapzy 商店捕获"
+            "value": "Snapzy 保存截屏与录屏的位置"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Snapzy 商店捕獲"
+            "value": "Snapzy 儲存截圖與錄製的位置"
           }
         }
       }
@@ -3441,7 +3441,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "保存位置"
+            "value": "儲存位置"
           }
         }
       }
@@ -3636,7 +3636,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "幫助"
+            "value": "說明"
           }
         }
       }
@@ -3701,7 +3701,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "啓動"
+            "value": "啟動"
           }
         }
       }
@@ -3766,7 +3766,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "存儲"
+            "value": "儲存空間"
           }
         }
       }
@@ -3831,7 +3831,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "軟件更新"
+            "value": "軟體更新"
           }
         }
       }
@@ -3896,7 +3896,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "登錄時啓動 Snapzy"
+            "value": "登入時啟動 Snapzy"
           }
         }
       }
@@ -3955,13 +3955,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "从登录开始"
+            "value": "登录时启动"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "從登錄開始"
+            "value": "登入時啟動"
           }
         }
       }
@@ -4345,13 +4345,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "所有截屏和录屏文件将被移到废纸篓并从历史中移除。此操作在 Snapzy 中无法撤销。"
+            "value": "所有截屏与录屏文件将被移到废纸篓并从历史记录中移除。此操作在 Snapzy 中无法撤销。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "所有截圖與錄製檔案將移到垃圾桶並從歷史記錄中移除。此操作在 Snapzy 中無法還原。"
+            "value": "所有截圖與錄製檔案將移到垃圾桶並從歷史紀錄中移除。此操作在 Snapzy 中無法還原。"
           }
         }
       }
@@ -4410,13 +4410,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "确定清除全部历史？"
+            "value": "确定要清空全部历史记录？"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "確定清除全部歷史記錄？"
+            "value": "確定要清空全部歷史紀錄？"
           }
         }
       }
@@ -4475,13 +4475,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "清除历史"
+            "value": "清空历史记录"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "清除歷史記錄"
+            "value": "清空歷史紀錄"
           }
         }
       }
@@ -4546,7 +4546,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "清除"
+            "value": "清空"
           }
         }
       }
@@ -4605,13 +4605,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "将所有截屏和录屏移到废纸篓并清空历史"
+            "value": "将所有截屏与录屏移到废纸篓并清空历史记录"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "將所有截圖與錄製移到垃圾桶並清空歷史記錄"
+            "value": "將所有截圖與錄製移到垃圾桶並清空歷史紀錄"
           }
         }
       }
@@ -4670,13 +4670,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "清除全部历史"
+            "value": "清空全部历史记录"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "清除全部歷史記錄"
+            "value": "清空全部歷史紀錄"
           }
         }
       }
@@ -4735,13 +4735,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "清除选择"
+            "value": "清除所选"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "清除選取"
+            "value": "清除所選項目"
           }
         }
       }
@@ -4995,13 +4995,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "将已选的 %d 项截屏或录屏移到废纸篓并从历史中移除。"
+            "value": "将已选的 %d 项移到废纸篓并从历史记录中移除。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "將所選的 %d 項截圖或錄製移到垃圾桶並從歷史記錄中移除。"
+            "value": "將所選的 %d 個項目移到垃圾桶並從歷史紀錄中移除。"
           }
         }
       }
@@ -5060,13 +5060,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "删除所选截屏和录屏？"
+            "value": "删除所选内容？"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "刪除所選截圖與錄製？"
+            "value": "刪除所選項目？"
           }
         }
       }
@@ -5580,13 +5580,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "最大存储条目数"
+            "value": "历史记录最多保存条数"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "最大儲存項目數"
+            "value": "歷史紀錄最多可儲存的項目數"
           }
         }
       }
@@ -5710,13 +5710,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "最多显示项目数"
+            "value": "面板中最多显示条目数"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "最多顯示項目數"
+            "value": "面板中最多顯示的項目數"
           }
         }
       }
@@ -6100,13 +6100,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "自动清理"
+            "value": "自动删除"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "自動清除"
+            "value": "自動刪除"
           }
         }
       }
@@ -6165,13 +6165,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "保留"
+            "value": "保留时间"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "保留"
+            "value": "保留時間"
           }
         }
       }
@@ -6490,13 +6490,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "捕捉"
+            "value": "截屏"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "捕捉"
+            "value": "截圖"
           }
         }
       }
@@ -6620,7 +6620,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "一般"
+            "value": "通用"
           }
         },
         "zh-Hant": {
@@ -6685,13 +6685,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "历史"
+            "value": "历史记录"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "歷史"
+            "value": "歷史紀錄"
           }
         }
       }
@@ -6880,13 +6880,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "快捷方式"
+            "value": "键盘快捷键"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "快捷方式"
+            "value": "鍵盤快速鍵"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/Shortcuts.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Shortcuts.xcstrings
@@ -329,10 +329,46 @@
     "preferences-shortcuts.application-recording-description" : {
       "extractionState" : "stale",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einzeltaste (A) koppelt mit „Bildschirm aufzeichnen“; Modifikator-Kombination (⇧⌘A)\nfunktioniert unabhängig."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Single key (A) pairs with Record Screen; modifier combo (⇧⌘A)\nworks independently."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La tecla única (A) se empareja con Grabar pantalla; la combinación de modificadores (⇧⌘A)\nfunciona de forma independiente."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La touche unique (A) est associée à Enregistrer l’écran ; la combinaison de modificateurs (⇧⌘A)\nfonctionne indépendamment."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "単一キー（A）は画面録画と連動します。修飾キーの組み合わせ（⇧⌘A）は\n独立して動作します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "단일 키(A)는 화면 녹화와 짝을 이룹니다. 조합 키(⇧⌘A)는\n독립적으로 동작합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Одиночная клавиша (A) сочетается с записью экрана; комбинация модификаторов (⇧⌘A)\nработает независимо."
           }
         },
         "vi" : {
@@ -340,22 +376,82 @@
             "state" : "translated",
             "value" : "Phím đơn (A) đi cùng Ghi màn hình; combo modifier (⇧⌘A)\nchạy độc lập."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "单键 (A) 与「录制屏幕」联动；修饰键组合 (⇧⌘A)\n可独立使用。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "單鍵 (A) 與「錄製螢幕」連動；修飾鍵組合 (⇧⌘A)\n可獨立使用。"
+          }
         }
       }
     },
     "preferences-shortcuts.application-recording-title" : {
       "extractionState" : "stale",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App-Aufzeichnung"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Application Recording"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grabación de aplicación"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistrement d’application"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アプリの画面録画"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "앱 화면 녹화"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запись приложения"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ghi ứng dụng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用录屏"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "應用程式錄製"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/Shortcuts.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Shortcuts.xcstrings
@@ -120,13 +120,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "注释编辑器内常见操作的快捷方式。"
+            "value" : "标注编辑器内常用操作的快捷键。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "注釋編輯器內常見操作的快捷方式。"
+            "value" : "標註編輯器中常用操作的快速鍵。"
           }
         }
       }
@@ -250,13 +250,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在区域捕获覆盖层中"
+            "value" : "在区域截屏叠加层中使用"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在區域擷取覆蓋層中"
+            "value" : "於區域截圖疊加層中使用"
           }
         }
       }
@@ -315,13 +315,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "应用捕获"
+            "value" : "应用窗口截屏"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "應用程式擷取"
+            "value" : "應用程式視窗截圖"
           }
         }
       }
@@ -445,13 +445,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "应用录屏"
+            "value" : "应用窗口录屏"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "應用程式錄製"
+            "value" : "應用程式視窗錄製"
           }
         }
       }
@@ -510,13 +510,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "选择要捕获的区域"
+            "value" : "选择要截取的屏幕区域"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "選擇要捕獲的區域"
+            "value" : "選擇要擷取的螢幕區域"
           }
         }
       }
@@ -575,13 +575,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "立即捕获整个屏幕"
+            "value" : "立即截取整个屏幕"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "立即捕獲整個螢幕"
+            "value" : "立即擷取整個螢幕"
           }
         }
       }
@@ -640,13 +640,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕捉快捷键"
+            "value" : "截屏快捷键"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕捉快捷鍵"
+            "value" : "截圖快速鍵"
           }
         }
       }
@@ -965,13 +965,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您将无法使用任何应用程序中的键盘快捷键来捕获屏幕截图或录音。您需要手动打开 Snapzy 才能使用捕获功能。"
+            "value" : "关闭后，你将无法在任何应用中使用键盘快捷键截屏或进行屏幕录制，需要手动打开 Snapzy 才能使用相关功能。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您將無法使用任何應用程序中的鍵盤快捷鍵來捕獲螢幕截圖或錄音。您需要手動打開 Snapzy 才能使用捕獲功能。"
+            "value" : "關閉後，你將無法在任何應用程式中使用鍵盤快速鍵來截圖或進行螢幕錄製；必須手動開啟 Snapzy 才能使用這些功能。"
           }
         }
       }
@@ -1095,13 +1095,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "从任何应用程序捕获"
+            "value" : "可在任意前台应用中使用快捷键截屏"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "從任何應用程序捕獲"
+            "value" : "在任何前景 App 都能使用鍵盤快速鍵截圖"
           }
         }
       }
@@ -1160,13 +1160,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "启用快捷方式"
+            "value" : "启用快捷键"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "啓用快捷方式"
+            "value" : "啟用快速鍵"
           }
         }
       }
@@ -1290,13 +1290,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用键盘快捷键从任何地方进行捕捉。"
+            "value" : "通过键盘快捷键随时截屏"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用鍵盤快捷鍵從任何地方進行捕捉。"
+            "value" : "使用鍵盤快速鍵隨時截圖"
           }
         }
       }
@@ -1810,13 +1810,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "单击快捷按钮来记录新按键。使用行切换开关关闭快捷方式。按 Esc 键取消。"
+            "value" : "点击快捷键按钮录制新的按键组合。可通过行内开关停用某项快捷键，按 Esc 取消。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "單擊快捷按鈕來記錄新按鍵。使用行切換開關關閉快捷方式。按 Esc 鍵取消。"
+            "value" : "按一下快速鍵按鈕以設定新的組合鍵；可用列內開關停用單一快速鍵。按 Esc 取消。"
           }
         }
       }
@@ -2460,13 +2460,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "工具快捷方式"
+            "value" : "工具快捷键"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "工具快捷方式"
+            "value" : "工具快速鍵"
           }
         }
       }
@@ -2720,13 +2720,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "应用捕获：%@"
+            "value" : "应用窗口截屏：%@"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "應用程式擷取：%@"
+            "value" : "應用程式視窗截圖：%@"
           }
         }
       }
@@ -3842,13 +3842,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕捉"
+            "value" : "截屏"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕捉"
+            "value" : "截圖"
           }
         }
       }
@@ -4687,13 +4687,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "macOS 捕获区域"
+            "value" : "macOS 截取区域"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "macOS 捕獲區域"
+            "value" : "macOS 區域截取"
           }
         }
       }
@@ -4752,13 +4752,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "macOS 捕捉全屏"
+            "value" : "macOS 全屏截屏"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "macOS 捕捉全屏"
+            "value" : "macOS 全螢幕截圖"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Shared/Common.xcstrings
+++ b/Snapzy/Resources/Localization/Shared/Common.xcstrings
@@ -55,13 +55,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕获区域"
+            "value" : "区域截屏"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕獲區域"
+            "value" : "區域截圖"
           }
         }
       }
@@ -120,13 +120,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕捉全屏"
+            "value" : "全屏截屏"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕捉全屏"
+            "value" : "全螢幕截圖"
           }
         }
       }
@@ -185,13 +185,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕捉主体"
+            "value" : "提取主体"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕捉主體"
+            "value" : "擷取主體"
           }
         }
       }
@@ -250,13 +250,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕获文本 (OCR)"
+            "value" : "识别文字（OCR）"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "捕獲文本 (OCR)"
+            "value" : "辨識文字（OCR）"
           }
         }
       }
@@ -315,13 +315,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "云上传"
+            "value" : "上传到云端"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "雲上傳"
+            "value" : "上傳至雲端"
           }
         }
       }
@@ -380,13 +380,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "打开注释"
+            "value" : "打开标注"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "打開注釋"
+            "value" : "開啟標註"
           }
         }
       }
@@ -451,7 +451,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "打開歷史記錄"
+            "value" : "打開歷史紀錄"
           }
         }
       }
@@ -575,13 +575,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "录制视频"
+            "value" : "屏幕录制"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "錄制影片"
+            "value" : "螢幕錄製"
           }
         }
       }
@@ -640,13 +640,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "滚动捕捉"
+            "value" : "滚动截屏"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "滾動捕捉"
+            "value" : "捲動截圖"
           }
         }
       }
@@ -705,13 +705,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "显示快速访问叠加"
+            "value" : "显示快速访问浮层"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "顯示快速訪問疊加"
+            "value" : "顯示快速存取浮層"
           }
         }
       }
@@ -770,13 +770,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "显示快捷方式列表"
+            "value" : "显示快捷键列表"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "顯示快捷方式列表"
+            "value" : "顯示快速鍵列表"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Shared/Common.xcstrings
+++ b/Snapzy/Resources/Localization/Shared/Common.xcstrings
@@ -394,16 +394,64 @@
     "action.open-history" : {
       "extractionState" : "stale",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verlauf öffnen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Open History"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abrir historial"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir l’historique"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "履歴を開く"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기록 열기"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Открыть историю"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mở lịch sử"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开历史记录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打開歷史記錄"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Shared/Permissions.xcstrings
+++ b/Snapzy/Resources/Localization/Shared/Permissions.xcstrings
@@ -640,13 +640,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Snapzy 需要特定权限才能捕获您的屏幕和音频。"
+            "value" : "Snapzy 需要截屏、访问麦克风音频及文件等权限。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Snapzy 需要特定權限才能捕獲您的螢幕和音頻。"
+            "value" : "Snapzy 需要擷取螢幕畫面、麥克風音訊與檔案等相關權限。"
           }
         }
       }

--- a/Snapzy/Shared/Localization/L10n.swift
+++ b/Snapzy/Shared/Localization/L10n.swift
@@ -6016,6 +6016,26 @@ enum L10n {
       defaultValue: "Filter shown when opening the floating panel",
       comment: "History settings description for default filter"
     )
+    static let defaultFilterAll = string(
+      "preferences-history.default-filter-all",
+      defaultValue: "All",
+      comment: "History settings default filter option for all capture types"
+    )
+    static let defaultFilterScreenshots = string(
+      "preferences-history.default-filter-screenshots",
+      defaultValue: "Screenshots",
+      comment: "History settings default filter option for screenshots"
+    )
+    static let defaultFilterVideos = string(
+      "preferences-history.default-filter-videos",
+      defaultValue: "Videos",
+      comment: "History settings default filter option for videos"
+    )
+    static let defaultFilterGifs = string(
+      "preferences-history.default-filter-gifs",
+      defaultValue: "GIFs",
+      comment: "History settings default filter option for GIFs"
+    )
     static let maxItemsTitle = string(
       "preferences-history.max-items-title",
       defaultValue: "Max Displayed Items",
@@ -6030,6 +6050,16 @@ enum L10n {
       "preferences-history.panel-size-description",
       defaultValue: "Resize the floating panel and its preview cards",
       comment: "History settings description for floating panel size"
+    )
+    static let panelSizeSmall = string(
+      "preferences-history.panel-size-small",
+      defaultValue: "S",
+      comment: "History settings short label for the small end of the panel size slider"
+    )
+    static let panelSizeLarge = string(
+      "preferences-history.panel-size-large",
+      defaultValue: "L",
+      comment: "History settings short label for the large end of the panel size slider"
     )
     static let maxItemsDescription = string(
       "preferences-history.max-items-description",
@@ -6164,6 +6194,11 @@ enum L10n {
     static let bottomCenter = string(
       "history-panel-position.bottom-center",
       defaultValue: "Bottom Center",
+      comment: "History panel position option"
+    )
+    static let center = string(
+      "history-panel-position.center",
+      defaultValue: "Center",
       comment: "History panel position option"
     )
   }


### PR DESCRIPTION
## Summary

- **History (Settings)** — Full string catalog coverage for History preferences (panel position/size, defaults, slider labels); Swift `L10n` + `PreferencesHistorySettingsView` wired to catalogs.
- **Menu bar** — `Open History` and Application Recording shortcut strings extended to all locales (not only en/vi).
- **Chinese** — Simplified and Traditional polish across Settings, Capture, Shortcuts, Common, etc. (terminology, garbled strings, tab labels).

## Commits

- `l10n: Complete History preferences string catalog coverage`
- `l10n: Localize status bar Open History and Application Recording`
- `l10n: Polish zh-Hans and zh-Hant capture and settings strings`

Assisted-by: Cursor

Made with [Cursor](https://cursor.com)