### PR TITLE
feat: add overlay-free active-window quick capture

### DIFF
--- a/Snapzy/App/AppStatusBarController.swift
+++ b/Snapzy/App/AppStatusBarController.swift
@@ -333,6 +333,18 @@ final class AppStatusBarController: ObservableObject {
     captureFullscreenItem.isEnabled = viewModel.hasPermission
     menu?.addItem(captureFullscreenItem)
 
+    let captureActiveWindowItem = NSMenuItem(
+      title: L10n.Actions.captureActiveWindow,
+      action: #selector(captureActiveWindowAction),
+      keyEquivalent: ""
+    )
+    applyConfiguredShortcut(captureActiveWindowItem, for: .activeWindow, using: shortcutManager)
+    captureActiveWindowItem.target = self
+    captureActiveWindowItem.image = NSImage(
+      systemSymbolName: "macwindow.on.rectangle", accessibilityDescription: nil)
+    captureActiveWindowItem.isEnabled = viewModel.hasPermission
+    menu?.addItem(captureActiveWindowItem)
+
     let scrollingCaptureItem = NSMenuItem(
       title: L10n.Actions.scrollingCapture,
       action: #selector(captureScrollingAction),
@@ -547,6 +559,11 @@ final class AppStatusBarController: ObservableObject {
   @objc private func captureFullscreenAction() {
     logMenuAction("captureFullscreen")
     viewModel?.captureFullscreen()
+  }
+
+  @objc private func captureActiveWindowAction() {
+    logMenuAction("captureActiveWindow")
+    viewModel?.captureActiveWindow()
   }
 
   @objc private func captureScrollingAction() {

--- a/Snapzy/App/SnapzyDeepLinkHandler.swift
+++ b/Snapzy/App/SnapzyDeepLinkHandler.swift
@@ -45,6 +45,8 @@ struct SnapzyDeepLinkHandler {
       screenCaptureViewModel.captureArea()
     case .captureApplication:
       screenCaptureViewModel.captureApplication()
+    case .captureActiveWindow:
+      screenCaptureViewModel.captureActiveWindow()
     case .captureAreaAnnotate:
       screenCaptureViewModel.captureAreaAnnotate()
     case .captureScrolling:
@@ -81,6 +83,7 @@ enum SnapzyDeepLinkAction: Equatable {
   case captureFullscreen
   case captureArea
   case captureApplication
+  case captureActiveWindow
   case captureAreaAnnotate
   case captureScrolling
   case captureOCR
@@ -110,6 +113,9 @@ enum SnapzyDeepLinkAction: Equatable {
       self = .captureArea
     case "capture/application", "capture/window", "application-capture", "window-capture", "screenshot/window":
       self = .captureApplication
+    case "capture/active-window", "capture/focused-window", "active-window-capture",
+      "active-window", "screenshot/active-window":
+      self = .captureActiveWindow
     case "capture/area-annotate", "capture-area-annotate", "area-annotate", "screenshot/area-annotate":
       self = .captureAreaAnnotate
     case "capture/scrolling", "scrolling-capture", "capture-scrolling", "scrolling", "screenshot/scrolling":
@@ -148,6 +154,7 @@ enum SnapzyDeepLinkAction: Equatable {
     case .captureFullscreen: return "captureFullscreen"
     case .captureArea: return "captureArea"
     case .captureApplication: return "captureApplication"
+    case .captureActiveWindow: return "captureActiveWindow"
     case .captureAreaAnnotate: return "captureAreaAnnotate"
     case .captureScrolling: return "captureScrolling"
     case .captureOCR: return "captureOCR"

--- a/Snapzy/Features/Capture/CaptureViewModel.swift
+++ b/Snapzy/Features/Capture/CaptureViewModel.swift
@@ -310,6 +310,8 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
       captureAreaAnnotate()
     case .captureApplication:
       captureApplication()
+    case .captureActiveWindow:
+      captureActiveWindow()
     case .captureScrolling:
       captureScrolling()
     case .captureOCR:
@@ -413,6 +415,59 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
       if !result.savedURLs.isEmpty {
         SoundManager.playScreenshotCapture()
         await postCaptureHandler.handleScreenshotCaptures(urls: result.savedURLs)
+      }
+    }
+  }
+
+  func captureActiveWindow() {
+    Task {
+      guard
+        let resolvedSaveDirectory = fileAccessManager.ensureExportDirectoryForOperation(
+          promptMessage: L10n.Recording.chooseSaveLocationMessage)
+      else {
+        lastCaptureResult = .failure(.saveFailed(L10n.ScreenCapture.saveLocationPermissionRequired))
+        DiagnosticLogger.shared.log(.error, .capture, "Active window capture aborted: no save location")
+        return
+      }
+      saveDirectory = resolvedSaveDirectory
+
+      isCapturing = true
+      DiagnosticLogger.shared.log(.info, .capture, "Active window capture flow started", context: [
+        "format": resolvedFormat.fileExtension,
+      ])
+
+      let prefetchedContentTask = captureManager.prefetchShareableContent(includeDesktopWindows: false)
+      guard let target = await ActiveWindowResolver.resolveActiveWindowTarget(
+        prefetchedContentTask: prefetchedContentTask
+      ) else {
+        isCapturing = false
+        lastCaptureResult = .failure(.captureFailed(L10n.ScreenCapture.failedToCropCapturedImage))
+        DiagnosticLogger.shared.log(.error, .capture, "Active window capture failed: no resolvable window")
+        return
+      }
+
+      let actualSaveDirectory = tempCaptureManager.resolveSaveDirectory(
+        for: .screenshot,
+        exportDirectory: resolvedSaveDirectory
+      )
+
+      let result = await captureManager.captureWindow(
+        target: target,
+        saveDirectory: actualSaveDirectory,
+        format: resolvedFormat,
+        showCursor: showsCursorInScreenshots,
+        excludeDesktopIcons: DesktopIconManager.shared.isIconHidingEnabled,
+        excludeDesktopWidgets: DesktopIconManager.shared.isWidgetHidingEnabled,
+        excludeOwnApplication: false,
+        prefetchedContentTask: prefetchedContentTask
+      )
+
+      isCapturing = false
+      lastCaptureResult = result
+
+      if case .success(let url) = result {
+        SoundManager.playScreenshotCapture()
+        await postCaptureHandler.handleScreenshotCaptures(urls: [url])
       }
     }
   }

--- a/Snapzy/Features/Capture/CaptureViewModel.swift
+++ b/Snapzy/Features/Capture/CaptureViewModel.swift
@@ -465,9 +465,8 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
       isCapturing = false
       lastCaptureResult = result
 
-      if case .success(let url) = result {
+      if case .success = result {
         SoundManager.playScreenshotCapture()
-        await postCaptureHandler.handleScreenshotCaptures(urls: [url])
       }
     }
   }

--- a/Snapzy/Features/Preferences/Components/PreferencesShortcutsSettingsView.swift
+++ b/Snapzy/Features/Preferences/Components/PreferencesShortcutsSettingsView.swift
@@ -13,6 +13,7 @@ struct ShortcutsSettingsView: View {
   @State private var fullscreenShortcut: ShortcutConfig?
   @State private var areaShortcut: ShortcutConfig?
   @State private var areaAnnotateShortcut: ShortcutConfig?
+  @State private var activeWindowShortcut: ShortcutConfig?
   @State private var areaApplicationCaptureShortcut: CaptureOverlayShortcut?
   @State private var recordingApplicationCaptureShortcut: CaptureOverlayShortcut?
   @State private var scrollingCaptureShortcut: ShortcutConfig?
@@ -49,6 +50,7 @@ struct ShortcutsSettingsView: View {
     _fullscreenShortcut = State(initialValue: KeyboardShortcutManager.shared.shortcut(for: .fullscreen))
     _areaShortcut = State(initialValue: KeyboardShortcutManager.shared.shortcut(for: .area))
     _areaAnnotateShortcut = State(initialValue: KeyboardShortcutManager.shared.shortcut(for: .areaAnnotate))
+    _activeWindowShortcut = State(initialValue: KeyboardShortcutManager.shared.shortcut(for: .activeWindow))
     _areaApplicationCaptureShortcut = State(
       initialValue: CaptureOverlayShortcutSettings.applicationCaptureShortcut
     )
@@ -315,6 +317,17 @@ struct ShortcutsSettingsView: View {
           )
 
           ShortcutRecorderView(
+            label: L10n.Actions.captureActiveWindow,
+            icon: "macwindow",
+            description: L10n.PreferencesShortcuts.captureActiveWindowDescription,
+            shortcut: $activeWindowShortcut,
+            defaultShortcut: .defaultActiveWindowCapture,
+            isEnabled: globalEnabledBinding(for: .activeWindow),
+            validationIssue: globalValidationIssues[.activeWindow],
+            onShortcutChanged: { handleGlobalShortcutChange($0, for: .activeWindow) }
+          )
+
+          ShortcutRecorderView(
             label: GlobalShortcutKind.scrollingCapture.displayName,
             icon: "arrow.up.and.down",
             description: "Guided session for long screenshots",
@@ -558,6 +571,7 @@ struct ShortcutsSettingsView: View {
     fullscreenShortcut = .defaultFullscreen
     areaShortcut = .defaultArea
     areaAnnotateShortcut = .defaultAreaAnnotate
+    activeWindowShortcut = .defaultActiveWindowCapture
     areaApplicationCaptureShortcut = CaptureOverlayShortcutSettings.defaultApplicationCaptureShortcut
     recordingApplicationCaptureShortcut =
       CaptureOverlayShortcutSettings.defaultRecordingApplicationCaptureShortcut
@@ -589,6 +603,7 @@ struct ShortcutsSettingsView: View {
     manager.setFullscreenShortcut(.defaultFullscreen)
     manager.setAreaShortcut(.defaultArea)
     manager.setAreaAnnotateShortcut(.defaultAreaAnnotate)
+    manager.setActiveWindowShortcut(.defaultActiveWindowCapture)
     manager.setScrollingCaptureShortcut(.defaultScrollingCapture)
     manager.setObjectCutoutShortcut(.defaultObjectCutout)
     manager.setOCRShortcut(.defaultOCR)
@@ -721,6 +736,9 @@ struct ShortcutsSettingsView: View {
       case .areaAnnotate:
         areaAnnotateShortcut = config
         manager.setAreaAnnotateShortcut(config)
+      case .activeWindow:
+        activeWindowShortcut = config
+        manager.setActiveWindowShortcut(config)
       case .scrollingCapture:
         scrollingCaptureShortcut = config
         manager.setScrollingCaptureShortcut(config)

--- a/Snapzy/Features/Shortcuts/ShortcutOverlayModels.swift
+++ b/Snapzy/Features/Shortcuts/ShortcutOverlayModels.swift
@@ -135,6 +135,7 @@ enum ShortcutOverlayContentBuilder {
         display: areaConfig.map { .keycaps($0.displayParts) } ?? .text(L10n.Common.none)
       ),
       globalItem(kind: .areaAnnotate, icon: "pencil.and.scribble", manager: manager),
+      globalItem(kind: .activeWindow, icon: "macwindow", manager: manager),
       globalItem(kind: .scrollingCapture, icon: "arrow.up.and.down", manager: manager),
     ]
 

--- a/Snapzy/Resources/Localization/Features/Shortcuts.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Shortcuts.xcstrings
@@ -521,6 +521,71 @@
         }
       }
     },
+    "preferences-shortcuts.capture-active-window-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erfasst das fokussierte Fenster sofort, ohne Auswahlschritt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instantly captures the focused window, no selection step"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Captura al instante la ventana activa, sin paso de selección"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture instantanément la fenêtre active, sans étape de sélection"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択操作なしでフォーカスされたウィンドウを即座にキャプチャします"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택 단계 없이 포커스된 창을 즉시 캡처합니다"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Мгновенно захватывает активное окно без шага выбора"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chụp ngay cửa sổ đang được focus, không cần bước chọn"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "立即捕获当前聚焦的窗口，无需选择步骤"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "立即擷取目前聚焦的視窗，無需選取步驟"
+          }
+        }
+      }
+    },
     "preferences-shortcuts.capture-area-annotate-description": {
       "extractionState": "stale",
       "localizations": {

--- a/Snapzy/Resources/Localization/Shared/Common.xcstrings
+++ b/Snapzy/Resources/Localization/Shared/Common.xcstrings
@@ -196,6 +196,71 @@
         }
       }
     },
+    "action.capture-active-window" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktives Fenster erfassen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capture Active Window"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capturar ventana activa"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capturer la fenêtre active"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アクティブウィンドウをキャプチャ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "활성 창 캡처"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Захват активного окна"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chụp cửa sổ đang hoạt động"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "捕获活动窗口"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "擷取使用中的視窗"
+          }
+        }
+      }
+    },
     "action.capture-subject" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Snapzy/Services/Capture/ActiveWindowResolver.swift
