### PR TITLE
Fix Simplified and Traditional Chinese translations for Snapzy’s screen recording feature

### DIFF
--- a/Snapzy/Resources/Localization/Features/Capture.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Capture.xcstrings
@@ -835,13 +835,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "录音"
+            "value": "屏幕录制"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "錄音"
+            "value": "螢幕錄製"
           }
         }
       }
@@ -1030,7 +1030,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "正在截屏或录制时无法清除缓存。"
+            "value": "正在截屏或录屏时无法清除缓存。"
           }
         },
         "zh-Hant": {
@@ -4540,13 +4540,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "选择用于录制的内置或外接麦克风"
+            "value": "选择录屏时使用的内置或外接麦克风"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "選擇用於錄製的內建或外接麥克風"
+            "value": "選擇螢幕錄製時使用的內建或外接麥克風"
           }
         }
       }
@@ -5263,7 +5263,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "錄制預覽：%@"
+            "value": "錄屏預覽：%@"
           }
         }
       }
@@ -5452,13 +5452,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "录音模板"
+            "value": "录屏模板"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "錄音模板"
+            "value": "錄屏模板"
           }
         }
       }
@@ -6818,13 +6818,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "录音格式"
+            "value": "录屏格式"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "錄音格式"
+            "value": "錄屏格式"
           }
         }
       }
@@ -6883,13 +6883,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "录音质量"
+            "value": "录屏质量"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "錄音質量"
+            "value": "錄屏質量"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/Menubar.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Menubar.xcstrings
@@ -451,7 +451,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "錄制螢幕"
+            "value" : "錄製螢幕"
           }
         }
       }
@@ -510,13 +510,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "停止录音 (%@)"
+            "value" : "停止录屏 (%@)"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "停止錄音 (%@)"
+            "value" : "停止錄屏 (%@)"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/Onboarding.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Onboarding.xcstrings
@@ -1940,13 +1940,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "需要截图和录音"
+            "value" : "需要截图和录屏"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "需要截圖和錄音"
+            "value" : "需要截圖和錄屏"
           }
         }
       }
@@ -2076,7 +2076,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "螢幕錄制"
+            "value" : "螢幕錄製"
           }
         }
       }
@@ -3427,13 +3427,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "录音"
+            "value" : "录屏"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "錄音"
+            "value" : "錄屏"
           }
         }
       }
@@ -4408,7 +4408,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "帶音頻錄制螢幕"
+            "value" : "帶音頻錄製螢幕"
           }
         }
       }
@@ -4473,7 +4473,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "適用於 macOS 的強大螢幕截圖和螢幕錄制應用"
+            "value" : "適用於 macOS 的強大螢幕截圖和螢幕錄製應用"
           }
         }
       }
@@ -4662,13 +4662,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "截图和录制，简化。"
+            "value" : "截图录屏，轻松搞定。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "截圖和錄制，簡化。"
+            "value" : "截圖錄屏，輕鬆搞定。"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/Recording.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Recording.xcstrings
@@ -1556,7 +1556,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Snapzy 需要麥克風權限才能錄制音頻。請在系統設置中授予訪問權限。"
+            "value": "Snapzy 需要麥克風權限才能錄製音頻。請在系統設置中授予訪問權限。"
           }
         }
       }
@@ -2460,13 +2460,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "取消录音"
+            "value": "取消录屏"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "取消錄音"
+            "value": "取消錄屏"
           }
         }
       }
@@ -2590,13 +2590,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "删除录音"
+            "value": "删除录屏"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "刪除錄音"
+            "value": "刪除錄屏"
           }
         }
       }
@@ -3045,13 +3045,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "录音选项"
+            "value": "录屏选项"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "錄音選項"
+            "value": "錄屏選項"
           }
         }
       }
@@ -3500,13 +3500,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "暂停录音"
+            "value": "暂停录屏"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "暫停錄音"
+            "value": "暫停錄屏"
           }
         }
       }
@@ -3890,13 +3890,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "录音进行中"
+            "value": "录屏中"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "錄音進行中"
+            "value": "錄屏中"
           }
         }
       }
@@ -3955,13 +3955,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "录音暂停"
+            "value": "录屏暂停"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "錄音暫停"
+            "value": "錄屏暫停"
           }
         }
       }
@@ -4020,13 +4020,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "重新开始录音"
+            "value": "重新开始录屏"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "重新開始錄音"
+            "value": "重新開始錄屏"
           }
         }
       }
@@ -4085,13 +4085,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "恢复录音"
+            "value": "恢复录屏"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "恢復錄音"
+            "value": "恢復錄屏"
           }
         }
       }
@@ -4150,13 +4150,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "录音设置"
+            "value": "录屏设置"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "錄音設置"
+            "value": "錄屏設置"
           }
         }
       }
