### PR TITLE
feat: add 90° image rotation buttons to annotate editor

### DIFF
--- a/Snapzy/Features/Annotate/AnnotateState.swift
+++ b/Snapzy/Features/Annotate/AnnotateState.swift
@@ -18,6 +18,29 @@ final class AnnotateState: ObservableObject {
     var embeddedImageAssets: [UUID: NSImage]
   }
 
+  /// Snapshot of every piece of state mutated by an image rotation. Used as a dedicated
+  /// undo entry so rotation undo never disturbs the annotation-only undo path.
+  private struct RotationSnapshot {
+    var sourceImage: NSImage?
+    var cutoutImage: NSImage?
+    var isCutoutApplied: Bool
+    var embeddedImageAssets: [UUID: NSImage]
+    var embeddedImageSourceData: [UUID: Data]
+    var embeddedImageSnapshotCacheData: [UUID: Data]
+    var annotations: [AnnotationItem]
+    var cropRect: CGRect?
+    var originalCropRect: CGRect?
+    var cropAspectRatio: CropAspectRatio
+    var isCropPortraitOrientation: Bool
+    var didCutoutAutoApplyCrop: Bool
+    var cutoutAutoAppliedCropRect: CGRect?
+  }
+
+  private enum UndoEntry {
+    case annotations(AnnotationSnapshot)
+    case rotation(RotationSnapshot)
+  }
+
   private struct TextEditingUndoTransaction {
     let annotationId: UUID
     let snapshotBeforeEdit: AnnotationSnapshot
@@ -1095,8 +1118,8 @@ final class AnnotateState: ObservableObject {
   @Published var canUndo: Bool = false
   @Published var canRedo: Bool = false
 
-  private var undoStack: [AnnotationSnapshot] = []
-  private var redoStack: [AnnotationSnapshot] = []
+  private var undoStack: [UndoEntry] = []
+  private var redoStack: [UndoEntry] = []
   private var textEditingUndoTransaction: TextEditingUndoTransaction?
 
   init(
@@ -1705,7 +1728,16 @@ final class AnnotateState: ObservableObject {
 
   private func pushUndoSnapshot(_ snapshot: AnnotationSnapshot, annotationCount: Int) {
     DiagnosticLogger.shared.log(.debug, .annotate, "Undo checkpoint", context: ["annotations": "\(annotationCount)"])
-    undoStack.append(snapshot)
+    undoStack.append(.annotations(snapshot))
+    redoStack.removeAll()
+    canUndo = true
+    canRedo = false
+    hasUnsavedChanges = true
+  }
+
+  private func pushRotationUndo(_ snapshot: RotationSnapshot) {
+    DiagnosticLogger.shared.log(.debug, .annotate, "Undo checkpoint", context: ["kind": "rotation"])
+    undoStack.append(.rotation(snapshot))
     redoStack.removeAll()
     canUndo = true
     canRedo = false
@@ -1718,8 +1750,14 @@ final class AnnotateState: ObservableObject {
     }
     DiagnosticLogger.shared.log(.debug, .annotate, "Undo", context: ["stackDepth": "\(undoStack.count)"])
     guard let previous = undoStack.popLast() else { return }
-    redoStack.append(currentSnapshot())
-    applySnapshot(previous)
+    switch previous {
+    case .annotations(let snapshot):
+      redoStack.append(.annotations(currentSnapshot()))
+      applySnapshot(snapshot)
+    case .rotation(let snapshot):
+      redoStack.append(.rotation(currentRotationSnapshot()))
+      applyRotationSnapshot(snapshot)
+    }
     canUndo = !undoStack.isEmpty
     canRedo = true
   }
@@ -1730,8 +1768,14 @@ final class AnnotateState: ObservableObject {
     }
     DiagnosticLogger.shared.log(.debug, .annotate, "Redo", context: ["stackDepth": "\(redoStack.count)"])
     guard let next = redoStack.popLast() else { return }
-    undoStack.append(currentSnapshot())
-    applySnapshot(next)
+    switch next {
+    case .annotations(let snapshot):
+      undoStack.append(.annotations(currentSnapshot()))
+      applySnapshot(snapshot)
+    case .rotation(let snapshot):
+      undoStack.append(.rotation(currentRotationSnapshot()))
+      applyRotationSnapshot(snapshot)
+    }
     canUndo = true
     canRedo = !redoStack.isEmpty
   }
@@ -1740,6 +1784,24 @@ final class AnnotateState: ObservableObject {
     AnnotationSnapshot(
       annotations: annotations,
       embeddedImageAssets: embeddedImageAssets
+    )
+  }
+
+  private func currentRotationSnapshot() -> RotationSnapshot {
+    RotationSnapshot(
+      sourceImage: sourceImage,
+      cutoutImage: cutoutImage,
+      isCutoutApplied: isCutoutApplied,
+      embeddedImageAssets: embeddedImageAssets,
+      embeddedImageSourceData: embeddedImageSourceData,
+      embeddedImageSnapshotCacheData: embeddedImageSnapshotCacheData,
+      annotations: annotations,
+      cropRect: cropRect,
+      originalCropRect: originalCropRect,
+      cropAspectRatio: cropAspectRatio,
+      isCropPortraitOrientation: isCropPortraitOrientation,
+      didCutoutAutoApplyCrop: didCutoutAutoApplyCrop,
+      cutoutAutoAppliedCropRect: cutoutAutoAppliedCropRect
     )
   }
 
@@ -1794,6 +1856,142 @@ final class AnnotateState: ObservableObject {
        !annotations.contains(where: { $0.id == editingTextAnnotationId }) {
       self.editingTextAnnotationId = nil
     }
+  }
+
+  private func applyRotationSnapshot(_ snapshot: RotationSnapshot) {
+    sourceImage = snapshot.sourceImage
+    cutoutImage = snapshot.cutoutImage
+    isCutoutApplied = snapshot.isCutoutApplied
+    embeddedImageAssets = snapshot.embeddedImageAssets
+    embeddedImageSourceData = snapshot.embeddedImageSourceData
+    embeddedImageSnapshotCacheData = snapshot.embeddedImageSnapshotCacheData
+    embeddedImageCGImageCache.removeAll()
+    annotations = snapshot.annotations
+    cropRect = snapshot.cropRect
+    originalCropRect = snapshot.originalCropRect
+    cropAspectRatio = snapshot.cropAspectRatio
+    isCropPortraitOrientation = snapshot.isCropPortraitOrientation
+    didCutoutAutoApplyCrop = snapshot.didCutoutAutoApplyCrop
+    cutoutAutoAppliedCropRect = snapshot.cutoutAutoAppliedCropRect
+
+    pruneUnusedEmbeddedAssets()
+    updateImportWarningIfNeeded()
+
+    let validAnnotationIds = Set(annotations.map(\.id))
+    setSelectedAnnotationIds(selectedAnnotationIds.intersection(validAnnotationIds))
+
+    if let editingTextAnnotationId,
+       !annotations.contains(where: { $0.id == editingTextAnnotationId }) {
+      self.editingTextAnnotationId = nil
+    }
+  }
+
+  // MARK: - Rotation
+
+  /// True when the user can rotate the source image 90°. Disabled while no image is loaded,
+  /// while crop is being actively edited, or while a background-cutout request is in flight.
+  var canRotateImage: Bool {
+    hasImage && !isCropActive && !isCutoutProcessing
+  }
+
+  /// Rotate the source image 90° clockwise (or counter-clockwise) and bring all annotations,
+  /// crop bounds, embedded image layers, and cutout state along for the ride. Pushes a
+  /// dedicated rotation undo entry so this transform can be reversed without touching the
+  /// annotation-only undo path.
+  func rotateImage(clockwise: Bool) {
+    guard canRotateImage,
+          let source = sourceImage,
+          let rotatedSource = source.rotated90(clockwise: clockwise) else {
+      return
+    }
+
+    if editingTextAnnotationId != nil {
+      commitTextEditing()
+    }
+
+    DiagnosticLogger.shared.log(.info, .annotate, "Image rotated", context: [
+      "direction": clockwise ? "clockwise" : "counterclockwise",
+      "oldSize": "\(Int(imageWidth))x\(Int(imageHeight))"
+    ])
+
+    let oldSize = CGSize(width: imageWidth, height: imageHeight)
+    pushRotationUndo(currentRotationSnapshot())
+
+    sourceImage = rotatedSource
+    if let cutoutImage {
+      self.cutoutImage = cutoutImage.rotated90(clockwise: clockwise)
+    }
+
+    // Rotate each embedded image asset so the rendered bitmap matches the rotated bounds, and
+    // invalidate the serialised data caches so persistence re-encodes from the rotated NSImage.
+    for (assetId, image) in embeddedImageAssets {
+      guard let rotatedAsset = image.rotated90(clockwise: clockwise) else { continue }
+      embeddedImageAssets[assetId] = rotatedAsset
+      embeddedImageSourceData.removeValue(forKey: assetId)
+      embeddedImageSnapshotCacheData.removeValue(forKey: assetId)
+    }
+    embeddedImageCGImageCache.removeAll()
+
+    annotations = annotations.map { rotateAnnotation($0, oldSize: oldSize, clockwise: clockwise) }
+
+    cropRect = cropRect.map { AnnotateImageRotation.rotateRect($0, oldSize: oldSize, clockwise: clockwise) }
+    originalCropRect = originalCropRect.map { AnnotateImageRotation.rotateRect($0, oldSize: oldSize, clockwise: clockwise) }
+    cutoutAutoAppliedCropRect = cutoutAutoAppliedCropRect.map {
+      AnnotateImageRotation.rotateRect($0, oldSize: oldSize, clockwise: clockwise)
+    }
+
+    // Aspect-ratio presets such as 16:9 keep their identity but the physical orientation flips.
+    if cropAspectRatio != .free, cropAspectRatio != .square {
+      isCropPortraitOrientation.toggle()
+    }
+
+    hasUnsavedChanges = true
+  }
+
+  private func rotateAnnotation(
+    _ annotation: AnnotationItem,
+    oldSize: CGSize,
+    clockwise: Bool
+  ) -> AnnotationItem {
+    var rotated = annotation
+    rotated.bounds = AnnotateImageRotation.rotateRect(annotation.bounds, oldSize: oldSize, clockwise: clockwise)
+
+    switch annotation.type {
+    case .arrow(let geometry):
+      let newStart = AnnotateImageRotation.rotatePoint(geometry.start, oldSize: oldSize, clockwise: clockwise)
+      let newEnd = AnnotateImageRotation.rotatePoint(geometry.end, oldSize: oldSize, clockwise: clockwise)
+      let newControl = geometry.resolvedControlPoint.map {
+        AnnotateImageRotation.rotatePoint($0, oldSize: oldSize, clockwise: clockwise)
+      }
+      let newGeometry = ArrowGeometry(start: newStart, end: newEnd, style: geometry.style, controlPoint: newControl)
+      rotated.type = .arrow(newGeometry)
+      rotated.bounds = newGeometry.bounds()
+
+    case .line(let start, let end):
+      let newStart = AnnotateImageRotation.rotatePoint(start, oldSize: oldSize, clockwise: clockwise)
+      let newEnd = AnnotateImageRotation.rotatePoint(end, oldSize: oldSize, clockwise: clockwise)
+      rotated.type = .line(start: newStart, end: newEnd)
+
+    case .path(let points):
+      rotated.type = .path(points.map {
+        AnnotateImageRotation.rotatePoint($0, oldSize: oldSize, clockwise: clockwise)
+      })
+
+    case .highlight(let points):
+      rotated.type = .highlight(points.map {
+        AnnotateImageRotation.rotatePoint($0, oldSize: oldSize, clockwise: clockwise)
+      })
+
+    case .rectangle, .filledRectangle, .oval, .text, .blur, .counter, .watermark, .embeddedImage:
+      // Bounds-only annotations: the rotated `bounds` above is the full transform we need.
+      // Per-annotation `rotationDegrees` (text/watermark) is clamped to ±45° so we deliberately
+      // leave it unchanged; the bounding box moves correctly but inner text orientation stays
+      // relative to the original canvas. Acceptable for v1 since rotation is typically applied
+      // before annotating.
+      break
+    }
+
+    return rotated
   }
 
   // MARK: - Counter

--- a/Snapzy/Features/Annotate/AnnotateState.swift
+++ b/Snapzy/Features/Annotate/AnnotateState.swift
@@ -1874,6 +1874,21 @@ final class AnnotateState: ObservableObject {
     didCutoutAutoApplyCrop = snapshot.didCutoutAutoApplyCrop
     cutoutAutoAppliedCropRect = snapshot.cutoutAutoAppliedCropRect
 
+    // Rotation is gated on `!isCropActive` (see `canRotateImage`), so any rotation snapshot
+    // by definition represents a non-crop state. If the user enters crop mode and then
+    // undoes the rotation, we must clear the crop interaction so it doesn't keep editing
+    // against the differently-sized restored image with stale bounds.
+    if isCropActive {
+      isCropActive = false
+      isCropResizing = false
+      isCropShiftLocked = false
+      cropInteractionContext = nil
+      shouldRestoreSidebarAfterCropInteraction = false
+      if selectedTool == .crop {
+        selectedTool = .selection
+      }
+    }
+
     pruneUnusedEmbeddedAssets()
     updateImportWarningIfNeeded()
 

--- a/Snapzy/Features/Annotate/Components/AnnotateToolbarView.swift
+++ b/Snapzy/Features/Annotate/Components/AnnotateToolbarView.swift
@@ -69,6 +69,20 @@ struct AnnotateToolbarView: View {
       }
       .help(L10n.AnnotateUI.crop)
 
+      ToolbarButton(icon: "rotate.left", isSelected: false) {
+        state.rotateImage(clockwise: false)
+      }
+      .help(L10n.AnnotateUI.rotateLeft)
+      .disabled(!state.canRotateImage)
+      .opacity(state.canRotateImage ? 1 : 0.4)
+
+      ToolbarButton(icon: "rotate.right", isSelected: false) {
+        state.rotateImage(clockwise: true)
+      }
+      .help(L10n.AnnotateUI.rotateRight)
+      .disabled(!state.canRotateImage)
+      .opacity(state.canRotateImage ? 1 : 0.4)
+
       ToolbarButton(
         icon: "rectangle.on.rectangle",
         isSelected: state.showSidebar,

--- a/Snapzy/Features/Annotate/Services/AnnotateImageRotation.swift
+++ b/Snapzy/Features/Annotate/Services/AnnotateImageRotation.swift
@@ -1,0 +1,100 @@
+//
+//  AnnotateImageRotation.swift
+//  Snapzy
+//
+//  90° rotation helpers for NSImage and CGRect used by the editor's
+//  rotate-left / rotate-right toolbar buttons.
+//
+
+import AppKit
+import CoreGraphics
+
+extension NSImage {
+  /// Returns a new `NSImage` rotated 90° clockwise or counter-clockwise.
+  ///
+  /// Preserves backing-pixel resolution (Retina) by rotating the underlying
+  /// `CGImage` and constructing an `NSImage` whose logical `size` is the
+  /// original size with width/height swapped.
+  func rotated90(clockwise: Bool) -> NSImage? {
+    guard let cgImage = self.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+      return nil
+    }
+
+    let pixelWidth = cgImage.width
+    let pixelHeight = cgImage.height
+    let newPixelWidth = pixelHeight
+    let newPixelHeight = pixelWidth
+
+    let colorSpace = cgImage.colorSpace ?? CGColorSpaceCreateDeviceRGB()
+    let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+
+    guard let context = CGContext(
+      data: nil,
+      width: newPixelWidth,
+      height: newPixelHeight,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: colorSpace,
+      bitmapInfo: bitmapInfo
+    ) else {
+      return nil
+    }
+
+    context.interpolationQuality = .high
+
+    // Translate origin to the rotation pivot (centre of the new canvas), rotate, then draw the
+    // source centred on the origin. CGContext uses bottom-left origin which is fine — we operate
+    // on a square-equivalent rotation that's orientation-agnostic.
+    context.translateBy(x: CGFloat(newPixelWidth) / 2, y: CGFloat(newPixelHeight) / 2)
+    context.rotate(by: clockwise ? -.pi / 2 : .pi / 2)
+    context.translateBy(x: -CGFloat(pixelWidth) / 2, y: -CGFloat(pixelHeight) / 2)
+    context.draw(cgImage, in: CGRect(x: 0, y: 0, width: pixelWidth, height: pixelHeight))
+
+    guard let rotatedCGImage = context.makeImage() else { return nil }
+
+    // Preserve logical point size (swap width/height) so display scale is unchanged on Retina.
+    let pointSize = NSSize(width: self.size.height, height: self.size.width)
+    return NSImage(cgImage: rotatedCGImage, size: pointSize)
+  }
+}
+
+/// Pure geometry helpers for rotating annotation coordinates in image-pixel space
+/// (top-left origin, y-down).
+enum AnnotateImageRotation {
+  /// Rotate a point 90° within an image of `oldSize`.
+  static func rotatePoint(
+    _ point: CGPoint,
+    oldSize: CGSize,
+    clockwise: Bool
+  ) -> CGPoint {
+    if clockwise {
+      return CGPoint(x: oldSize.height - point.y, y: point.x)
+    } else {
+      return CGPoint(x: point.y, y: oldSize.width - point.x)
+    }
+  }
+
+  /// Rotate a rect 90° within an image of `oldSize`. The returned rect is standardised.
+  static func rotateRect(
+    _ rect: CGRect,
+    oldSize: CGSize,
+    clockwise: Bool
+  ) -> CGRect {
+    let standardised = rect.standardized
+    if clockwise {
+      return CGRect(
+        x: oldSize.height - standardised.minY - standardised.height,
+        y: standardised.minX,
+        width: standardised.height,
+        height: standardised.width
+      )
+    } else {
+      return CGRect(
+        x: standardised.minY,
+        y: oldSize.width - standardised.minX - standardised.width,
+        width: standardised.height,
+        height: standardised.width
+      )
+    }
+  }
+}

--- a/Snapzy/Resources/Localization/Features/Annotate.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Annotate.xcstrings
@@ -7800,6 +7800,28 @@
           }
         }
       }
+    },
+    "annotate.rotate-left" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rotate left 90°"
+          }
+        }
+      }
+    },
+    "annotate.rotate-right" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rotate right 90°"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/Snapzy/Shared/Localization/L10n.swift
+++ b/Snapzy/Shared/Localization/L10n.swift
@@ -3632,6 +3632,16 @@ enum L10n {
       defaultValue: "Crop",
       comment: "Tooltip for entering crop mode in annotate"
     )
