### PR TITLE
Add optional live (non-frozen) mode for area capture

### DIFF
--- a/Snapzy/Features/Capture/CaptureViewModel.swift
+++ b/Snapzy/Features/Capture/CaptureViewModel.swift
@@ -138,6 +138,13 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
     UserDefaults.standard.object(forKey: PreferencesKeys.screenshotShowCursor) as? Bool ?? false
   }
 
+  /// When enabled (default), area capture selects against a frozen snapshot of the screen. When
+  /// disabled, the screen stays live during selection (e.g. video keeps playing) and the region is
+  /// captured at the moment selection completes.
+  private var freezesAreaCapture: Bool {
+    UserDefaults.standard.object(forKey: PreferencesKeys.screenshotFreezeArea) as? Bool ?? true
+  }
+
   private var isBackgroundCutoutAutoCropEnabled: Bool {
     UserDefaults.standard.object(forKey: PreferencesKeys.backgroundCutoutAutoCropEnabled) as? Bool ?? true
   }
@@ -540,6 +547,22 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
 
     // Hide only normal-level app windows (not overlay panels) to avoid hiding pooled overlay windows
     let hiddenWindowSession = hideVisibleNormalWindowsIfNeeded(shouldHideOwnWindows)
+
+    // Live mode: skip the frozen snapshot so on-screen content keeps playing during selection,
+    // then capture the chosen region at completion time.
+    if !freezesAreaCapture {
+      startLiveAreaSelection(
+        saveDirectory: resolvedSaveDirectory,
+        prefetchedContentTask: prefetchedContentTask,
+        showCursor: showCursor,
+        excludeDesktopIcons: excludeDesktopIcons,
+        excludeDesktopWidgets: excludeDesktopWidgets,
+        excludeOwnApplication: excludeOwnApplication,
+        initialInteractionMode: initialInteractionMode,
+        hiddenWindowSession: hiddenWindowSession
+      )
+      return
+    }
 
     // Give WindowServer enough time to fully remove hidden app windows before
     // the frozen backdrop is prepared.
@@ -976,6 +999,93 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
           if case .success = result {
             SoundManager.playScreenshotCapture()
           }
