### PR TITLE
[OLD] Add space-to-move for area capture selection

### DIFF
--- a/Snapzy/Services/Capture/AreaSelectionWindow.swift
+++ b/Snapzy/Services/Capture/AreaSelectionWindow.swift
@@ -88,6 +88,10 @@ final class AreaSelectionController: NSObject {
   /// app activates, so the local monitor never sees them and the selection silently resets.
   /// A global monitor still receives those events, ensuring the first gesture commits.
   private var manualSelectionGlobalMonitor: Any?
+  private var manualSelectionKeyLocalMonitor: Any?
+  private var manualSelectionKeyGlobalMonitor: Any?
+  private var isMovingManualSelection = false
+  private var manualSelectionLastPointerLocation: CGPoint?
   private var previouslyActiveApplication: NSRunningApplication?
 
   /// Whether the overlay should be dismissed immediately after a selection is made.
@@ -702,6 +706,8 @@ final class AreaSelectionController: NSObject {
     manualSelectionCurrentPoint = screenPoint
     manualSelectionSourceWindow = window
     activeWindow = window
+    isMovingManualSelection = false
+    manualSelectionLastPointerLocation = screenPoint
     installManualSelectionMonitorIfNeeded()
     requestDisplayActivationForManualSelection()
     renderManualSelectionIfNeeded()
@@ -709,10 +715,41 @@ final class AreaSelectionController: NSObject {
 
   private func updateManualSelection(to screenPoint: CGPoint) {
     guard manualSelectionStartPoint != nil else { return }
-    guard screenPoint != manualSelectionCurrentPoint else { return }
-    manualSelectionCurrentPoint = screenPoint
+    defer { manualSelectionLastPointerLocation = screenPoint }
+
+    if isMovingManualSelection {
+      guard let last = manualSelectionLastPointerLocation else { return }
+      let dx = screenPoint.x - last.x
+      let dy = screenPoint.y - last.y
+      guard dx != 0 || dy != 0 else { return }
+      manualSelectionStartPoint?.x += dx
+      manualSelectionStartPoint?.y += dy
+      manualSelectionCurrentPoint?.x += dx
+      manualSelectionCurrentPoint?.y += dy
+    } else {
+      guard screenPoint != manualSelectionCurrentPoint else { return }
+      manualSelectionCurrentPoint = screenPoint
+    }
+
     requestDisplayActivationForManualSelection()
     renderManualSelectionIfNeeded()
+  }
+
+  private func handleManualSelectionSpaceEvent(_ event: NSEvent) -> Bool {
+    guard event.keyCode == 49 else { return false }
+    guard manualSelectionStartPoint != nil else { return false }
+    switch event.type {
+    case .keyDown:
+      if !isMovingManualSelection {
+        manualSelectionLastPointerLocation = NSEvent.mouseLocation
+        isMovingManualSelection = true
+      }
+    case .keyUp:
+      isMovingManualSelection = false
+    default:
+      return false
+    }
+    return true
   }
 
   private func endManualSelection(at screenPoint: CGPoint) {
@@ -776,6 +813,27 @@ final class AreaSelectionController: NSObject {
       }
     }
 
+    if manualSelectionKeyLocalMonitor == nil {
+      manualSelectionKeyLocalMonitor = NSEvent.addLocalMonitorForEvents(
+        matching: [.keyDown, .keyUp]
+      ) { [weak self] event in
+        var handled = false
+        MainActor.assumeIsolated {
+          handled = self?.handleManualSelectionSpaceEvent(event) ?? false
+        }
+        return handled ? nil : event
+      }
+    }
+    if manualSelectionKeyGlobalMonitor == nil {
+      manualSelectionKeyGlobalMonitor = NSEvent.addGlobalMonitorForEvents(
+        matching: [.keyDown, .keyUp]
+      ) { [weak self] event in
+        MainActor.assumeIsolated {
+          _ = self?.handleManualSelectionSpaceEvent(event)
+        }
+      }
+    }
+
     // Global monitor receives drag/up even while Snapzy is inactive (the first ⌘⇧4 gesture on a
     // nonactivating overlay). The handlers are idempotent — `updateManualSelection` just records
     // the current point and `endManualSelection` early-returns once the selection is torn down —
@@ -807,6 +865,16 @@ final class AreaSelectionController: NSObject {
       NSEvent.removeMonitor(monitor)
       manualSelectionGlobalMonitor = nil
     }
+    if let monitor = manualSelectionKeyLocalMonitor {
+      NSEvent.removeMonitor(monitor)
+      manualSelectionKeyLocalMonitor = nil
+    }
+    if let monitor = manualSelectionKeyGlobalMonitor {
+      NSEvent.removeMonitor(monitor)
+      manualSelectionKeyGlobalMonitor = nil
+    }
+    isMovingManualSelection = false
+    manualSelectionLastPointerLocation = nil
   }
 
   private func clearManualSelectionTracking(render: Bool) {


### PR DESCRIPTION
Hey! 👋

I use Snapzy all day for screenshots, and the one thing I kept reaching for out of habit was being able to hold space to reposition the selection while I'm dragging it out, the way the built-in macOS screenshot tool (⌘⇧4) works. Snapzy didn't have it, so I added it.

While you're dragging out a capture region, hold `Space` and the whole selection box moves with your cursor (same size, just repositioned). Let go of space and you're back to resizing from wherever it ended up. It's that small thing where you start the drag, realize the corner's slightly off, and now you can nudge it into place instead of starting over.

It's all in AreaSelectionController (in AreaSelectionWindow.swift), which already tracks the live drag:
- While space is held, both corners of the selection get shifted by the pointer delta instead of just the dragged corner, so the size stays put and the box follows the mouse.
- I added local + global key monitors for the space bar alongside the drag monitors that were already there, so it works even when the overlay is triggered from a global shortcut (and the local one swallows the space key so there's no system beep).
- It only kicks in during normal region selection, the window-picker mode and the Escape/right-click-to-cancel behavior are untouched.

Totally open to feedback if you'd want it done differently, happy to adjust. Thanks for the great app! 🙏