### PR TITLE
fix: don't drop first click on area selection overlay while backdrop is pending

### DIFF
--- a/Snapzy/Services/Capture/AreaSelectionWindow.swift
+++ b/Snapzy/Services/Capture/AreaSelectionWindow.swift
@@ -837,6 +837,25 @@ extension AreaSelectionController: AreaSelectionWindowDelegate {
     requestDisplayActivationIfNeeded(for: window)
   }
 
+  func areaSelectionWindowDidRequestImmediateManualSelection(_ window: AreaSelectionWindow) {
+    guard interactionMode == .manualRegion else { return }
+    guard let displayID = window.displayID else { return }
+    // If the backdrop has already arrived (or live-fallback is already on) the click was
+    // processed normally — no need to enable fallback. Otherwise switch to live capture so
+    // the pending click can be activated without waiting for the lazy snapshot.
+    guard selectionBackdrops[displayID] == nil,
+          !liveFallbackDisplayIDs.contains(displayID) else {
+      return
+    }
+    DiagnosticLogger.shared.log(
+      .info,
+      .capture,
+      "Area selection live fallback enabled by user click",
+      context: ["displayID": "\(displayID)"]
+    )
+    enableLiveFallbackSelection(for: displayID)
+  }
+
   func areaSelectionWindow(_ window: AreaSelectionWindow, manualSelectionBeganAt screenPoint: CGPoint) {
     beginManualSelection(at: screenPoint, from: window)
   }