+++ b/Snapzy/Services/Capture/ActiveWindowResolver.swift
@@ -1,0 +1,118 @@
+//
+//  ActiveWindowResolver.swift
+//  Snapzy
+//
+//  Resolves the currently focused window for one-shot active-window capture.
+//
+
+import AppKit
+import ApplicationServices
+import Foundation
+
+@MainActor
+enum ActiveWindowResolver {
+  /// Resolves the window that should be captured for the "capture active window" action.
+  /// Intentionally never excludes Snapzy's own windows: if a Snapzy window is focused,
+  /// capturing it is the whole point of triggering this action on it.
+  static func resolveActiveWindowTarget(
+    prefetchedContentTask: ShareableContentPrefetchTask? = nil
+  ) async -> WindowCaptureTarget? {
+    guard
+      let snapshot = await WindowSelectionQueryService.prepareSnapshot(
+        prefetchedContentTask: prefetchedContentTask,
+        excludeOwnApplication: false
+      )
+    else {
+      return nil
+    }
+
+    if let focusedTarget = focusedWindowTarget(in: snapshot) {
+      return focusedTarget
+    }
+
+    return snapshot.orderedCandidates.first?.target
+  }
+
+  private static func focusedWindowTarget(
+    in snapshot: WindowSelectionSnapshot
+  ) -> WindowCaptureTarget? {
+    guard AXIsProcessTrusted() else { return nil }
+    guard let frontmostApplication = NSWorkspace.shared.frontmostApplication else { return nil }
+    guard let focusedFrame = focusedWindowFrame(forProcessIdentifier: frontmostApplication.processIdentifier) else {
+      return nil
+    }
+
+    let bundleIdentifier = frontmostApplication.bundleIdentifier
+    let sameAppCandidates = snapshot.orderedCandidates.filter { $0.target.bundleIdentifier == bundleIdentifier }
+    guard !sameAppCandidates.isEmpty else { return nil }
+
+    return sameAppCandidates.min {
+      frameDistance($0.target.frame, focusedFrame) < frameDistance($1.target.frame, focusedFrame)
+    }?.target
+  }
+
+  private static func focusedWindowFrame(forProcessIdentifier pid: pid_t) -> CGRect? {
+    let appElement = AXUIElementCreateApplication(pid)
+
+    var focusedWindowRef: CFTypeRef?
+    let focusedWindowResult = AXUIElementCopyAttributeValue(
+      appElement,
+      kAXFocusedWindowAttribute as CFString,
+      &focusedWindowRef
+    )
+    guard
+      focusedWindowResult == .success,
+      let focusedWindowRef,
+      CFGetTypeID(focusedWindowRef) == AXUIElementGetTypeID()
+    else { return nil }
+    let focusedWindow = focusedWindowRef as! AXUIElement
+
+    guard
+      let position = axValue(of: focusedWindow, attribute: kAXPositionAttribute, type: .cgPoint, as: CGPoint.self),
+      let size = axValue(of: focusedWindow, attribute: kAXSizeAttribute, type: .cgSize, as: CGSize.self)
+    else {
+      return nil
+    }
+
+    // AX position/size are reported in top-left-origin global screen coordinates,
+    // matching CGWindowList's coordinate space. Convert to AppKit's bottom-left origin
+    // the same way WindowSelectionQueryService does, so frames compare directly.
+    let quartzFrame = CGRect(origin: position, size: size)
+    let mainScreenHeight = NSScreen.screens.first(where: { $0.displayID == CGMainDisplayID() })?.frame.height
+      ?? CGDisplayBounds(CGMainDisplayID()).height
+
+    return CGRect(
+      x: quartzFrame.origin.x,
+      y: mainScreenHeight - quartzFrame.maxY,
+      width: quartzFrame.width,
+      height: quartzFrame.height
+    ).integral
+  }
+
+  private static func axValue<T>(
+    of element: AXUIElement,
+    attribute: String,
+    type: AXValueType,
+    as valueType: T.Type
+  ) -> T? {
+    var rawValue: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, attribute as CFString, &rawValue) == .success,
+      let rawValue,
+      CFGetTypeID(rawValue) == AXValueGetTypeID()
+    else {
+      return nil
+    }
+    let axValue = rawValue as! AXValue
+    guard AXValueGetType(axValue) == type else { return nil }
+
+    var value = T.self == CGPoint.self ? CGPoint.zero as! T : CGSize.zero as! T
+    guard AXValueGetValue(axValue, type, &value) else { return nil }
+    return value
+  }
+
+  private static func frameDistance(_ lhs: CGRect, _ rhs: CGRect) -> CGFloat {
+    let dx = lhs.midX - rhs.midX
+    let dy = lhs.midY - rhs.midY
+    return (dx * dx + dy * dy).squareRoot() + abs(lhs.width - rhs.width) + abs(lhs.height - rhs.height)
+  }
+}

