### PR TITLE
fix: Right-align application window capture/recording shortcuts in menubar

### DIFF
--- a/Snapzy/App/AppStatusBarController.swift
+++ b/Snapzy/App/AppStatusBarController.swift
@@ -305,17 +305,13 @@ final class AppStatusBarController: ObservableObject {
 
     let applicationCaptureShortcut = CaptureOverlayShortcutSettings.applicationCaptureShortcut
     let applicationCaptureItem = NSMenuItem(
-      title: overlayMenuTitle(
-        base: L10n.PreferencesShortcuts.applicationCaptureTitle,
-        shortcut: applicationCaptureShortcut,
-        parentShortcut: shortcutManager.shortcut(for: .area),
-        isParentShortcutEnabled: shortcutManager.isShortcutEnabled(for: .area)
-      ),
+      title: L10n.PreferencesShortcuts.applicationCaptureTitle,
       action: #selector(captureApplicationAction),
       keyEquivalent: ""
     )
-    applyConfiguredOverlayShortcut(
+    configureOverlayMenuItem(
       applicationCaptureItem,
+      base: L10n.PreferencesShortcuts.applicationCaptureTitle,
       shortcut: applicationCaptureShortcut,
       parentKind: .area,
       using: shortcutManager
@@ -390,17 +386,13 @@ final class AppStatusBarController: ObservableObject {
 
     let applicationRecordingShortcut = CaptureOverlayShortcutSettings.recordingApplicationCaptureShortcut
     let applicationRecordingItem = NSMenuItem(
-      title: overlayMenuTitle(
-        base: L10n.PreferencesShortcuts.applicationRecordingTitle,
-        shortcut: applicationRecordingShortcut,
-        parentShortcut: shortcutManager.shortcut(for: .recording),
-        isParentShortcutEnabled: shortcutManager.isShortcutEnabled(for: .recording)
-      ),
+      title: L10n.PreferencesShortcuts.applicationRecordingTitle,
       action: #selector(recordApplicationAction),
       keyEquivalent: ""
     )
-    applyConfiguredOverlayShortcut(
+    configureOverlayMenuItem(
       applicationRecordingItem,
+      base: L10n.PreferencesShortcuts.applicationRecordingTitle,
       shortcut: applicationRecordingShortcut,
       parentKind: .recording,
       using: shortcutManager
@@ -763,36 +755,47 @@ final class AppStatusBarController: ObservableObject {
     item.keyEquivalentModifierMask = config.menuModifierFlags
   }
 
-  private func applyConfiguredOverlayShortcut(
+  private func configureOverlayMenuItem(
     _ item: NSMenuItem,
+    base: String,
     shortcut: CaptureOverlayShortcut?,
     parentKind: GlobalShortcutKind,
     using manager: KeyboardShortcutManager
   ) {
-    guard manager.isShortcutEnabled(for: parentKind),
-          let config = shortcut?.independentShortcutConfig,
-          let keyEquivalent = config.menuKeyEquivalent else {
+    guard let shortcut else {
+      item.title = base
       item.keyEquivalent = ""
       item.keyEquivalentModifierMask = []
       return
     }
 
-    item.keyEquivalent = keyEquivalent
-    item.keyEquivalentModifierMask = config.menuModifierFlags
-  }
+    if shortcut.isIndependent {
+      item.title = base
+      guard let config = shortcut.independentShortcutConfig,
+            let keyEquivalent = config.menuKeyEquivalent else {
+        item.keyEquivalent = ""
+        item.keyEquivalentModifierMask = []
+        return
+      }
 
-  private func overlayMenuTitle(
-    base: String,
-    shortcut: CaptureOverlayShortcut?,
-    parentShortcut: ShortcutConfig?,
-    isParentShortcutEnabled: Bool
-  ) -> String {
-    guard let shortcut, isParentShortcutEnabled, !shortcut.isIndependent, let parentShortcut else {
-      return base
+      item.keyEquivalent = keyEquivalent
+      item.keyEquivalentModifierMask = config.menuModifierFlags
+      return
     }
-    let parentDisplay = CaptureOverlayShortcut.inlineDisplay(parts: parentShortcut.displayParts)
+
     let childDisplay = CaptureOverlayShortcut.inlineDisplay(parts: shortcut.displayParts)
-    return "\(base) \(parentDisplay) \(childDisplay)"
+    guard manager.isShortcutEnabled(for: parentKind),
+          let parentConfig = manager.shortcut(for: parentKind),
+          let parentKeyEquivalent = parentConfig.menuKeyEquivalent else {
+      item.title = base
+      item.keyEquivalent = ""
+      item.keyEquivalentModifierMask = []
+      return
+    }
+
+    item.title = "\(base) \(childDisplay)"
+    item.keyEquivalent = parentKeyEquivalent
+    item.keyEquivalentModifierMask = parentConfig.menuModifierFlags
   }
 
   private func schedulePreferencesWindowTracking(excludingWindowNumbers existingWindowNumbers: Set<Int>) {


### PR DESCRIPTION
## Summary

- Fixes menubar shortcut alignment for **Application Capture** and **Application Recording** items when using paired overlay shortcuts (e.g. `⌘⇧4` + `A`).
- Paired mode now uses the parent shortcut's native `keyEquivalent` for the right-aligned column (same as other menu items), with the overlay key shown in the menu title (e.g. `应用窗口截屏 A`).
- Independent overlay shortcuts (e.g. `⇧⌘A`) continue to use `keyEquivalent` directly.

## Problem

Previously, both parent and child shortcut glyphs were inlined in the menu item title (`应用窗口截屏 ⌘⇧4 A`), so they did not align with the standard AppKit shortcut column used by other entries.

## Test plan

- [ ] Open status bar menu with default paired shortcuts (`A` overlay key)
- [ ] Verify **Application Capture** and **Application Recording** shortcuts align with **Capture Area** / **Record Screen** in the right column
- [ ] Verify overlay key appears in the title (e.g. `应用窗口截屏 A`)
- [ ] Set an independent overlay shortcut (e.g. `⇧⌘A`) and confirm it shows in the right column
- [ ] Disable parent shortcut and confirm overlay items show title only with no shortcut column


Made with [Cursor](https://cursor.com)