@@ -859,6 +878,10 @@ protocol AreaSelectionWindowDelegate: AnyObject {
   func areaSelectionWindowDidBecomeActive(_ window: AreaSelectionWindow)
   func areaSelectionWindow(_ window: AreaSelectionWindow, didReceiveKeyEvent event: NSEvent) -> Bool
   func areaSelectionWindowDidRequestDisplayActivation(_ window: AreaSelectionWindow)
+  /// User pressed inside the overlay before the per-display backdrop snapshot arrived. The
+  /// controller should enable live-fallback selection for the window's display so the click
+  /// is not dropped if the user releases before the snapshot completes.
+  func areaSelectionWindowDidRequestImmediateManualSelection(_ window: AreaSelectionWindow)
   func areaSelectionWindow(_ window: AreaSelectionWindow, manualSelectionBeganAt screenPoint: CGPoint)
   func areaSelectionWindow(_ window: AreaSelectionWindow, manualSelectionChangedTo screenPoint: CGPoint)
   func areaSelectionWindow(_ window: AreaSelectionWindow, manualSelectionEndedAt screenPoint: CGPoint)
@@ -972,6 +995,10 @@ extension AreaSelectionWindow: AreaSelectionOverlayViewDelegate {
     selectionDelegate?.areaSelectionWindowDidRequestDisplayActivation(self)
   }
 
+  func overlayViewDidRequestImmediateManualSelection(_ view: AreaSelectionOverlayView) {
+    selectionDelegate?.areaSelectionWindowDidRequestImmediateManualSelection(self)
+  }
+
   func overlayView(_ view: AreaSelectionOverlayView, manualSelectionBeganAt point: CGPoint) {
     selectionDelegate?.areaSelectionWindow(self, manualSelectionBeganAt: convertToScreenPoint(point))
   }
@@ -1012,6 +1039,10 @@ protocol AreaSelectionOverlayViewDelegate: AnyObject {
   func overlayView(_ view: AreaSelectionOverlayView, didSelectWindow target: WindowCaptureTarget)
   func overlayViewDidCancel(_ view: AreaSelectionOverlayView)
   func overlayViewDidRequestDisplayActivation(_ view: AreaSelectionOverlayView)
+  /// Signals that the user pressed inside the overlay before the per-display backdrop snapshot
+  /// was ready. The controller should enable live-fallback selection for the overlay's display
+  /// so the click is not silently dropped.
+  func overlayViewDidRequestImmediateManualSelection(_ view: AreaSelectionOverlayView)
   func overlayView(_ view: AreaSelectionOverlayView, manualSelectionBeganAt point: CGPoint)
   func overlayView(_ view: AreaSelectionOverlayView, manualSelectionChangedTo point: CGPoint)
   func overlayView(_ view: AreaSelectionOverlayView, manualSelectionEndedAt point: CGPoint)
@@ -1760,6 +1791,11 @@ final class AreaSelectionOverlayView: NSView {
     guard selectionEnabled else {
       if interactionMode == .manualRegion {
         pendingSelectionStartPoint = point
+        // Backdrop snapshot is still being prepared for this display. Ask the controller to
+        // enable live-fallback selection so the click isn't silently dropped if the user
+        // releases before the snapshot arrives. The lazy snapshot continues in the background
+        // and will replace the live view via applyBackdrop() once ready.
+        delegate?.overlayViewDidRequestImmediateManualSelection(self)
       }
       return
     }


### PR DESCRIPTION
## Problem

When triggering area selection (multi-display setups, or the slow ScreenCaptureKit prep path), the crosshair overlay sometimes shows up but the first click silently dismisses it instead of starting a drag-to-select. Re-clicking works. The bug is intermittent and very annoying — users perceive it as "the first click dismissed the crosshairs".

## Root cause

`AreaSelectionWindow` shows the crosshair indicator as soon as the overlay window appears, but per-display backdrop snapshots are prepared **lazily**. While a display's backdrop is still being captured, `selectionEnabled(for:)` returns `false` for that display. In that state:

1. `mouseDown` records `pendingSelectionStartPoint` but does **not** start a selection (no `manualSelectionBeganAt` fires, no event monitor is installed). See `AreaSelectionWindow.swift:1756-1773`.
2. If the user releases (or just taps) before the lazy snapshot arrives, `mouseUp` unconditionally clears `pendingSelectionStartPoint` (line 1794-1801) and the click is lost.
3. The next interaction reinitialises the crosshair, so the user sees the visual reset and reads it as a dismiss.

The live-fallback infrastructure (`enableLiveFallbackSelection`) was already in place but only wired to:
- `mouseDragged` after a manual selection was already in progress (`enableLiveSelectionDuringManualDrag`)
- The controller path when the lazy snapshot **fails** (`CaptureViewModel.swift:1039`)

The initial-click path on a not-yet-ready display was never hooked up.

## Fix

`mouseDown` now signals `overlayViewDidRequestImmediateManualSelection` when it stores a pending start point. The controller responds by enabling live-fallback for that display (only when no backdrop is set and fallback isn't already on), which:

- Flips `selectionEnabled` to `true`
- Replays the pending click via the existing `activatePendingSelectionIfNeeded` path
- Installs the local event monitor for `leftMouseDragged` / `leftMouseUp` before `mouseUp` ever fires

The lazy snapshot continues in the background and `applyBackdrop()` swaps the live view for the frozen one when ready — same behaviour as today's drag-mid-snapshot path.

## Files

- `Snapzy/Services/Capture/AreaSelectionWindow.swift` — single file:
  - New overlay delegate method `overlayViewDidRequestImmediateManualSelection`
  - New window delegate method `areaSelectionWindowDidRequestImmediateManualSelection`
  - `mouseDown` raises the new delegate call when storing `pendingSelectionStartPoint`
  - Controller implementation calls `enableLiveFallbackSelection` only when backdrop is missing and fallback isn't already enabled

+36 lines, single file, no other call sites touched.

## Verification

- `xcodebuild -scheme Snapzy build` → ✅ BUILD SUCCEEDED
- `codex review --base master` → ✅ clean — "did not find any discrete correctness, performance, security, or maintainability issues introduced by this diff"

## Notes

The bug was introduced in upstream commit `b847718` (#178, multi-display feature). The fix is fully self-contained — no protocol callers outside this file needed changes, since the new delegate method is only invoked by the overlay view itself.