--- a/Snapzy/Services/Configuration/SnapzyConfigurationDefaultDocument.swift
+++ b/Snapzy/Services/Configuration/SnapzyConfigurationDefaultDocument.swift
@@ -235,6 +235,7 @@ enum SnapzyConfigurationDefaultDocument {
     case .fullscreen: return .defaultFullscreen
     case .area: return .defaultArea
     case .areaAnnotate: return .defaultAreaAnnotate
+    case .activeWindow: return .defaultActiveWindowCapture
     case .scrollingCapture: return .defaultScrollingCapture
     case .recording: return .defaultRecording
     case .annotate: return .defaultAnnotate

--- a/Snapzy/Services/Configuration/SnapzyConfigurationShortcutsExporter.swift
+++ b/Snapzy/Services/Configuration/SnapzyConfigurationShortcutsExporter.swift
@@ -116,6 +116,7 @@ extension GlobalShortcutKind {
     case .fullscreen: return "fullscreen"
     case .area: return "area"
     case .areaAnnotate: return "area_annotate"
+    case .activeWindow: return "active_window"
     case .scrollingCapture: return "scrolling_capture"
     case .recording: return "recording"
     case .annotate: return "annotate"

--- a/Snapzy/Services/Configuration/SnapzyConfigurationShortcutsImporter.swift
+++ b/Snapzy/Services/Configuration/SnapzyConfigurationShortcutsImporter.swift
@@ -273,6 +273,8 @@ private extension KeyboardShortcutManager {
       setAreaShortcut(config)
     case .areaAnnotate:
       setAreaAnnotateShortcut(config)
+    case .activeWindow:
+      setActiveWindowShortcut(config)
     case .scrollingCapture:
       setScrollingCaptureShortcut(config)
     case .recording:

--- a/Snapzy/Services/Shortcuts/KeyboardShortcutManager.swift
+++ b/Snapzy/Services/Shortcuts/KeyboardShortcutManager.swift
@@ -61,6 +61,12 @@ struct ShortcutConfig: Equatable, Codable {
     modifiers: UInt32(cmdKey | shiftKey)
   )
 
+  /// Cmd + Shift + 9
+  static let defaultActiveWindowCapture = ShortcutConfig(
+    keyCode: UInt32(kVK_ANSI_9),
+    modifiers: UInt32(cmdKey | shiftKey)
+  )
+
   /// Cmd + Shift + A
   static let defaultAnnotate = ShortcutConfig(
     keyCode: UInt32(kVK_ANSI_A),
@@ -396,6 +402,7 @@ enum GlobalShortcutKind: String, CaseIterable, Codable {
   case fullscreen
   case area
   case areaAnnotate
+  case activeWindow
   case scrollingCapture
   case recording
   case annotate
@@ -425,6 +432,8 @@ extension GlobalShortcutKind {
       return L10n.Actions.captureArea
     case .areaAnnotate:
       return L10n.Actions.captureAreaAnnotate
+    case .activeWindow:
+      return L10n.Actions.captureActiveWindow
     case .scrollingCapture:
       return L10n.Actions.scrollingCapture
     case .recording:
@@ -453,6 +462,7 @@ enum ShortcutAction {
   case captureArea
   case captureAreaAnnotate
   case captureApplication
+  case captureActiveWindow
   case captureScrolling
   case captureOCR
   case captureObjectCutout
@@ -490,6 +500,7 @@ final class KeyboardShortcutManager {
   private(set) var ocrShortcut: ShortcutConfig
   private(set) var objectCutoutShortcut: ShortcutConfig
   private(set) var historyShortcut: ShortcutConfig
+  private(set) var activeWindowShortcut: ShortcutConfig
   private(set) var isEnabled: Bool = false
   private var disabledShortcuts: Set<GlobalShortcutKind> = []
   private var clearedShortcuts: Set<GlobalShortcutKind> = []
@@ -509,6 +520,7 @@ final class KeyboardShortcutManager {
   private var ocrHotkeyRef: EventHotKeyRef?
   private var objectCutoutHotkeyRef: EventHotKeyRef?
   private var historyHotkeyRef: EventHotKeyRef?
+  private var activeWindowHotkeyRef: EventHotKeyRef?
 
   // Hotkey IDs
   private let fullscreenHotkeyID = EventHotKeyID(signature: OSType(0x5A53_4631), id: 1)  // "ZSF1"
@@ -525,6 +537,7 @@ final class KeyboardShortcutManager {
   private let applicationCaptureHotkeyID = EventHotKeyID(signature: OSType(0x5A53_4643), id: 12)  // "ZSFC"
   private let applicationRecordingHotkeyID = EventHotKeyID(signature: OSType(0x5A53_4644), id: 13)  // "ZSFD"
   private let areaAnnotateHotkeyID = EventHotKeyID(signature: OSType(0x5A53_4645), id: 14)  // "ZSFE"
+  private let activeWindowHotkeyID = EventHotKeyID(signature: OSType(0x5A53_4646), id: 15)  // "ZSFF"
 
   private var eventHandler: EventHandlerRef?
 
@@ -541,6 +554,7 @@ final class KeyboardShortcutManager {
   private let ocrShortcutKey = "ocrShortcut"
   private let objectCutoutShortcutKey = "objectCutoutShortcut"
   private let historyShortcutKey = "historyShortcut"
+  private let activeWindowShortcutKey = "activeWindowShortcut"
   private let shortcutsEnabledKey = "shortcutsEnabled"
   private let disabledShortcutsKey = PreferencesKeys.disabledGlobalShortcuts
   private let clearedShortcutsKey = PreferencesKeys.clearedGlobalShortcuts
@@ -558,6 +572,7 @@ final class KeyboardShortcutManager {
     ocrShortcut = .defaultOCR
     objectCutoutShortcut = .defaultObjectCutout
     historyShortcut = .defaultHistory
+    activeWindowShortcut = .defaultActiveWindowCapture
     loadShortcuts()
     loadDisabledShortcuts()
     loadClearedShortcuts()
@@ -623,6 +638,7 @@ final class KeyboardShortcutManager {
     case .fullscreen: return fullscreenShortcut
     case .area: return areaShortcut
     case .areaAnnotate: return areaAnnotateShortcut
+    case .activeWindow: return activeWindowShortcut
     case .scrollingCapture: return scrollingCaptureShortcut
     case .recording: return recordingShortcut
     case .annotate: return annotateShortcut
@@ -678,6 +694,17 @@ final class KeyboardShortcutManager {
     mutateShortcutRegistration {
       setShortcut(config, for: .areaAnnotate) {
         areaAnnotateShortcut = $0
+      }
+      saveShortcuts()
+      saveClearedShortcuts()
+    }
+  }
+
+  /// Update active window capture shortcut
+  func setActiveWindowShortcut(_ config: ShortcutConfig?) {
+    mutateShortcutRegistration {
+      setShortcut(config, for: .activeWindow) {
+        activeWindowShortcut = $0
       }
       saveShortcuts()
       saveClearedShortcuts()
@@ -833,6 +860,9 @@ final class KeyboardShortcutManager {
     if let objectCutoutData = try? encoder.encode(objectCutoutShortcut) {
       UserDefaults.standard.set(objectCutoutData, forKey: objectCutoutShortcutKey)
     }
+    if let activeWindowData = try? encoder.encode(activeWindowShortcut) {
+      UserDefaults.standard.set(activeWindowData, forKey: activeWindowShortcutKey)
+    }
     if let historyData = try? encoder.encode(historyShortcut) {
       UserDefaults.standard.set(historyData, forKey: historyShortcutKey)
     }
@@ -899,6 +929,11 @@ final class KeyboardShortcutManager {
       let config = try? decoder.decode(ShortcutConfig.self, from: historyData)
     {
       historyShortcut = config
+    }
+    if let activeWindowData = UserDefaults.standard.data(forKey: activeWindowShortcutKey),
+      let config = try? decoder.decode(ShortcutConfig.self, from: activeWindowData)
+    {
+      activeWindowShortcut = config
     }
   }
 
@@ -987,6 +1022,9 @@ final class KeyboardShortcutManager {
     case areaAnnotateHotkeyID.id:
       actionName = "area-annotate"
       action = .captureAreaAnnotate
+    case activeWindowHotkeyID.id:
+      actionName = "active-window"
+      action = .captureActiveWindow
     case applicationCaptureHotkeyID.id:
       actionName = "application-capture"
       action = .captureApplication
@@ -1054,6 +1092,12 @@ final class KeyboardShortcutManager {
       config: shortcut(for: .areaAnnotate),
       hotkeyID: areaAnnotateHotkeyID,
       ref: &areaAnnotateHotkeyRef
+    )
+    registerShortcutIfNeeded(
+      kind: .activeWindow,
+      config: shortcut(for: .activeWindow),
+      hotkeyID: activeWindowHotkeyID,
+      ref: &activeWindowHotkeyRef
     )
     registerShortcutIfNeeded(
       kind: .scrollingCapture,
@@ -1196,6 +1240,10 @@ final class KeyboardShortcutManager {
     if let ref = areaAnnotateHotkeyRef {
       UnregisterEventHotKey(ref)
       areaAnnotateHotkeyRef = nil
+    }
+    if let ref = activeWindowHotkeyRef {
+      UnregisterEventHotKey(ref)
+      activeWindowHotkeyRef = nil
     }
     if let ref = scrollingCaptureHotkeyRef {
       UnregisterEventHotKey(ref)

--- a/Snapzy/Shared/Localization/L10n.swift
+++ b/Snapzy/Shared/Localization/L10n.swift
@@ -582,6 +582,11 @@ enum L10n {
       defaultValue: "Capture Fullscreen",
       comment: "Action title for fullscreen screenshot capture"
     )
+    static let captureActiveWindow = string(
+      "action.capture-active-window",
+      defaultValue: "Capture Active Window",
+      comment: "Action title for instant active-window screenshot capture"
+    )
     static let scrollingCapture = string(
       "action.scrolling-capture",
       defaultValue: "Scrolling Capture",
@@ -2861,6 +2866,11 @@ enum L10n {
       "preferences-shortcuts.capture-area-annotate-description",
       defaultValue: "Select a region, annotate in place, then finish with ⌘S or Enter",
       comment: "Description for inline area annotate capture shortcut"
+    )
+    static let captureActiveWindowDescription = string(
+      "preferences-shortcuts.capture-active-window-description",
+      defaultValue: "Instantly captures the focused window, no selection step",
+      comment: "Description for instant active-window capture shortcut"
     )
     static let applicationCaptureTitle = string(
       "preferences-shortcuts.application-capture-title",


### PR DESCRIPTION
Closes #254

## Summary

Adds an instant, overlay-free screenshot of the currently focused window — same "no selection step" UX as Fullscreen (`⌘⇧3`), just scoped to one window.

- New configurable global shortcut, default `⌘⇧9` (`GlobalShortcutKind.activeWindow`)
- New status-bar menu item, "Capture Active Window"
- New `snapzy://capture/active-window` deep link
- New `ActiveWindowResolver`: resolves the frontmost app's focused window via `kAXFocusedWindowAttribute`, matches it against the existing `WindowSelectionQueryService.prepareSnapshot()` candidate list (same z-order snapshot the application-window overlay mode already builds) by bundle identifier + closest frame, then falls back to the topmost on-screen candidate when Accessibility is untrusted or AX resolution fails
- Captures through the existing `ScreenCaptureManager.captureWindow()` — no new capture/overlay UI
- Preferences → Shortcuts row, shortcut cheat-sheet overlay entry, and `shortcuts.global.active_window` TOML export/import support, mirroring the existing global shortcuts

**Deliberate behavior difference from every other capture path:** this action does not apply "exclude own application." If a Snapzy window (e.g. Preferences) is the one focused, capturing it is the point of triggering the action on it.

## Test plan

Manually tested end-to-end on macOS 26 (no Xcode available in this environment, so verified via a CI-built signed artifact rather than a local Xcode build; `tools/localization/CatalogTool.swift verify` passes with `missing=0 extra=0`):

- [x] Hotkey, status-bar menu item, and `open "snapzy://capture/active-window"` all trigger an identical single capture (confirmed via diagnostic logs — exactly one `executeActions`/Quick Access card per trigger, no duplication)
- [x] Cold launch via deep link (app not running) — single capture, no duplication
- [x] Own-window capture: focusing a Snapzy window and triggering captures that window, unlike Fullscreen/Area
- [x] Multi-window same app: focusing a non-topmost window of an app with multiple windows captures the *focused* one, not just the frontmost by z-order
- [x] Accessibility-untrusted fallback: with Accessibility access revoked, capture still succeeds via the CGWindowList-based topmost-window fallback, no crash
- [x] Preferences → Shortcuts: reconfigure the shortcut, conflict validation, reset to default
- [x] TOML export/import round-trip for `shortcuts.global.active_window`
- [x] Shortcut cheat-sheet overlay shows the action with its current binding

### Known follow-ups found during testing (not fixed in this PR, pre-existing and out of scope)

- TOML Import does not refresh already-open Preferences → Shortcuts `@State` for *any* global shortcut (not specific to this one) until the Settings window is reopened/app relaunched.
- TOML Import runs synchronously on the main thread and can visibly stall the UI for a moment on import, independent of this change.

Happy to file those separately if useful.