### PR TITLE
fix: correct Simplified and Traditional Chinese UI translations

### DIFF
--- a/Snapzy/Resources/Localization/Features/Annotate.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Annotate.xcstrings
@@ -1615,13 +1615,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "作物"
+            "value" : "裁剪"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "作物"
+            "value" : "裁剪"
           }
         }
       }
@@ -2590,13 +2590,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "弯头"
+            "value" : "折线"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "彎頭"
+            "value" : "折線"
           }
         }
       }
@@ -3175,13 +3175,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "样机"
+            "value" : "样机展示"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "樣機"
+            "value" : "樣機展示"
           }
         }
       }
@@ -3695,13 +3695,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "钉窗"
+            "value" : "固定窗口"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "釘窗"
+            "value" : "固定視窗"
           }
         }
       }
@@ -4475,13 +4475,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "重置样机"
+            "value" : "重置样机展示"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "重置樣機"
+            "value" : "重設樣機展示"
           }
         }
       }
@@ -5125,13 +5125,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "直"
+            "value" : "直线"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "直"
+            "value" : "直線"
           }
         }
       }
@@ -5840,13 +5840,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "柜台"
+            "value" : "计数器"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "櫃台"
+            "value" : "計數器"
           }
         }
       }
@@ -5905,13 +5905,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "作物"
+            "value" : "裁剪"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "作物"
+            "value" : "裁剪"
           }
         }
       }
@@ -6100,13 +6100,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "线"
+            "value" : "直线"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "線"
+            "value" : "直線"
           }
         }
       }
@@ -6165,13 +6165,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "样机"
+            "value" : "样机展示"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "樣機"
+            "value" : "樣機展示"
           }
         }
       }
@@ -7400,13 +7400,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "对角"
+            "value" : "对角线"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "對角"
+            "value" : "對角線"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/Capture.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Capture.xcstrings
@@ -5421,13 +5421,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "按键覆盖"
+            "value" : "按键显示浮层"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "按鍵覆蓋"
+            "value" : "按鍵顯示浮層"
           }
         }
       }
@@ -9404,13 +9404,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "会话活跃。 %d 个帧拼接成 %d 像素。"
+            "value" : "会话进行中。已将 %d 帧拼接为 %d 像素。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "會話活躍。 %d 個幀拼接成 %d 像素。"
+            "value" : "工作階段進行中。已將 %d 個畫格拼接為 %d 像素。"
           }
         }
       }
@@ -12719,13 +12719,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "减速"
+            "value" : "请放慢滚动"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "減速"
+            "value" : "請放慢捲動"
           }
         }
       }
@@ -13954,13 +13954,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "准备好了"
+            "value" : "就绪"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "準備好了"
+            "value" : "就緒"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/Cloud.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Cloud.xcstrings
@@ -4085,13 +4085,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "加载之前导出的 Snapzy 云存档以预填写此表单。"
+            "value" : "加载之前导出的 Snapzy 云存档以预填充此表单。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "加載之前導出的 Snapzy 雲存檔以預填寫此表單。"
+            "value" : "載入之前匯出的 Snapzy 雲端存檔以預填充此表單。"
           }
         }
       }
@@ -10325,13 +10325,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "解雇"
+            "value" : "关闭"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "解雇"
+            "value" : "關閉"
           }
         }
       }
@@ -11560,13 +11560,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "活跃"
+            "value" : "使用中"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "活躍"
+            "value" : "使用中"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/QuickAccess.xcstrings
+++ b/Snapzy/Resources/Localization/Features/QuickAccess.xcstrings
@@ -185,13 +185,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "角落"
+            "value" : "角标"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "角落"
+            "value" : "角標"
           }
         }
       }
@@ -705,13 +705,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "浮动覆盖"
+            "value" : "浮动浮层"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "浮動覆蓋"
+            "value" : "浮動浮層"
           }
         }
       }
@@ -770,13 +770,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "保持覆盖打开直到关闭"
+            "value" : "保持浮层打开，直到关闭"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "保持覆蓋打開直到關閉"
+            "value" : "保持浮層開啟，直到關閉"
           }
         }
       }
@@ -965,13 +965,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "覆盖尺寸"
+            "value" : "浮层尺寸"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "覆蓋尺寸"
+            "value" : "浮層尺寸"
           }
         }
       }
@@ -1420,13 +1420,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "覆盖层出现的位置"
+            "value" : "浮层出现的位置"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "覆蓋層出現的位置"
+            "value" : "浮層出現的位置"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/Recording.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Recording.xcstrings
@@ -2200,13 +2200,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "坚持"
+            "value" : "保留标注"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "堅持"
+            "value" : "保留標註"
           }
         }
       }
