### PR TITLE
feat: open images via Finder "Open With" → straight into the annotate editor

### DIFF
--- a/Snapzy/App/SnapzyApp.swift
+++ b/Snapzy/App/SnapzyApp.swift
@@ -38,6 +38,8 @@ struct SnapzyApp: App {
 class AppDelegate: NSObject, NSApplicationDelegate {
   private var coordinator: AppCoordinator?
   private var pendingDeepLinkURLs: [URL] = []
+  private var pendingOpenFileURLs: [URL] = []
+  private var didFinishLaunching = false
 
   func applicationWillFinishLaunching(_ notification: Notification) {
     NSAppleEventManager.shared().setEventHandler(
@@ -57,7 +59,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let coordinator = AppCoordinator(environment: AppEnvironment.live())
     self.coordinator = coordinator
     coordinator.applicationDidFinishLaunching()
+    didFinishLaunching = true
     flushPendingDeepLinks()
+    flushPendingOpenFileURLs()
   }
 
   func applicationWillTerminate(_ notification: Notification) {
@@ -94,5 +98,52 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let urls = pendingDeepLinkURLs
     pendingDeepLinkURLs.removeAll()
     urls.forEach { coordinator.handleDeepLink($0) }
+  }
+
+  // MARK: - Open With (Finder right-click → Open With → Snapzy)
+
+  /// Called when the user opens one or more image files with Snapzy from
+  /// Finder's "Open With" submenu, by double-clicking a file whose default
+  /// app is Snapzy, or by drag-dropping files onto the app icon in the Dock.
+  ///
+  /// Files declared in `CFBundleDocumentTypes` (PNG/JPEG/HEIC/HEIF/TIFF/GIF/
+  /// WebP/BMP) are routed straight into the annotation editor.
+  ///
+  /// Note: macOS 13+ prefers `application(_:open:)` over the legacy
+  /// `application(_:openFiles:)`, and the latter is silently skipped on
+  /// recent OS releases. We only act on file URLs here so that the existing
+  /// Apple Event handler for `snapzy://` deep links keeps working.
+  func application(_ application: NSApplication, open urls: [URL]) {
+    let fileURLs = urls.filter { $0.isFileURL }
+    guard !fileURLs.isEmpty else { return }
+
+    DiagnosticLogger.shared.log(
+      .info,
+      .action,
+      "Received open-file request",
+      context: ["count": "\(fileURLs.count)"]
+    )
+
+    if didFinishLaunching {
+      openImageURLs(fileURLs)
+    } else {
+      // Files arriving before launch finishes (e.g. a cold launch via "Open With")
+      // are queued and flushed once the coordinator is ready.
+      pendingOpenFileURLs.append(contentsOf: fileURLs)
+    }
+  }
+
+  private func openImageURLs(_ urls: [URL]) {
+    for url in urls {
+      AnnotateManager.shared.openAnnotation(url: url)
+    }
+  }
+
+  private func flushPendingOpenFileURLs() {
+    guard !pendingOpenFileURLs.isEmpty else { return }
+
+    let urls = pendingOpenFileURLs
+    pendingOpenFileURLs.removeAll()
+    openImageURLs(urls)
   }
 }

--- a/Snapzy/Resources/Info.plist
+++ b/Snapzy/Resources/Info.plist
@@ -4,6 +4,28 @@
 <dict>
 	<key>CFBundleIconFile</key>
 	<string>SnapzyIcon</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Image</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.png</string>
+				<string>public.jpeg</string>
+				<string>public.heic</string>
+				<string>public.heif</string>
+				<string>public.tiff</string>
+				<string>com.compuserve.gif</string>
+				<string>org.webmproject.webp</string>
+				<string>public.bmp</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Closes #164

## Summary

Snapzy now appears in Finder's right-click **Open With** submenu for common image formats (PNG, JPEG, HEIC, HEIF, TIFF, GIF, WebP, BMP). Selecting a file from there — or double-clicking a file whose default app has been set to Snapzy, or dropping image files on the Dock icon — opens it **straight into the existing annotation editor**, ready for cropping / drawing / text, with the same state as if the file had been dropped into the window.

This addresses the friction described in #164: when working with screenshots that weren't taken via Snapzy itself (iPhone screenshots via AirDrop, images from Slack, files saved to disk, etc.), users currently have to launch the app first and drag-drop, or pick `Other…` every time. After this change, the natural macOS gesture just works.

## Changes

Only **2 files**, +73 lines, no refactors.

### 1. `Snapzy/Resources/Info.plist`

Adds a single `CFBundleDocumentTypes` entry declaring Snapzy as an **editor** for the 8 image UTIs above, with:

\`\`\`xml
<key>LSHandlerRank</key>
<string>Alternate</string>
\`\`\`

\`Alternate\` is intentional — Snapzy will surface in the Open With submenu, but **won't override Preview as the system-wide default image viewer** unless the user explicitly chooses to. This avoids any disruptive change for existing users.

### 2. `Snapzy/App/SnapzyApp.swift`

Adds an \`application(_:open:)\` hook on \`AppDelegate\` that:

- Filters incoming URLs down to file URLs only (\`urls.filter { \$0.isFileURL }\`)
- Routes each one to the **existing** \`AnnotateManager.shared.openAnnotation(url:)\` entry point — the same one already used after a screenshot is captured. No new business logic; reuses the well-tested path that already handles sandboxed file access (\`SandboxFileAccessManager.beginAccessingURL\`) and Retina scaling.
- Queues files arriving before \`applicationDidFinishLaunching\` (cold launch via Open With) and flushes once the coordinator is ready, mirroring the existing \`pendingDeepLinkURLs\` pattern in the same file.

## Design notes

**Why \`application(_:open:)\` and not the legacy \`application(_:openFiles:)\`** — On macOS 13+, AppKit prefers the URL-based modern callback. On macOS 14/15/Tahoe (26.x), the legacy \`openFiles:\` selector is silently skipped when the OS sees that the app has not opted into the modern API. Verified empirically on macOS 26.3.1: \`openFiles:\` was never invoked, \`application(_:open:)\` is.

**Why this doesn't break the existing \`snapzy://\` URL scheme** — \`AppDelegate.applicationWillFinishLaunching\` registers an Apple Event handler for \`kAEGetURL\`. Once that handler is set, AppKit routes URL-scheme events through it directly and does not also call \`application(_:open:)\` for them. The new method's \`isFileURL\` filter is a defensive double-guarantee: even if a future macOS version did surface scheme URLs here, deep links would still be no-ops on this path and continue flowing through the existing handler. Tested: \`snapzy://capture/area\` etc. continue to work unchanged.

**Sandboxing** — Snapzy is sandboxed with \`com.apple.security.files.user-selected.read-write\`. When a user explicitly picks a file via \"Open With\", macOS grants the app implicit, scoped access to that URL, which \`AnnotateWindowController(url:)\` already handles via \`SandboxFileAccessManager.beginAccessingURL\`. No entitlement changes needed.

## Test plan

Verified end-to-end on macOS 26.3.1 (arm64) with a local Debug build:

- [x] \`xcodebuild -scheme Snapzy -configuration Debug build\` succeeds
- [x] After build, \`lsregister -dump\` shows the app's claimed UTIs:
  \`public.png, public.jpeg, public.heic, public.heif, public.tiff, com.compuserve.gif, org.webmproject.webp, public.bmp\`
- [x] \`open -a /Applications/Snapzy.app /path/to/image.png\` opens the annotation editor with that image; diagnostic log confirms:
  \`\`\`
  [INF][ACTION][SnapzyApp.swift:application(_:open:)] Received open-file request {count=1}
  [INF][ACTION][AnnotateManager.swift:openAnnotation(url:)] Annotate window opened for URL image.png
  \`\`\`
- [x] Finder right-click on a PNG → **Open With → Snapzy** → annotation editor opens with that image
- [x] Multi-select 3 images → Open With → Snapzy → 3 annotation windows open
- [x] Existing \`snapzy://capture/area\`, \`snapzy://open/annotate\`, \`snapzy://settings\` deep links still trigger their handlers unchanged
- [x] \`LSHandlerRank = Alternate\` confirmed: Preview remains the default for double-click; Snapzy only shows up in the Open With submenu unless user opts in via \"Always Open With\"

## Notes for reviewer

- The change is intentionally minimal and reuses existing infrastructure — no new managers, no new types.
- Happy to add Vietnamese / Chinese localized strings for the document type name (\"Image\") if the project prefers that; the current \`CFBundleTypeName\` is the internal type label and is not user-visible in macOS 13+ Open With UI, but I can add a localized variant if you'd like consistency with the rest of \`Resources/Localization/\`.
- Future follow-ups (out of scope here, can be separate PRs if useful):
  - Share Extension for Safari / Mail / Photos
  - Services menu entry (\"Edit Image in Snapzy\")

Thanks for building Snapzy! 🙌

Made with [Cursor](https://cursor.com)