### PR TITLE
fix: Improve Chinese translations for General and Restart Onboarding (#158)

### DIFF
--- a/Snapzy/Resources/Localization/Features/Onboarding.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Onboarding.xcstrings
@@ -1101,7 +1101,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "你之後可以隨時在「設定 -> 一般」中更改。"
+            "value" : "你之後可以隨時在「設定 -> 通用」中更改。"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/Settings.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Settings.xcstrings
@@ -3240,13 +3240,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "重新运行引导"
+            "value": "重启引导页"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "重新開始引導"
+            "value": "重啟引導頁"
           }
         }
       }
@@ -6626,7 +6626,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "一般"
+            "value": "通用"
           }
         }
       }


### PR DESCRIPTION
## Summary

- Fixes #158
- Changes zh-Hant "General" tab translation from "一般" to "通用"
- Changes zh-Hans "Restart Onboarding" from "重新运行引导" to "重启引导页"
- Changes zh-Hant "Restart Onboarding" from "重新開始引導" to "重啟引導頁"
- Updates onboarding hint referencing General tab in zh-Hant to use "通用"

## Test plan

- [x] Verify zh-Hans localization renders correctly in UI
- [x] Verify zh-Hant localization renders correctly in UI