+    static let rotateLeft = string(
+      "annotate.rotate-left",
+      defaultValue: "Rotate left 90°",
+      comment: "Tooltip for rotating the source image 90° counter-clockwise"
+    )
+    static let rotateRight = string(
+      "annotate.rotate-right",
+      defaultValue: "Rotate right 90°",
+      comment: "Tooltip for rotating the source image 90° clockwise"
+    )
     static let toggleSidebar = string(
       "annotate.toggle-sidebar",
       defaultValue: "Toggle sidebar",

--- a/SnapzyTests/Features/Annotate/AnnotateImageRotationTests.swift
+++ b/SnapzyTests/Features/Annotate/AnnotateImageRotationTests.swift
@@ -1,0 +1,161 @@
+//
+//  AnnotateImageRotationTests.swift
+//  SnapzyTests
+//
+//  Unit tests for 90° point/rect rotation helpers used by the editor rotation tools.
+//  Coordinate system is top-left origin (y-down), matching annotation storage.
+//
+
+import AppKit
+import CoreGraphics
+import XCTest
+@testable import Snapzy
+
+final class AnnotateImageRotationTests: XCTestCase {
+  private let imageSize = CGSize(width: 400, height: 200)
+
+  // MARK: - rotatePoint
+
+  func testRotatePoint_clockwise_topLeftCornerMovesToTopRight() {
+    let rotated = AnnotateImageRotation.rotatePoint(.zero, oldSize: imageSize, clockwise: true)
+    XCTAssertEqual(rotated, CGPoint(x: imageSize.height, y: 0))
+  }
+
+  func testRotatePoint_clockwise_topRightCornerMovesToBottomRight() {
+    let rotated = AnnotateImageRotation.rotatePoint(
+      CGPoint(x: imageSize.width, y: 0),
+      oldSize: imageSize,
+      clockwise: true
+    )
+    XCTAssertEqual(rotated, CGPoint(x: imageSize.height, y: imageSize.width))
+  }
+
+  func testRotatePoint_clockwise_bottomRightCornerMovesToBottomLeft() {
+    let rotated = AnnotateImageRotation.rotatePoint(
+      CGPoint(x: imageSize.width, y: imageSize.height),
+      oldSize: imageSize,
+      clockwise: true
+    )
+    XCTAssertEqual(rotated, CGPoint(x: 0, y: imageSize.width))
+  }
+
+  func testRotatePoint_counterClockwise_topLeftCornerMovesToBottomLeft() {
+    let rotated = AnnotateImageRotation.rotatePoint(.zero, oldSize: imageSize, clockwise: false)
+    XCTAssertEqual(rotated, CGPoint(x: 0, y: imageSize.width))
+  }
+
+  func testRotatePoint_counterClockwise_topRightCornerMovesToTopLeft() {
+    let rotated = AnnotateImageRotation.rotatePoint(
+      CGPoint(x: imageSize.width, y: 0),
+      oldSize: imageSize,
+      clockwise: false
+    )
+    XCTAssertEqual(rotated, .zero)
+  }
+
+  func testRotatePoint_fourClockwiseRotationsReturnsToOriginal() {
+    let point = CGPoint(x: 137, y: 92)
+    let pass1 = AnnotateImageRotation.rotatePoint(point, oldSize: imageSize, clockwise: true)
+    let pass2 = AnnotateImageRotation.rotatePoint(
+      pass1,
+      oldSize: CGSize(width: imageSize.height, height: imageSize.width),
+      clockwise: true
+    )
+    let pass3 = AnnotateImageRotation.rotatePoint(pass2, oldSize: imageSize, clockwise: true)
+    let pass4 = AnnotateImageRotation.rotatePoint(
+      pass3,
+      oldSize: CGSize(width: imageSize.height, height: imageSize.width),
+      clockwise: true
+    )
+    XCTAssertEqual(pass4, point)
+  }
+
+  func testRotatePoint_clockwiseThenCounterClockwiseReturnsToOriginal() {
+    let point = CGPoint(x: 137, y: 92)
+    let forward = AnnotateImageRotation.rotatePoint(point, oldSize: imageSize, clockwise: true)
+    let back = AnnotateImageRotation.rotatePoint(
+      forward,
+      oldSize: CGSize(width: imageSize.height, height: imageSize.width),
+      clockwise: false
+    )
+    XCTAssertEqual(back, point)
+  }
+
+  // MARK: - rotateRect
+
+  func testRotateRect_clockwise_swapsDimensionsAndRepositions() {
+    let rect = CGRect(x: 10, y: 20, width: 80, height: 60)
+    let rotated = AnnotateImageRotation.rotateRect(rect, oldSize: imageSize, clockwise: true)
+    XCTAssertEqual(
+      rotated,
+      CGRect(
+        x: imageSize.height - rect.minY - rect.height,
+        y: rect.minX,
+        width: rect.height,
+        height: rect.width
+      )
+    )
+  }
+
+  func testRotateRect_counterClockwise_swapsDimensionsAndRepositions() {
+    let rect = CGRect(x: 10, y: 20, width: 80, height: 60)
+    let rotated = AnnotateImageRotation.rotateRect(rect, oldSize: imageSize, clockwise: false)
+    XCTAssertEqual(
+      rotated,
+      CGRect(
+        x: rect.minY,
+        y: imageSize.width - rect.minX - rect.width,
+        width: rect.height,
+        height: rect.width
+      )
+    )
+  }
+
+  func testRotateRect_fullImageRectClockwiseProducesFullRotatedCanvas() {
+    let fullRect = CGRect(origin: .zero, size: imageSize)
+    let rotated = AnnotateImageRotation.rotateRect(fullRect, oldSize: imageSize, clockwise: true)
+    XCTAssertEqual(rotated, CGRect(x: 0, y: 0, width: imageSize.height, height: imageSize.width))
+  }
+
+  func testRotateRect_handlesNonStandardRectByStandardising() {
+    let nonStandard = CGRect(x: 100, y: 90, width: -40, height: -20)
+    let expectedStandardised = nonStandard.standardized
+    let rotated = AnnotateImageRotation.rotateRect(nonStandard, oldSize: imageSize, clockwise: true)
+    XCTAssertEqual(rotated.width, expectedStandardised.height)
+    XCTAssertEqual(rotated.height, expectedStandardised.width)
+  }
+
+  // MARK: - NSImage.rotated90
+
+  func testNSImageRotated90Clockwise_swapsLogicalPointSize() {
+    let image = makeImage(width: 200, height: 100)
+    let rotated = image.rotated90(clockwise: true)
+    XCTAssertNotNil(rotated)
+    XCTAssertEqual(rotated?.size, NSSize(width: 100, height: 200))
+  }
+
+  func testNSImageRotated90CounterClockwise_swapsLogicalPointSize() {
+    let image = makeImage(width: 200, height: 100)
+    let rotated = image.rotated90(clockwise: false)
+    XCTAssertNotNil(rotated)
+    XCTAssertEqual(rotated?.size, NSSize(width: 100, height: 200))
+  }
+
+  func testNSImageRotated90Twice_preservesOriginalAspectRatio() {
+    let image = makeImage(width: 300, height: 100)
+    let rotated = image.rotated90(clockwise: true)?.rotated90(clockwise: true)
+    XCTAssertEqual(rotated?.size, NSSize(width: 300, height: 100))
+  }
+
+  // MARK: - Helpers
+
+  private func makeImage(width: CGFloat, height: CGFloat) -> NSImage {
+    let size = NSSize(width: width, height: height)
+    let image = NSImage(size: size)
+    image.lockFocus()
+    NSColor.red.setFill()
+    NSRect(origin: .zero, size: size).fill()
+    image.unlockFocus()
+    return image
+  }
+}


### PR DESCRIPTION
## Summary

Adds rotate-left / rotate-right toolbar buttons next to crop in the annotate editor. Rotates the source image 90° and brings all editor state along with it.

Before this PR there was no way to rotate a screenshot once captured — only crop, draw, blur, mockup, etc.

## What rotates

- Source image, cutout image, and every embedded image layer — via a new `NSImage.rotated90(clockwise:)` helper that preserves Retina pixel resolution and swaps logical point size.
- All annotation bounds + embedded coordinate data (`path`, `highlight`, `line`, `arrow` including elbow/curve control points).
- `cropRect`, `originalCropRect`, and `cutoutAutoAppliedCropRect`.
- `isCropPortraitOrientation` toggles when an aspect-ratio preset (16:9, etc.) is active, so the preset identity survives rotation.
- Embedded image `embeddedImageSourceData` / `embeddedImageSnapshotCacheData` are cleared per asset on rotation so persistence re-encodes from the rotated `NSImage` (otherwise saved files would stale-revert the embedded layers).

## Undo / redo

Introduces a typed undo entry — `enum UndoEntry { case annotations(AnnotationSnapshot); case rotation(RotationSnapshot) }`. The existing annotation-only undo path is unchanged. Rotation gets its own `RotationSnapshot` capturing the 13 mutated fields, so rotation undo can never silently roll back background cutout or crop state (which sit outside the annotation undo stack).

`applyRotationSnapshot` also clears any active crop interaction when restoring — rotation is gated on `!isCropActive`, so a rotation snapshot by definition represents a non-crop state, and a stale `isCropActive` against the restored image dimensions would otherwise corrupt the crop UI.

## Disabled when

- No image is loaded
- Crop is being actively edited (`isCropActive`)
- A background-cutout request is in flight (`isCutoutProcessing`)

## Files

- `Snapzy/Features/Annotate/Services/AnnotateImageRotation.swift` — new helper (NSImage rotation + pure point/rect rotation formulas)
- `Snapzy/Features/Annotate/AnnotateState.swift` — `UndoEntry` enum, `RotationSnapshot`, `rotateImage(clockwise:)`, `canRotateImage`, `rotateAnnotation`, `applyRotationSnapshot`
- `Snapzy/Features/Annotate/Components/AnnotateToolbarView.swift` — two new buttons in `captureToolsGroup`
- `Snapzy/Shared/Localization/L10n.swift` + `Snapzy/Resources/Localization/Features/Annotate.xcstrings` — new `rotateLeft` / `rotateRight` strings
- `SnapzyTests/Features/Annotate/AnnotateImageRotationTests.swift` — 14 new unit tests

## Tests

`xcodebuild test -only-testing:SnapzyTests/AnnotateImageRotationTests -only-testing:SnapzyTests/AnnotateCoreTests` — green.

New tests cover:
- Point rotation formulas (CW + CCW, every corner of an asymmetric image)
- 4× CW identity round-trip
- CW↔CCW reversibility
- Rect rotation formulas (CW + CCW)
- Non-standard rect normalisation
- Full-image rect round-trip
- `NSImage.rotated90` swaps logical point size in both directions
- Two rotations preserve original aspect ratio

## Localisation

English strings added in `L10n.swift` and the Annotate xcstrings catalog. Other locales will fall back to the English default until translated; `swift tools/localization/CatalogTool.swift verify` passes (`keys=1168 missing=0 extra=0`).

## Known limitations

Per-annotation `rotationDegrees` (text/watermark) is clamped to ±45° in `AnnotationProperties.clampedRotationDegrees`, so adding ±90° cleanly isn't possible. The annotation's bounding box rotates correctly; only the inner-text orientation stays relative to the original canvas. Most users rotate before annotating, so this is acceptable for v1.

## Review process

Pre-flight reviewed with `codex review --base master`, which caught the crop-state bug now fixed in `0cfc418`.