@@ -4345,13 +4345,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "开始录制为 %@"
+            "value": "开始录屏为 %@"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "開始錄制為 %@"
+            "value": "開始錄屏為 %@"
           }
         }
       }
@@ -4416,7 +4416,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "使用當前設置開始螢幕錄制"
+            "value": "使用當前設置開始螢幕錄製"
           }
         }
       }
@@ -4475,13 +4475,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "录音状态栏"
+            "value": "录屏状态栏"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "錄音狀態欄"
+            "value": "錄屏狀態欄"
           }
         }
       }
@@ -4605,13 +4605,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "停止录制 - 持续时间：%@"
+            "value": "停止录屏 - 持续时间：%@"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "停止錄制 - 持續時間：%@"
+            "value": "停止錄屏 - 持續時間：%@"
           }
         }
       }
@@ -4670,13 +4670,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "停止并保存录音"
+            "value": "停止并保存录屏"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "停止並保存錄音"
+            "value": "停止並保存錄屏"
           }
         }
       }
@@ -4865,13 +4865,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "录音工具栏"
+            "value": "录屏工具栏"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "錄音工具欄"
+            "value": "錄屏工具欄"
           }
         }
       }
@@ -4930,13 +4930,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "选择 Snapzy 保存屏幕截图和录音的位置"
+            "value": "选择 Snapzy 保存屏幕截图和录屏的位置"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "選擇 Snapzy 保存螢幕截圖和錄音的位置"
+            "value": "選擇 Snapzy 保存螢幕截圖和錄屏的位置"
           }
         }
       }
@@ -4995,13 +4995,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "录音已取消"
+            "value": "录屏已取消"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "錄音已取消"
+            "value": "錄屏已取消"
           }
         }
       }
@@ -5521,7 +5521,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "螢幕錄制權限被拒絕"
+            "value": "螢幕錄製權限被拒絕"
           }
         }
       }
@@ -5840,13 +5840,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "录音失败"
+            "value": "录屏失败"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "錄音失敗"
+            "value": "錄屏失敗"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/Settings.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Settings.xcstrings
@@ -1917,13 +1917,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "macOS 的屏幕截图和录制"
+            "value": "macOS 的屏幕截图和录屏"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "macOS 的螢幕截圖和錄制"
+            "value": "macOS 的螢幕截圖和錄屏"
           }
         }
       }
@@ -3152,7 +3152,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "保存用于应用、截图、录制和崩溃诊断的本地日志"
+            "value": "保存用于应用、截图、录屏和崩溃诊断的本地日志"
           }
         },
         "zh-Hant": {

--- a/Snapzy/Resources/Localization/Features/Shortcuts.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Shortcuts.xcstrings
@@ -1946,7 +1946,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "開始螢幕錄制"
+            "value": "開始螢幕錄製"
           }
         }
       }
@@ -2070,13 +2070,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "录音快捷键"
+            "value": "录屏快捷键"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "錄音快捷鍵"
+            "value": "錄屏快捷鍵"
           }
         }
       }
@@ -2464,7 +2464,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "單擊即可錄制。錄制時使用退格鍵或行切換可關閉快捷方式。 Esc 取消。"
+            "value": "單擊即可錄製。錄製時使用退格鍵或行切換可關閉快捷方式。 Esc 取消。"
           }
         }
       }
@@ -3953,13 +3953,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "仅录音"
+            "value": "仅录屏"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "僅錄音"
+            "value": "僅錄屏"
           }
         }
       }
@@ -4213,13 +4213,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "截图+录音"
+            "value": "截图+录屏"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "截圖+錄音"
+            "value": "截圖+錄屏"
           }
         }
       }
@@ -5454,7 +5454,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "macOS 螢幕截圖和錄制選項"
+            "value": "macOS 螢幕截圖和錄製選項"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Shared/Permissions.xcstrings
+++ b/Snapzy/Resources/Localization/Shared/Permissions.xcstrings
@@ -185,13 +185,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "选择 Snapzy 保存屏幕截图和录音的位置"
+            "value" : "选择 Snapzy 保存屏幕截图和录屏的位置"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "選擇 Snapzy 保存螢幕截圖和錄音的位置"
+            "value" : "選擇 Snapzy 保存螢幕截圖和錄屏的位置"
           }
         }
       }


### PR DESCRIPTION
In Chinese, `录音` / `錄音` specifically means **audio recording**, such as recording from a microphone. It does not normally mean recording the screen.

In Snapzy, `Recording` refers to screen/video recording. Translating this as `录音` / `錄音` makes the UI read as if the feature is only for recording sound.

Native Chinese UI usually uses:

- Simplified Chinese: `屏幕录制` or the shorter `录屏`
- Traditional Chinese: `螢幕錄製` or the shorter `錄屏`

This PR updates the affected Chinese strings to use screen-recording terminology, while keeping audio/microphone-related text distinct where needed.