### PR TITLE
Fix Quick Access dismiss lag by deferring cleanup

### DIFF
--- a/Snapzy/Features/QuickAccess/Components/QuickAccessCardView.swift
+++ b/Snapzy/Features/QuickAccess/Components/QuickAccessCardView.swift
@@ -383,7 +383,10 @@ struct QuickAccessCardView: View {
   }
 
   private func openAnnotation() {
-    AnnotateManager.shared.openAnnotation(for: item)
+    Task { @MainActor in
+      await Task.yield()
+      AnnotateManager.shared.openAnnotation(for: item)
+    }
   }
 
   private func openVideoEditor() {

--- a/Snapzy/Features/QuickAccess/QuickAccessManager.swift
+++ b/Snapzy/Features/QuickAccess/QuickAccessManager.swift
@@ -416,11 +416,50 @@ final class QuickAccessManager: ObservableObject {
       return
     }
 
-    // Auto-delete temp files on dismiss (unsaved captures)
-    // Skip deletion if history is enabled and the file has a history record —
-    // the retention service will clean it up when the record ages out.
-    if tempCaptureManager.isTempFile(item.url) {
-      let url = item.url
+    let url = item.url
+    let isTempFile = tempCaptureManager.isTempFile(url)
+
+    cancelDismissTimer(for: id)
+    pinWindowManager.close(id: id)
+    editingItemIds.remove(id)
+    activityHoldItemIds.remove(id)
+    // Clear annotation session cache for this item
+    AnnotateManager.shared.clearSessionData(for: id)
+    // Fast animation (0.15s) for immediate perceived response
+    withAnimation(.spring(response: 0.15, dampingFraction: 0.8)) {
+      items.removeAll { $0.id == id }
+    }
+
+    if items.isEmpty {
+      panelController.hide()
+    }
+
+    scheduleDismissCleanup(for: url, isTempFile: isTempFile)
+  }
+
+  /// Remove a screenshot from the stack (backward compatible alias)
+  func removeScreenshot(id: UUID) {
+    removeItem(id: id)
+  }
+
+  private func scheduleDismissCleanup(for url: URL, isTempFile: Bool) {
+    guard isTempFile else {
+      DiagnosticLogger.shared.log(
+        .info,
+        .action,
+        "Quick access item dismissed; saved file retained",
+        context: ["fileName": url.lastPathComponent]
+      )
+      return
+    }
+
+    // Let SwiftUI commit the card removal before checking history or touching disk.
+    Task { @MainActor in
+      await Task.yield()
+
+      // Auto-delete temp files on dismiss (unsaved captures).
+      // Skip deletion if history is enabled and the file has a history record —
+      // the retention service will clean it up when the record ages out.
       let historyEnabled = UserDefaults.standard.bool(forKey: PreferencesKeys.historyEnabled)
       let hasHistoryRecord = historyEnabled && CaptureHistoryStore.shared.hasRecord(forFilePath: url.path)
 
@@ -439,38 +478,9 @@ final class QuickAccessManager: ObservableObject {
           context: ["fileName": url.lastPathComponent]
         )
         AnnotationSessionStore.shared.deleteSession(for: url)
-        Task { @MainActor in
-          tempCaptureManager.deleteTempFile(at: url)
-        }
+        tempCaptureManager.deleteTempFile(at: url)
       }
-    } else {
-      DiagnosticLogger.shared.log(
-        .info,
-        .action,
-        "Quick access item dismissed; saved file retained",
-        context: ["fileName": item.url.lastPathComponent]
-      )
     }
-
-    cancelDismissTimer(for: id)
-    pinWindowManager.close(id: id)
-    editingItemIds.remove(id)
-    activityHoldItemIds.remove(id)
-    // Clear annotation session cache for this item
-    AnnotateManager.shared.clearSessionData(for: id)
-    // Fast animation (0.15s) for immediate perceived response
-    withAnimation(.spring(response: 0.15, dampingFraction: 0.8)) {
-      items.removeAll { $0.id == id }
-    }
-
-    if items.isEmpty {
-      panelController.hide()
-    }
-  }
-
-  /// Remove a screenshot from the stack (backward compatible alias)
-  func removeScreenshot(id: UUID) {
-    removeItem(id: id)
   }
 
   /// Remove card from UI only — does NOT delete the underlying file.

--- a/SnapzyTests/Features/QuickAccess/QuickAccessHistoryCleanupTests.swift
+++ b/SnapzyTests/Features/QuickAccess/QuickAccessHistoryCleanupTests.swift
@@ -45,6 +45,20 @@ final class QuickAccessHistoryCleanupTests: XCTestCase {
     return fileURL
   }
 
+  private func waitUntil(
+    timeout: TimeInterval = 1.0,
+    condition: @escaping @MainActor () -> Bool
+  ) async -> Bool {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+      if condition() {
+        return true
+      }
+      try? await Task.sleep(nanoseconds: 20_000_000)
+    }
+    return condition()
+  }
+
   // MARK: - Tests
 
   func testDeleteItem_removesHistoryRecordForTempFile() async throws {
@@ -89,6 +103,31 @@ final class QuickAccessHistoryCleanupTests: XCTestCase {
       CaptureHistoryStore.shared.hasRecord(forFilePath: fileURL.path),
       "History record should be preserved after auto-dismiss path"
     )
+  }
+
+  func testRemoveItem_removesCardBeforeDeferredTempCleanup() async throws {
+    let fileURL = try createTestFile(in: TempCaptureManager.shared.tempCaptureDirectory)
+
+    await QuickAccessManager.shared.addScreenshot(url: fileURL)
+    let item = try XCTUnwrap(
+      QuickAccessManager.shared.items.first { $0.url == fileURL },
+      "Quick Access item should have been added"
+    )
+
+    QuickAccessManager.shared.removeItem(id: item.id)
+
+    XCTAssertFalse(
+      QuickAccessManager.shared.items.contains { $0.id == item.id },
+      "Quick Access card should be removed synchronously before cleanup runs"
+    )
+    XCTAssertTrue(
+      FileManager.default.fileExists(atPath: fileURL.path),
+      "Temp file should still exist until deferred cleanup gets a chance to run"
+    )
+    let didDeleteTempFile = await waitUntil {
+      !FileManager.default.fileExists(atPath: fileURL.path)
+    }
+    XCTAssertTrue(didDeleteTempFile, "Deferred cleanup should delete unpreserved temp files")
   }
 
   func testDeleteItem_removesHistoryRecordForSavedFile() async throws {


### PR DESCRIPTION
## Summary
- Remove Quick Access cards from UI before temp/history/session cleanup runs.
- Defer dismiss cleanup until after SwiftUI can commit the removal animation.
- Yield before opening annotation from the edit action so the button response is not blocked in the same call stack.
- Add coverage that temp-file cleanup happens after synchronous card removal.

Fixes #219.

## Verification
- `xcodebuild -project Snapzy.xcodeproj -scheme Snapzy -configuration Debug -destination 'platform=macOS' -derivedDataPath build/DerivedData -clonedSourcePackagesDirPath build/SourcePackages CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO build`\n- `git diff --check`\n\nNote: I also attempted `./scripts/run-tests.sh -only-testing:SnapzyTests/QuickAccessHistoryCleanupTests`; it built and linked, then the app-hosted XCTest run hung after launching `Snapzy Debug.app`. No leftover app/test/build processes remained after cleanup.