### PR TITLE
fix: update deprecated stanza in snapzy.rb

### DIFF
--- a/Casks/snapzy.rb
+++ b/Casks/snapzy.rb
@@ -7,7 +7,7 @@ cask "snapzy" do
   desc "Native macOS screenshots, recording, annotation, and editing from the menu bar"
   homepage "https://github.com/duongductrong/Snapzy"
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   app "Snapzy.app"
 


### PR DESCRIPTION
This PR updates the `depends_on macos` stanza to use the new syntax.

Fixes #237.