### PR TITLE
Increase menu bar icon visual scale

### DIFF
--- a/Snapzy/App/AppStatusBarController.swift
+++ b/Snapzy/App/AppStatusBarController.swift
@@ -229,11 +229,25 @@ final class AppStatusBarController: ObservableObject {
   private func makeIdleStatusImage() -> NSImage? {
     guard let appIcon = NSImage(named: "MenubarIcon") else { return nil }
 
-    let size = NSSize(width: 18, height: 18)
-    let resizedIcon = NSImage(size: size)
+    let canvasSize = NSSize(width: 18, height: 18)
+    let targetVisibleOccupancy: CGFloat = 0.89
+    // Current MenubarIcon PNG alpha bounds occupy 75.28% of its transparent canvas.
+    let sourceVisibleOccupancy: CGFloat = 0.7528
+    let drawSize = NSSize(
+      width: canvasSize.width * targetVisibleOccupancy / sourceVisibleOccupancy,
+      height: canvasSize.height * targetVisibleOccupancy / sourceVisibleOccupancy
+    )
+    let drawRect = NSRect(
+      x: (canvasSize.width - drawSize.width) / 2,
+      y: (canvasSize.height - drawSize.height) / 2,
+      width: drawSize.width,
+      height: drawSize.height
+    )
+
+    let resizedIcon = NSImage(size: canvasSize)
     resizedIcon.lockFocus()
     appIcon.draw(
-      in: NSRect(origin: .zero, size: size),
+      in: drawRect,
       from: NSRect(origin: .zero, size: appIcon.size),
       operation: .copy,
       fraction: 1.0


### PR DESCRIPTION
## Summary
- scale the menu bar icon so its visible glyph occupies 89% of the 18pt menu bar canvas
- keep the status item image canvas at 18pt to avoid changing menu bar layout

## Verification
- xcodebuild -project Snapzy.xcodeproj -scheme Snapzy -destination 'platform=macOS' -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO build\n- built and launched a local ad-hoc test app from build/Snapzy.app\n\n## Notes\n- no debug app bundles, zip files, or packaging artifacts are included