### PR TITLE
Add a keyboard shortcut to edit the latest capture from its preview

### DIFF
--- a/Snapzy/Features/Annotate/Managers/AnnotateWindow.swift
+++ b/Snapzy/Features/Annotate/Managers/AnnotateWindow.swift
@@ -33,8 +33,6 @@ extension Notification.Name {
 /// Custom NSWindow for annotation editing with dark mode appearance
 class AnnotateWindow: NSWindow {
   weak var interactionState: AnnotateState?
-  /// Invoked when Esc is pressed while not editing text or cropping. Returns true if it handled the
-  /// key (e.g. discarded the capture and closed the window), in which case the event is consumed.
   var onEscape: (() -> Bool)?
   private static let activeEditorLevel = NSWindow.Level(rawValue: NSWindow.Level.floating.rawValue + 1)
   private var restingLevel: NSWindow.Level = .normal

--- a/Snapzy/Features/Annotate/Managers/AnnotateWindow.swift
+++ b/Snapzy/Features/Annotate/Managers/AnnotateWindow.swift
@@ -33,6 +33,9 @@ extension Notification.Name {
 /// Custom NSWindow for annotation editing with dark mode appearance
 class AnnotateWindow: NSWindow {
   weak var interactionState: AnnotateState?
+  /// Invoked when Esc is pressed while not editing text or cropping. Returns true if it handled the
+  /// key (e.g. discarded the capture and closed the window), in which case the event is consumed.
+  var onEscape: (() -> Bool)?
   private static let activeEditorLevel = NSWindow.Level(rawValue: NSWindow.Level.floating.rawValue + 1)
   private var restingLevel: NSWindow.Level = .normal
 
@@ -276,9 +279,12 @@ class AnnotateWindow: NSWindow {
   override func sendEvent(_ event: NSEvent) {
     switch event.type {
     case .keyDown where event.keyCode == 53:
-      guard !isTextInputActive, interactionState?.isCropInteractionActive == true else { break }
-      interactionState?.cancelCrop()
-      return
+      if isTextInputActive { break }
+      if interactionState?.isCropInteractionActive == true {
+        interactionState?.cancelCrop()
+        return
+      }
+      if onEscape?() == true { return }
 
     case .keyDown where event.keyCode == 36 || event.keyCode == 76:
       guard !isTextInputActive, interactionState?.isCropInteractionActive == true else { break }

--- a/Snapzy/Features/Annotate/Managers/AnnotateWindowController.swift
+++ b/Snapzy/Features/Annotate/Managers/AnnotateWindowController.swift
@@ -219,20 +219,19 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
     let mainView = AnnotateMainView(state: capturedState)
     window?.contentView = NSHostingView(rootView: mainView)
     (window as? AnnotateWindow)?.onEscape = { [weak self] in
-      self?.discardCaptureAndClose() ?? false
+      self?.discardEditsAndClose() ?? false
     }
   }
 
-  private func discardCaptureAndClose() -> Bool {
+  private func discardEditsAndClose() -> Bool {
     guard let quickAccessItemId else { return false }
     DiagnosticLogger.shared.log(
       .info,
       .action,
-      "Annotate window discarded capture via Esc",
+      "Annotate window closed via Esc, discarding edits",
       context: ["itemId": quickAccessItemId.uuidString]
     )
-    QuickAccessManager.shared.deleteItem(id: quickAccessItemId)
-    window?.close()
+    forceClose()
     return true
   }
 

--- a/Snapzy/Features/Annotate/Managers/AnnotateWindowController.swift
+++ b/Snapzy/Features/Annotate/Managers/AnnotateWindowController.swift
@@ -815,20 +815,6 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
   private func executeSave() {
     guard state.hasImage else { return }
 
-    if let sourceURL = state.sourceURL,
-       let itemId = quickAccessItemId,
-       TempCaptureManager.shared.isTempFile(sourceURL) {
-      guard AnnotateExporter.confirmTransparencyLossIfNeeded(state: state, targetURL: sourceURL) else {
-        return
-      }
-      saveSessionCache(makeSessionSnapshot())
-      state.markAsSaved()
-      AnnotateExporter.saveToOriginal(state: state)
-      QuickAccessManager.shared.saveItem(id: itemId, revealInFinder: false)
-      forceClose()
-      return
-    }
-
     if state.sourceURL != nil {
       if let targetURL = state.sourceURL {
         guard AnnotateExporter.confirmTransparencyLossIfNeeded(state: state, targetURL: targetURL) else {

--- a/Snapzy/Features/Annotate/Managers/AnnotateWindowController.swift
+++ b/Snapzy/Features/Annotate/Managers/AnnotateWindowController.swift
@@ -830,7 +830,7 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
       saveSessionCache(makeSessionSnapshot())
       state.markAsSaved()
       AnnotateExporter.saveToOriginal(state: state)
-      QuickAccessManager.shared.saveItem(id: itemId)
+      QuickAccessManager.shared.saveItem(id: itemId, revealInFinder: false)
       forceClose()
       return
     }

--- a/Snapzy/Features/Annotate/Managers/AnnotateWindowController.swift
+++ b/Snapzy/Features/Annotate/Managers/AnnotateWindowController.swift
@@ -223,9 +223,6 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
     }
   }
 
-  /// Esc with no active text/crop edit discards the capture: delete the backing image and close.
-  /// Only applies to windows opened for a Quick Access item; URL/empty editors keep the default
-  /// (non-destructive) behavior.
   private func discardCaptureAndClose() -> Bool {
     guard let quickAccessItemId else { return false }
     DiagnosticLogger.shared.log(
@@ -819,8 +816,6 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
   private func executeSave() {
     guard state.hasImage else { return }
 
-    // Quick Access temp capture: bake in the annotations, move the file into the default screenshot
-    // folder, dismiss the preview popup, and close the editor.
     if let sourceURL = state.sourceURL,
        let itemId = quickAccessItemId,
        TempCaptureManager.shared.isTempFile(sourceURL) {

--- a/Snapzy/Features/Annotate/Managers/AnnotateWindowController.swift
+++ b/Snapzy/Features/Annotate/Managers/AnnotateWindowController.swift
@@ -819,6 +819,22 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
   private func executeSave() {
     guard state.hasImage else { return }
 
+    // Quick Access temp capture: bake in the annotations, move the file into the default screenshot
+    // folder, dismiss the preview popup, and close the editor.
+    if let sourceURL = state.sourceURL,
+       let itemId = quickAccessItemId,
+       TempCaptureManager.shared.isTempFile(sourceURL) {
+      guard AnnotateExporter.confirmTransparencyLossIfNeeded(state: state, targetURL: sourceURL) else {
+        return
+      }
+      saveSessionCache(makeSessionSnapshot())
+      state.markAsSaved()
+      AnnotateExporter.saveToOriginal(state: state)
+      QuickAccessManager.shared.saveItem(id: itemId)
+      forceClose()
+      return
+    }
+
     if state.sourceURL != nil {
       if let targetURL = state.sourceURL {
         guard AnnotateExporter.confirmTransparencyLossIfNeeded(state: state, targetURL: targetURL) else {

--- a/Snapzy/Features/Annotate/Managers/AnnotateWindowController.swift
+++ b/Snapzy/Features/Annotate/Managers/AnnotateWindowController.swift
@@ -218,6 +218,25 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
     let capturedState = self.state
     let mainView = AnnotateMainView(state: capturedState)
     window?.contentView = NSHostingView(rootView: mainView)
+    (window as? AnnotateWindow)?.onEscape = { [weak self] in
+      self?.discardCaptureAndClose() ?? false
+    }
+  }
+
+  /// Esc with no active text/crop edit discards the capture: delete the backing image and close.
+  /// Only applies to windows opened for a Quick Access item; URL/empty editors keep the default
+  /// (non-destructive) behavior.
+  private func discardCaptureAndClose() -> Bool {
+    guard let quickAccessItemId else { return false }
+    DiagnosticLogger.shared.log(
+      .info,
+      .action,
+      "Annotate window discarded capture via Esc",
+      context: ["itemId": quickAccessItemId.uuidString]
+    )
+    QuickAccessManager.shared.deleteItem(id: quickAccessItemId)
+    window?.close()
+    return true
   }
 
 

--- a/Snapzy/Features/Preferences/Components/PreferencesShortcutsSettingsView.swift
+++ b/Snapzy/Features/Preferences/Components/PreferencesShortcutsSettingsView.swift
@@ -30,6 +30,7 @@ struct ShortcutsSettingsView: View {
   @State private var cloudUploadsShortcut: ShortcutConfig?
   @State private var shortcutListShortcut: ShortcutConfig?
   @State private var historyShortcut: ShortcutConfig?
+  @State private var openEditorShortcut: ShortcutConfig?
   @State private var copyAndCloseShortcut: ShortcutConfig?
   @State private var toggleSidebarShortcut: ShortcutConfig?
   @State private var togglePinShortcut: ShortcutConfig?
@@ -84,6 +85,7 @@ struct ShortcutsSettingsView: View {
     _cloudUploadsShortcut = State(initialValue: KeyboardShortcutManager.shared.shortcut(for: .cloudUploads))
     _shortcutListShortcut = State(initialValue: KeyboardShortcutManager.shared.shortcut(for: .shortcutList))
     _historyShortcut = State(initialValue: KeyboardShortcutManager.shared.shortcut(for: .history))
+    _openEditorShortcut = State(initialValue: QuickAccessManager.shared.openEditorShortcut)
     _copyAndCloseShortcut = State(initialValue: AnnotateShortcutManager.shared.copyAndCloseShortcut)
     _toggleSidebarShortcut = State(initialValue: AnnotateShortcutManager.shared.toggleSidebarShortcut)
     _togglePinShortcut = State(initialValue: AnnotateShortcutManager.shared.togglePinShortcut)
@@ -554,6 +556,34 @@ struct ShortcutsSettingsView: View {
         }
 
         Section {
+          Text(L10n.PreferencesShortcuts.quickAccessSectionDescription)
+            .font(.caption)
+            .foregroundColor(.secondary)
+
+          ShortcutRecorderView(
+            label: L10n.PreferencesShortcuts.editLatestCapture,
+            icon: "pencil.tip.crop.circle",
+            description: L10n.PreferencesShortcuts.editLatestCaptureDescription,
+            shortcut: $openEditorShortcut,
+            defaultShortcut: QuickAccessManager.defaultOpenEditorShortcut,
+            onShortcutChanged: { config in
+              QuickAccessManager.shared.setOpenEditorShortcut(config)
+              return true
+            }
+          )
+        } header: {
+          HStack {
+            Text(L10n.PreferencesShortcuts.quickAccessSection)
+            Spacer()
+            Button(L10n.Common.reset) {
+              resetQuickAccessSection()
+            }
+            .buttonStyle(.borderless)
+            .font(.caption)
+          }
+        }
+
+        Section {
           Text(L10n.PreferencesShortcuts.annotateActionsDescription)
             .font(.caption)
             .foregroundColor(.secondary)
@@ -793,6 +823,11 @@ struct ShortcutsSettingsView: View {
     }
   }
 
+  private func resetQuickAccessSection() {
+    openEditorShortcut = QuickAccessManager.defaultOpenEditorShortcut
+    QuickAccessManager.shared.setOpenEditorShortcut(QuickAccessManager.defaultOpenEditorShortcut)
+  }
+
   private func resetAnnotateActionsSection() {
     copyAndCloseShortcut = AnnotateShortcutManager.defaultCopyAndClose
     toggleSidebarShortcut = AnnotateShortcutManager.defaultToggleSidebar
@@ -825,6 +860,7 @@ struct ShortcutsSettingsView: View {
     resetCaptureSection(refresh: false)
     resetRecordingSection(refresh: false)
     resetToolsSection(refresh: false)
+    resetQuickAccessSection()
     resetAnnotateActionsSection()
     resetAnnotateToolKeysSection()
 

--- a/Snapzy/Features/QuickAccess/QuickAccessManager.swift
+++ b/Snapzy/Features/QuickAccess/QuickAccessManager.swift
@@ -128,8 +128,9 @@ final class QuickAccessManager: ObservableObject {
   private var editingItemIds: Set<UUID> = []
   /// Tracks items doing async work, such as GIF conversion or cloud upload.
   private var activityHoldItemIds: Set<UUID> = []
-  private var editShortcutLocalMonitor: Any?
-  private var editShortcutGlobalMonitor: Any?
+  private var editHotKeyRef: EventHotKeyRef?
+  private var editHotKeyHandler: EventHandlerRef?
+  fileprivate let editHotKeyID = EventHotKeyID(signature: OSType(0x5A51_4145), id: 1)
 
   // MARK: - UserDefaults Keys (preserved for backward compatibility)
 
@@ -1126,7 +1127,7 @@ final class QuickAccessManager: ObservableObject {
       itemCount: visiblePanelItemCount,
       scale: CGFloat(overlayScale)
     )
-    installEditShortcutMonitorIfNeeded()
+    installEditHotKeyIfNeeded()
     DiagnosticLogger.shared.log(
       .debug,
       .ui,
@@ -1141,7 +1142,7 @@ final class QuickAccessManager: ObservableObject {
   }
 
   private func hidePanel() {
-    removeEditShortcutMonitor()
+    removeEditHotKey()
     panelController.hide()
   }
 
@@ -1162,36 +1163,60 @@ final class QuickAccessManager: ObservableObject {
     return true
   }
 
-  // The preview panel is non-activating, so the foreground app can still own key focus after capture.
-  // Keep both monitors scoped to the panel lifetime; the local monitor consumes matches when Snapzy is frontmost.
-  private func installEditShortcutMonitorIfNeeded() {
-    if editShortcutLocalMonitor == nil {
-      editShortcutLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-        let handled = MainActor.assumeIsolated { self?.handleEditShortcut(event) ?? false }
-        return handled ? nil : event
+  private func installEditHotKeyIfNeeded() {
+    guard editHotKeyRef == nil, let shortcut = openEditorShortcut else { return }
+
+    if editHotKeyHandler == nil {
+      var spec = EventTypeSpec(
+        eventClass: OSType(kEventClassKeyboard),
+        eventKind: OSType(kEventHotKeyPressed)
+      )
+      let callback: EventHandlerUPP = { _, event, userData in
+        guard let userData, let event else { return OSStatus(eventNotHandledErr) }
+        var hotKeyID = EventHotKeyID()
+        GetEventParameter(
+          event,
+          EventParamName(kEventParamDirectObject),
+          EventParamType(typeEventHotKeyID),
+          nil,
+          MemoryLayout<EventHotKeyID>.size,
+          nil,
+          &hotKeyID
+        )
+        let manager = Unmanaged<QuickAccessManager>.fromOpaque(userData).takeUnretainedValue()
+        guard hotKeyID.signature == manager.editHotKeyID.signature else {
+          return OSStatus(eventNotHandledErr)
+        }
+        DispatchQueue.main.async {
+          MainActor.assumeIsolated { _ = manager.openEditorForNewestItem() }
+        }
+        return noErr
       }
+      InstallEventHandler(
+        GetApplicationEventTarget(),
+        callback,
+        1,
+        &spec,
+        Unmanaged.passUnretained(self).toOpaque(),
+        &editHotKeyHandler
+      )
     }
-    if editShortcutGlobalMonitor == nil {
-      editShortcutGlobalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
-        MainActor.assumeIsolated { _ = self?.handleEditShortcut(event) }
-      }
-    }
+
+    RegisterEventHotKey(
+      shortcut.keyCode,
+      shortcut.modifiers,
+      editHotKeyID,
+      GetApplicationEventTarget(),
+      0,
+      &editHotKeyRef
+    )
   }
 
-  private func removeEditShortcutMonitor() {
-    if let editShortcutLocalMonitor {
-      NSEvent.removeMonitor(editShortcutLocalMonitor)
-      self.editShortcutLocalMonitor = nil
+  private func removeEditHotKey() {
+    if let editHotKeyRef {
+      UnregisterEventHotKey(editHotKeyRef)
+      self.editHotKeyRef = nil
     }
-    if let editShortcutGlobalMonitor {
-      NSEvent.removeMonitor(editShortcutGlobalMonitor)
-      self.editShortcutGlobalMonitor = nil
-    }
-  }
-
-  private func handleEditShortcut(_ event: NSEvent) -> Bool {
-    guard matchesOpenEditorShortcut(event) else { return false }
-    return openEditorForNewestItem()
   }
 
   func setOpenEditorShortcut(_ config: ShortcutConfig?) {
@@ -1200,6 +1225,10 @@ final class QuickAccessManager: ObservableObject {
       UserDefaults.standard.set(data, forKey: Keys.openEditorShortcut)
     } else {
       UserDefaults.standard.set(explicitEmptyShortcutData, forKey: Keys.openEditorShortcut)
+    }
+    if editHotKeyRef != nil {
+      removeEditHotKey()
+      installEditHotKeyIfNeeded()
     }
   }
 
@@ -1214,11 +1243,6 @@ final class QuickAccessManager: ObservableObject {
     }
     openEditorShortcut =
       (try? JSONDecoder().decode(ShortcutConfig.self, from: data)) ?? Self.defaultOpenEditorShortcut
-  }
-
-  private func matchesOpenEditorShortcut(_ event: NSEvent) -> Bool {
-    guard let openEditorShortcut, let pressed = ShortcutConfig(from: event) else { return false }
-    return pressed == openEditorShortcut
   }
 
   private var visiblePanelItemCount: Int {
@@ -1375,11 +1399,11 @@ final class QuickAccessManager: ObservableObject {
     )
 
     if let editIndex = items.firstIndex(where: { $0.id == id }) {
-      // Item still exists — resume it + items at lower indices (newer)
+      // Item still exists — restart it + items at lower indices (newer) with a fresh countdown
       for i in 0...editIndex {
         let itemId = items[i].id
         guard !isItemCountdownHeld(itemId) else { continue }
-        dismissTimers[itemId]?.resume()
+        dismissTimers[itemId]?.restart(duration: autoDismissDelay)
       }
     } else {
       // Edited item was already removed (swiped/dismissed during editing).

--- a/Snapzy/Features/QuickAccess/QuickAccessManager.swift
+++ b/Snapzy/Features/QuickAccess/QuickAccessManager.swift
@@ -6,6 +6,7 @@
 //
 
 import AppKit
+import Carbon.HIToolbox
 import Combine
 import Foundation
 import os.log
@@ -105,6 +106,15 @@ final class QuickAccessManager: ObservableObject {
       UserDefaults.standard.set(pauseCountdownOnHover, forKey: Keys.pauseCountdownOnHover)
     }
   }
+  /// Configurable shortcut that opens the editor for the newest capture while its preview is shown.
+  @Published private(set) var openEditorShortcut: ShortcutConfig?
+
+  /// Default: ⌘↩
+  static let defaultOpenEditorShortcut = ShortcutConfig(
+    keyCode: UInt32(kVK_Return),
+    modifiers: UInt32(cmdKey)
+  )
+
   // MARK: - Configuration
 
   let maxVisibleItems = 5
@@ -120,6 +130,8 @@ final class QuickAccessManager: ObservableObject {
   private var editingItemIds: Set<UUID> = []
   /// Tracks items doing async work, such as GIF conversion or cloud upload.
   private var activityHoldItemIds: Set<UUID> = []
+  private var editShortcutLocalMonitor: Any?
+  private var editShortcutGlobalMonitor: Any?
 
   // MARK: - UserDefaults Keys (preserved for backward compatibility)
 
@@ -135,7 +147,11 @@ final class QuickAccessManager: ObservableObject {
     static let twoFingerSwipeToDismissEnabled = "floatingScreenshot.twoFingerSwipeToDismissEnabled"
     static let swipeSensitivity = "floatingScreenshot.swipeSensitivity"
     static let pauseCountdownOnHover = "floatingScreenshot.pauseCountdownOnHover"
+    static let openEditorShortcut = "quickAccess.openEditorShortcut"
   }
+
+  /// Marker persisted when the user explicitly clears the shortcut, distinguishing it from "never set".
+  private let explicitEmptyShortcutData = Data("null".utf8)
 
   // MARK: - Init
 
@@ -175,6 +191,7 @@ final class QuickAccessManager: ObservableObject {
       UserDefaults.standard.object(forKey: Keys.swipeSensitivity) as? Double ?? 1.0
     pauseCountdownOnHover =
       UserDefaults.standard.object(forKey: Keys.pauseCountdownOnHover) as? Bool ?? true
+    loadOpenEditorShortcut()
     DiagnosticLogger.shared.log(
       .debug,
       .ui,
@@ -467,7 +484,7 @@ final class QuickAccessManager: ObservableObject {
     }
 
     if items.isEmpty {
-      panelController.hide()
+      hidePanel()
     }
 
     scheduleDismissCleanup(for: url, isTempFile: isTempFile)
@@ -539,7 +556,7 @@ final class QuickAccessManager: ObservableObject {
       items.removeAll { $0.id == id }
     }
     if items.isEmpty {
-      panelController.hide()
+      hidePanel()
     }
   }
 
@@ -855,7 +872,7 @@ final class QuickAccessManager: ObservableObject {
     items.removeAll()
     editingItemIds.removeAll()
     activityHoldItemIds.removeAll()
-    panelController.hide()
+    hidePanel()
     DiagnosticLogger.shared.log(
       .info,
       .action,
@@ -1044,7 +1061,7 @@ final class QuickAccessManager: ObservableObject {
       items.removeAll { $0.id == id }
     }
     if items.isEmpty {
-      panelController.hide()
+      hidePanel()
     }
 
     // Move file from temp to export location
@@ -1111,6 +1128,7 @@ final class QuickAccessManager: ObservableObject {
       itemCount: visiblePanelItemCount,
       scale: CGFloat(overlayScale)
     )
+    installEditShortcutMonitorIfNeeded()
     DiagnosticLogger.shared.log(
       .debug,
       .ui,
@@ -1122,6 +1140,91 @@ final class QuickAccessManager: ObservableObject {
   private func showPanelIfNeeded() {
     guard !panelController.isVisible else { return }
     showPanel()
+  }
+
+  private func hidePanel() {
+    removeEditShortcutMonitor()
+    panelController.hide()
+  }
+
+  /// Opens the editor for the most recently captured item while its preview is on screen, letting
+  /// the editor be reached from the keyboard without moving the mouse.
+  @discardableResult
+  func openEditorForNewestItem() -> Bool {
+    guard isEnabled, panelController.isVisible, let item = items.first else { return false }
+    if item.isVideo {
+      VideoEditorManager.shared.openEditor(for: item)
+    } else {
+      AnnotateManager.shared.openAnnotation(for: item)
+    }
+    DiagnosticLogger.shared.log(
+      .info,
+      .action,
+      "Quick access editor opened via keyboard shortcut",
+      context: ["itemId": item.id.uuidString, "isVideo": item.isVideo ? "true" : "false"]
+    )
+    return true
+  }
+
+  /// Watches for the configured shortcut only while the preview is on screen, so the combo is never
+  /// captured the rest of the time. A global monitor is required because the non-activating preview
+  /// panel can't become key — right after a capture another app still holds focus. The local monitor
+  /// consumes the matched event to avoid a system beep when Snapzy itself is frontmost.
+  private func installEditShortcutMonitorIfNeeded() {
+    if editShortcutLocalMonitor == nil {
+      editShortcutLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+        let handled = MainActor.assumeIsolated { self?.handleEditShortcut(event) ?? false }
+        return handled ? nil : event
+      }
+    }
+    if editShortcutGlobalMonitor == nil {
+      editShortcutGlobalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+        MainActor.assumeIsolated { _ = self?.handleEditShortcut(event) }
+      }
+    }
+  }
+
+  private func removeEditShortcutMonitor() {
+    if let editShortcutLocalMonitor {
+      NSEvent.removeMonitor(editShortcutLocalMonitor)
+      self.editShortcutLocalMonitor = nil
+    }
+    if let editShortcutGlobalMonitor {
+      NSEvent.removeMonitor(editShortcutGlobalMonitor)
+      self.editShortcutGlobalMonitor = nil
+    }
+  }
+
+  private func handleEditShortcut(_ event: NSEvent) -> Bool {
+    guard matchesOpenEditorShortcut(event) else { return false }
+    return openEditorForNewestItem()
+  }
+
+  func setOpenEditorShortcut(_ config: ShortcutConfig?) {
+    openEditorShortcut = config
+    if let config, let data = try? JSONEncoder().encode(config) {
+      UserDefaults.standard.set(data, forKey: Keys.openEditorShortcut)
+    } else {
+      UserDefaults.standard.set(explicitEmptyShortcutData, forKey: Keys.openEditorShortcut)
+    }
+  }
+
+  private func loadOpenEditorShortcut() {
+    guard let data = UserDefaults.standard.data(forKey: Keys.openEditorShortcut) else {
+      openEditorShortcut = Self.defaultOpenEditorShortcut
+      return
+    }
+    if data == explicitEmptyShortcutData {
+      openEditorShortcut = nil
+      return
+    }
+    openEditorShortcut =
+      (try? JSONDecoder().decode(ShortcutConfig.self, from: data)) ?? Self.defaultOpenEditorShortcut
+  }
+
+  private func matchesOpenEditorShortcut(_ event: NSEvent) -> Bool {
+    guard let openEditorShortcut, let pressed = ShortcutConfig(from: event) else { return false }
+    return pressed == openEditorShortcut
   }
 
   private var visiblePanelItemCount: Int {

--- a/Snapzy/Features/QuickAccess/QuickAccessManager.swift
+++ b/Snapzy/Features/QuickAccess/QuickAccessManager.swift
@@ -1033,7 +1033,7 @@ final class QuickAccessManager: ObservableObject {
   }
 
   /// Save a temp capture file to the permanent export location, then reveal in Finder
-  func saveItem(id: UUID) {
+  func saveItem(id: UUID, revealInFinder: Bool = true) {
     guard let item = items.first(where: { $0.id == id }) else {
       DiagnosticLogger.shared.log(
         .warning,
@@ -1087,7 +1087,9 @@ final class QuickAccessManager: ObservableObject {
 
         let fileAccess = fileAccessManager.beginAccessingURL(savedURL)
         defer { fileAccess.stop() }
-        NSWorkspace.shared.selectFile(savedURL.path, inFileViewerRootedAtPath: "")
+        if revealInFinder {
+          NSWorkspace.shared.selectFile(savedURL.path, inFileViewerRootedAtPath: "")
+        }
         DiagnosticLogger.shared.log(
           .info,
           .action,

--- a/Snapzy/Features/QuickAccess/QuickAccessManager.swift
+++ b/Snapzy/Features/QuickAccess/QuickAccessManager.swift
@@ -106,10 +106,8 @@ final class QuickAccessManager: ObservableObject {
       UserDefaults.standard.set(pauseCountdownOnHover, forKey: Keys.pauseCountdownOnHover)
     }
   }
-  /// Configurable shortcut that opens the editor for the newest capture while its preview is shown.
   @Published private(set) var openEditorShortcut: ShortcutConfig?
 
-  /// Default: ⌘↩
   static let defaultOpenEditorShortcut = ShortcutConfig(
     keyCode: UInt32(kVK_Return),
     modifiers: UInt32(cmdKey)
@@ -150,7 +148,6 @@ final class QuickAccessManager: ObservableObject {
     static let openEditorShortcut = "quickAccess.openEditorShortcut"
   }
 
-  /// Marker persisted when the user explicitly clears the shortcut, distinguishing it from "never set".
   private let explicitEmptyShortcutData = Data("null".utf8)
 
   // MARK: - Init
@@ -1032,7 +1029,6 @@ final class QuickAccessManager: ObservableObject {
     }
   }
 
-  /// Save a temp capture file to the permanent export location, then reveal in Finder
   func saveItem(id: UUID, revealInFinder: Bool = true) {
     guard let item = items.first(where: { $0.id == id }) else {
       DiagnosticLogger.shared.log(
@@ -1149,8 +1145,6 @@ final class QuickAccessManager: ObservableObject {
     panelController.hide()
   }
 
-  /// Opens the editor for the most recently captured item while its preview is on screen, letting
-  /// the editor be reached from the keyboard without moving the mouse.
   @discardableResult
   func openEditorForNewestItem() -> Bool {
     guard isEnabled, panelController.isVisible, let item = items.first else { return false }
@@ -1168,10 +1162,8 @@ final class QuickAccessManager: ObservableObject {
     return true
   }
 
-  /// Watches for the configured shortcut only while the preview is on screen, so the combo is never
-  /// captured the rest of the time. A global monitor is required because the non-activating preview
-  /// panel can't become key — right after a capture another app still holds focus. The local monitor
-  /// consumes the matched event to avoid a system beep when Snapzy itself is frontmost.
+  // The preview panel is non-activating, so the foreground app can still own key focus after capture.
+  // Keep both monitors scoped to the panel lifetime; the local monitor consumes matches when Snapzy is frontmost.
   private func installEditShortcutMonitorIfNeeded() {
     if editShortcutLocalMonitor == nil {
       editShortcutLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in

--- a/Snapzy/Features/QuickAccess/QuickAccessManager.swift
+++ b/Snapzy/Features/QuickAccess/QuickAccessManager.swift
@@ -1030,7 +1030,7 @@ final class QuickAccessManager: ObservableObject {
     }
   }
 
-  func saveItem(id: UUID, revealInFinder: Bool = true) {
+  func saveItem(id: UUID) {
     guard let item = items.first(where: { $0.id == id }) else {
       DiagnosticLogger.shared.log(
         .warning,
@@ -1084,9 +1084,7 @@ final class QuickAccessManager: ObservableObject {
 
         let fileAccess = fileAccessManager.beginAccessingURL(savedURL)
         defer { fileAccess.stop() }
-        if revealInFinder {
-          NSWorkspace.shared.selectFile(savedURL.path, inFileViewerRootedAtPath: "")
-        }
+        NSWorkspace.shared.selectFile(savedURL.path, inFileViewerRootedAtPath: "")
         DiagnosticLogger.shared.log(
           .info,
           .action,

--- a/Snapzy/Features/QuickAccess/Services/QuickAccessCountdownTimer.swift
+++ b/Snapzy/Features/QuickAccess/Services/QuickAccessCountdownTimer.swift
@@ -92,6 +92,13 @@ final class QuickAccessCountdownTimer {
     scheduleTask()
   }
 
+  /// Restart the countdown from the full duration.
+  func restart(duration: TimeInterval) {
+    isPaused = false
+    remainingTime = duration
+    scheduleTask()
+  }
+
   /// Cancel the countdown entirely
   func cancel() {
     isPaused = false

--- a/Snapzy/Resources/Localization/Features/Shortcuts.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Shortcuts.xcstrings
@@ -1236,6 +1236,28 @@
         }
       }
     },
+    "preferences-shortcuts.edit-latest-capture": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit latest capture"
+          }
+        }
+      }
+    },
+    "preferences-shortcuts.edit-latest-capture-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open the editor for the most recent capture while its preview is showing"
+          }
+        }
+      }
+    },
     "preferences-shortcuts.enable-shortcuts-description": {
       "extractionState": "stale",
       "localizations": {
@@ -1882,6 +1904,28 @@
           "stringUnit": {
             "state": "translated",
             "value": "打開影片編輯工具"
+          }
+        }
+      }
+    },
+    "preferences-shortcuts.quick-access-section": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quick Access"
+          }
+        }
+      }
+    },
+    "preferences-shortcuts.quick-access-section-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shortcuts active while a Quick Access preview is on screen."
           }
         }
       }

--- a/Snapzy/Shared/Localization/L10n.swift
+++ b/Snapzy/Shared/Localization/L10n.swift
@@ -3019,6 +3019,26 @@ enum L10n {
       defaultValue: "Open keyboard shortcuts overlay",
       comment: "Description for shortcut list shortcut"
     )
+    static let quickAccessSection = string(
+      "preferences-shortcuts.quick-access-section",
+      defaultValue: "Quick Access",
+      comment: "Shortcuts preferences section title for Quick Access preview actions"
+    )
+    static let quickAccessSectionDescription = string(
+      "preferences-shortcuts.quick-access-section-description",
+      defaultValue: "Shortcuts active while a Quick Access preview is on screen.",
+      comment: "Description for the Quick Access shortcuts section"
+    )
+    static let editLatestCapture = string(
+      "preferences-shortcuts.edit-latest-capture",
+      defaultValue: "Edit latest capture",
+      comment: "Label for the shortcut that opens the editor for the most recent capture"
+    )
+    static let editLatestCaptureDescription = string(
+      "preferences-shortcuts.edit-latest-capture-description",
+      defaultValue: "Open the editor for the most recent capture while its preview is showing",
+      comment: "Description for the edit latest capture shortcut"
+    )
     static let recorderHint = string(
       "preferences-shortcuts.recorder-hint",
       defaultValue: "Click a shortcut button to record new keys. Use Backspace/Delete while recording to clear keys. Use the row toggle to turn a shortcut off. Press Esc to cancel.",


### PR DESCRIPTION
Hey again 👋 

This one's about keeping the capture flow fully keyboard-driven. Right now, after you take a screenshot the Quick Access preview pops up in the corner, but to edit it you have to grab the mouse and click the edit button before it disappears. I wanted to never leave the keyboard, so I added a shortcut that opens the editor for the most recent capture while its preview is still on screen.

What it does
- Take a capture → while its Quick Access preview is showing → press the shortcut → the editor opens on that capture. No mouse needed.
- Works for both screenshots (annotation editor) and recordings (video editor).
- Configurable in Settings → Shortcuts → Quick Access ("Edit latest capture"), default ⌘↩.

Design notes
- It's a contextual shortcut, not a global hotkey, the key monitor is only installed while a preview is actually on screen, so the combo is never stolen from other apps the rest of the time.
- A global monitor is used (alongside a local one) because the preview is a non-activating panel that can't take key focus, right after a capture another app still holds focus. The local monitor consumes the matched event so there's no system beep when Snapzy itself is frontmost.
- Storage/persistence/matching follows the existing AnnotateShortcutManager action-shortcut pattern, and the settings row reuses the shared ShortcutRecorderView, so it fits right in with the other shortcuts (recordable, clearable, resettable, and included in "Reset to defaults").
- New strings go through the existing L10n helper with English defaults, so untranslated locales fall back gracefully.

Happy to tweak the default shortcut or wording if you'd prefer something else :)