@@ -3435,13 +3435,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "覆盖"
+            "value" : "浮层"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "覆蓋"
+            "value" : "浮層"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/Shortcuts.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Shortcuts.xcstrings
@@ -2263,13 +2263,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "打开键盘快捷键覆盖"
+            "value" : "打开键盘快捷键浮层"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "打開鍵盤快捷鍵覆蓋"
+            "value" : "打開鍵盤快速鍵浮層"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/VideoEditor.xcstrings
+++ b/Snapzy/Resources/Localization/Features/VideoEditor.xcstrings
@@ -3825,13 +3825,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "保持原创"
+            "value" : "保留原文件"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "保持原創"
+            "value" : "保留原始檔案"
           }
         }
       }
@@ -5840,13 +5840,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "段"
+            "value" : "片段"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "段"
+            "value" : "片段"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Shared/Common.xcstrings
+++ b/Snapzy/Resources/Localization/Shared/Common.xcstrings
@@ -1225,13 +1225,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "黑暗"
+            "value" : "深色"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "黑暗"
+            "value" : "深色"
           }
         }
       }
@@ -1290,13 +1290,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "光"
+            "value" : "浅色"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "光"
+            "value" : "淺色"
           }
         }
       }
@@ -1420,13 +1420,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "活跃"
+            "value" : "启用"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "活躍"
+            "value" : "啟用"
           }
         }
       }
@@ -1485,13 +1485,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "申请"
+            "value" : "应用"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "申請"
+            "value" : "套用"
           }
         }
       }
@@ -2265,13 +2265,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "角落"
+            "value" : "圆角"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "角落"
+            "value" : "圓角"
           }
         }
       }
@@ -2460,13 +2460,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "定制"
+            "value" : "自定义"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "定制"
+            "value" : "自訂"
           }
         }
       }
@@ -3045,13 +3045,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "估计"
+            "value" : "预估"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "估計"
+            "value" : "預估"
           }
         }
       }
@@ -3175,13 +3175,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "出口"
+            "value" : "导出"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "出口"
+            "value" : "匯出"
           }
         }
       }
@@ -3305,13 +3305,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "填写"
+            "value" : "填充"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "填寫"
+            "value" : "填充"
           }
         }
       }
@@ -3760,13 +3760,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "插图"
+            "value" : "内边距"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "插圖"
+            "value" : "內邊距"
           }
         }
       }
@@ -3890,13 +3890,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "中等的"
+            "value" : "中等"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "中等的"
+            "value" : "中等"
           }
         }
       }
@@ -3955,13 +3955,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "修改"
+            "value" : "已修改"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "修改"
+            "value" : "已修改"
           }
         }
       }
@@ -4150,13 +4150,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "姓名"
+            "value" : "名称"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "姓名"
+            "value" : "名稱"
           }
         }
       }
@@ -4410,13 +4410,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "关闭"
+            "value" : "关"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "關閉"
+            "value" : "關"
           }
         }
       }
@@ -4540,13 +4540,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "上"
+            "value" : "开"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "上"
+            "value" : "開"
           }
         }
       }
@@ -4865,13 +4865,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "原创"
+            "value" : "原始"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "原創"
+            "value" : "原始"
           }
         }
       }
@@ -4995,13 +4995,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "填充"
+            "value" : "内边距"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "填充"
+            "value" : "內邊距"
           }
         }
       }
@@ -5125,13 +5125,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "观点"
+            "value" : "透视"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "觀點"
+            "value" : "透視"
           }
         }
       }
@@ -5190,13 +5190,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "偏好"
+            "value" : "设置"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "偏好"
+            "value" : "設定"
           }
         }
       }
@@ -5385,13 +5385,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "准备好了"
+            "value" : "就绪"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "準備好了"
+            "value" : "就緒"
           }
         }
       }
@@ -6052,13 +6052,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "影子"
+            "value" : "阴影"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "影子"
+            "value" : "陰影"
           }
         }
       }
@@ -6247,13 +6247,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "固体"
+            "value" : "纯色"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "固體"
+            "value" : "純色"
           }
         }
       }
@@ -6377,13 +6377,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "中风"
+            "value" : "描边"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "中風"
+            "value" : "描邊"
           }
         }
       }


### PR DESCRIPTION
## Summary
- Fix incorrect zh-Hans and zh-Hant strings that used literal dictionary translations (e.g. Stroke → 中风/中風, Export → 出口, Overlay → 覆盖/覆蓋).
- Use UI-appropriate terms instead: 描边/描邊, 导出/匯出, 浮层/浮層, 裁剪, 计数器/計數器, and related fixes across Common, Annotate, Capture, Recording, Quick Access, Cloud, Shortcuts, and Video Editor catalogs.
- Rebased onto latest `upstream/master`.

## Test plan
- [ ] Switch app language to 简体中文 and spot-check annotation toolbar (Stroke, Fill, Export, Overlay-related settings).
- [ ] Switch to 繁體中文 and verify the same strings use the updated Traditional Chinese terms.
- [ ] Confirm no broken format strings (`%d`, `%@`) in scrolling capture status text.


Made with [Cursor](https://cursor.com)