### PR TITLE
fix: normalize export_location to ~/ relative path on export

### DIFF
--- a/Snapzy/Services/Configuration/SnapzyConfigurationExporter.swift
+++ b/Snapzy/Services/Configuration/SnapzyConfigurationExporter.swift
@@ -34,7 +34,7 @@ enum SnapzyConfigurationExporter {
     writer.value("appearance", appearance(defaults: defaults))
     writer.value("play_sounds", defaults.object(forKey: PreferencesKeys.playSounds) as? Bool ?? true)
     writer.value("start_at_login", LoginItemManager.isEnabled)
-    writer.value("export_location", SandboxFileAccessManager.shared.exportLocationPath)
+    writer.value("export_location", SnapzyConfigurationPaths.collapsingHomePath(SandboxFileAccessManager.shared.exportLocationPath))
 
     writer.section("updates")
     let updater = UpdaterManager.shared.updater

--- a/Snapzy/Services/Configuration/SnapzyConfigurationPaths.swift
+++ b/Snapzy/Services/Configuration/SnapzyConfigurationPaths.swift
@@ -44,6 +44,21 @@ nonisolated enum SnapzyConfigurationPaths {
       .appendingPathComponent("snapzy", isDirectory: true)
   }
 
+  static func collapsingHomePath(_ path: String) -> String {
+    collapsingHomePath(path, homeDirectory: userHomeDirectory)
+  }
+
+  static func collapsingHomePath(_ path: String, homeDirectory: URL) -> String {
+    let home = homeDirectory.path
+    if path == home {
+      return "~"
+    }
+    if path.hasPrefix(home + "/") {
+      return "~/" + String(path.dropFirst(home.count + 1))
+    }
+    return path
+  }
+
   static func expandedUserPath(_ path: String, homeDirectory: URL) -> String {
     guard path.hasPrefix("~/") else { return path }
     return homeDirectory

--- a/SnapzyTests/Services/Configuration/SnapzyConfigurationPathsTests.swift
+++ b/SnapzyTests/Services/Configuration/SnapzyConfigurationPathsTests.swift
@@ -27,6 +27,23 @@ final class SnapzyConfigurationPathsTests: XCTestCase {
     XCTAssertEqual(url.path, "/Users/example/.config/snapzy")
   }
 
+  func testCollapsingHomePathConvertsAbsolutePathToTilde() {
+    let home = URL(fileURLWithPath: "/Users/example", isDirectory: true)
+
+    XCTAssertEqual(
+      SnapzyConfigurationPaths.collapsingHomePath("/Users/example/Desktop", homeDirectory: home),
+      "~/Desktop"
+    )
+    XCTAssertEqual(
+      SnapzyConfigurationPaths.collapsingHomePath("/Users/example", homeDirectory: home),
+      "~"
+    )
+    XCTAssertEqual(
+      SnapzyConfigurationPaths.collapsingHomePath("/tmp/snapzy", homeDirectory: home),
+      "/tmp/snapzy"
+    )
+  }
+
   func testExpandedUserPathUsesProvidedHomeDirectory() {
     let home = URL(fileURLWithPath: "/Users/example", isDirectory: true)
 


### PR DESCRIPTION
## Problem

The exported `config.toml` always wrote `export_location` as an absolute path (e.g. `/Users/stone/Desktop`). This makes the config file machine-specific and harder to read or share across accounts.

## Solution

Collapse the home directory prefix to `~/` when writing `export_location` during export, so the field always reads like `~/Desktop` regardless of the actual username.

### Changes

- **`SnapzyConfigurationPaths`** — add `collapsingHomePath(_:)` and `collapsingHomePath(_:homeDirectory:)` as the inverse of the existing `expandedUserPath` helpers.
- **`SnapzyConfigurationExporter`** — apply `collapsingHomePath` when writing the `export_location` field.
- **`SnapzyConfigurationPathsTests`** — add `testCollapsingHomePathConvertsAbsolutePathToTilde` covering subdirectory, exact home root, and out-of-home cases.

## Compatibility

The import side already expands `~/` via `expandedUserPath`, so the roundtrip (export → import → export) is stable. Users with existing config files that contain absolute paths will have the field silently upgraded to the `~/` format on the next automatic sync (same behaviour as any other settings change that results in a clean overwrite).