+        }
+      }
+    }
+  }
+
+  /// Area selection without a frozen backdrop: the overlay sits over the live screen (excluded from
+  /// capture via its `.none` sharing type), and the region is captured when the user commits.
+  private func startLiveAreaSelection(
+    saveDirectory resolvedSaveDirectory: URL,
+    prefetchedContentTask: ShareableContentPrefetchTask?,
+    showCursor: Bool,
+    excludeDesktopIcons: Bool,
+    excludeDesktopWidgets: Bool,
+    excludeOwnApplication: Bool,
+    initialInteractionMode: AreaSelectionInteractionMode,
+    hiddenWindowSession: HiddenWindowSession
+  ) {
+    activeAreaSelectionSessionID = UUID()
+
+    AreaSelectionController.shared.startSelection(
+      mode: .screenshot,
+      backdrops: [:],
+      applicationConfiguration: AreaSelectionApplicationConfiguration(
+        prefetchedContentTask: prefetchedContentTask,
+        excludeOwnApplication: excludeOwnApplication
+      ),
+      initialInteractionMode: initialInteractionMode
+    ) { [weak self] selection in
+      guard let self = self else {
+        hiddenWindowSession.restore()
+        return
+      }
+      defer { self.isAreaSelectionActive = false }
+
+      guard let selection else {
+        hiddenWindowSession.restore()
+        DiagnosticLogger.shared.log(.info, .capture, "Live area capture cancelled by user")
+        self.lastCaptureResult = .failure(.cancelled)
+        return
+      }
+
+      Task { @MainActor in
+        defer { hiddenWindowSession.restore() }
+        self.isCapturing = true
+        await Task.yield()
+
+        let actualSaveDirectory = self.tempCaptureManager.resolveSaveDirectory(
+          for: .screenshot,
+          exportDirectory: resolvedSaveDirectory
+        )
+
+        let result: CaptureResult
+        switch selection.target {
+        case .rect:
+          DiagnosticLogger.shared.log(
+            .info,
+            .capture,
+            "Area captured live",
+            context: ["rect": "\(Int(selection.rect.width))x\(Int(selection.rect.height))"]
+          )
+          result = await self.captureManager.captureArea(
+            rect: selection.rect,
+            saveDirectory: actualSaveDirectory,
+            format: self.resolvedFormat,
+            showCursor: showCursor,
+            excludeDesktopIcons: excludeDesktopIcons,
+            excludeDesktopWidgets: excludeDesktopWidgets,
+            excludeOwnApplication: excludeOwnApplication,
+            prefetchedContentTask: prefetchedContentTask
+          )
+        case .window(let target):
+          result = await self.captureManager.captureWindow(
+            target: target,
+            saveDirectory: actualSaveDirectory,
+            format: self.resolvedFormat,
+            showCursor: showCursor,
+            excludeDesktopIcons: excludeDesktopIcons,
+            excludeDesktopWidgets: excludeDesktopWidgets,
+            excludeOwnApplication: excludeOwnApplication,
+            prefetchedContentTask: prefetchedContentTask
+          )
+        }
+
+        self.isCapturing = false
+        self.lastCaptureResult = result
+        if case .success = result {
+          SoundManager.playScreenshotCapture()
         }
       }
     }

--- a/Snapzy/Features/Preferences/Components/PreferencesCaptureSettingsView.swift
+++ b/Snapzy/Features/Preferences/Components/PreferencesCaptureSettingsView.swift
@@ -33,6 +33,7 @@ struct CaptureSettingsView: View {
   @AppStorage(PreferencesKeys.hideDesktopWidgets) private var hideDesktopWidgets = false
   @AppStorage(PreferencesKeys.screenshotIncludeOwnApp) private var includeOwnAppInScreenshots = false
   @AppStorage(PreferencesKeys.screenshotShowCursor) private var screenshotShowCursor = false
+  @AppStorage(PreferencesKeys.screenshotFreezeArea) private var freezeAreaCapture = true
 
   @AppStorage(PreferencesKeys.screenshotFormat) private var screenshotFormat = "png"
   @AppStorage(PreferencesKeys.scrollingCaptureShowHints) private var scrollingCaptureShowHints = true
@@ -167,6 +168,15 @@ struct CaptureSettingsView: View {
               description: L10n.PreferencesCapture.showCursorDescription
             ) {
               Toggle("", isOn: $screenshotShowCursor)
+                .labelsHidden()
+            }
+
+            SettingRow(
+              icon: "snowflake",
+              title: L10n.PreferencesCapture.freezeAreaTitle,
+              description: L10n.PreferencesCapture.freezeAreaDescription
+            ) {
+              Toggle("", isOn: $freezeAreaCapture)
                 .labelsHidden()
             }
 

--- a/Snapzy/Features/Preferences/Models/PreferencesKeys.swift
+++ b/Snapzy/Features/Preferences/Models/PreferencesKeys.swift
@@ -52,6 +52,7 @@ enum PreferencesKeys {
   static let screenshotFileNameTemplate = "screenshot.fileNameTemplate"
   static let screenshotIncludeOwnApp = "screenshot.includeOwnApp"
   static let screenshotShowCursor = "screenshot.showCursor"
+  static let screenshotFreezeArea = "screenshot.freezeArea"
   static let scrollingCaptureShowHints = "scrollingCapture.showHints"
   static let backgroundCutoutAutoCropEnabled = "backgroundCutout.autoCropEnabled"
   static let annotateCanvasPresets = "annotate.canvasPresets.v1"

--- a/Snapzy/Shared/Localization/L10n.swift
+++ b/Snapzy/Shared/Localization/L10n.swift
@@ -2481,6 +2481,16 @@ enum L10n {
       defaultValue: "Include mouse pointer in captured screenshots",
       comment: "Capture preferences setting description"
     )
+    static let freezeAreaTitle = string(
+      "preferences-capture.freeze-area-title",
+      defaultValue: "Freeze screen during area capture",
+      comment: "Capture preferences setting title"
+    )
+    static let freezeAreaDescription = string(
+      "preferences-capture.freeze-area-description",
+      defaultValue: "Hold a still snapshot while selecting. Turn off to keep content like videos playing; the region is captured when you release.",
+      comment: "Capture preferences setting description"
+    )
     static let recordingShowCursorDescription = string(
       "preferences-capture.recording-show-cursor-description",
       defaultValue: "Include mouse pointer in recorded videos and GIFs",


### PR DESCRIPTION
I noticed an inefficiency when capturing screenshots: the moment you trigger an area capture, Snapzy grabs and renders a full-screen snapshot just to show a frozen backdrop to select against. It works great for precision, but it does a chunk of work up front every single time, and it has a side effect I kept running into, which is that anything moving on screen (a playing video, an animation) freezes the instant I start selecting, so I can't line up the exact frame I actually want.

I understand the freeze is genuinely useful for some use cases, so I didn't change the default, I just added the option to disable it. There's a small toggle in Settings → Capture → Screenshot, "Freeze screen during area capture", on by default so nothing changes for anyone unless they want it to. Turn it off and the screen just stays live while you drag out your selection, and the region gets captured the moment you release.

The nice part is that the live path is actually lighter than the default, it skips that up-front snapshot-and-render entirely and reuses the capture path that was already in the codebase as a fallback, and the selection overlay is already excluded from the capture, so nothing leaks into the image. The only real tradeoff is that the frame comes from when you release rather than when you trigger, which is exactly what you want when the whole point is to catch a live moment.