### PR TITLE
Add option to hide menu bar icon

### DIFF
--- a/Snapzy/App/AppStatusBarController.swift
+++ b/Snapzy/App/AppStatusBarController.swift
@@ -52,7 +52,7 @@ final class AppStatusBarController: ObservableObject {
     self.updater = updater
     self.didDetectCrash = didCrash
 
-    setupStatusItem()
+    syncStatusItemVisibility()
     buildMenu()
     observeRecordingState()
 
@@ -118,7 +118,31 @@ final class AppStatusBarController: ObservableObject {
 
   // MARK: - Private Setup
 
+  func setMenuBarIconVisible(_ visible: Bool) {
+    UserDefaults.standard.set(visible, forKey: PreferencesKeys.showMenuBarIcon)
+    syncStatusItemVisibility()
+  }
+
+  var isMenuBarIconVisible: Bool {
+    statusItem != nil
+  }
+
+  private func syncStatusItemVisibility() {
+    let shouldShow = UserDefaults.standard.object(forKey: PreferencesKeys.showMenuBarIcon) as? Bool ?? true
+
+    if shouldShow {
+      setupStatusItem()
+    } else {
+      removeStatusItem()
+    }
+  }
+
   private func setupStatusItem() {
+    guard statusItem == nil else {
+      renderStatusItem()
+      return
+    }
+
     statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
 
     if let button = statusItem?.button {
@@ -128,6 +152,16 @@ final class AppStatusBarController: ObservableObject {
       button.sendAction(on: [.leftMouseUp, .rightMouseUp])
       renderStatusItem()
     }
+  }
+
+  private func removeStatusItem() {
+    guard let statusItem else { return }
+    processingSpinner?.stopAnimation(nil)
+    processingSpinner?.removeFromSuperview()
+    processingSpinner = nil
+    isProcessing = false
+    NSStatusBar.system.removeStatusItem(statusItem)
+    self.statusItem = nil
   }
 
   @objc private func statusBarButtonClicked(_ sender: NSStatusBarButton) {

--- a/Snapzy/App/SnapzyApp.swift
+++ b/Snapzy/App/SnapzyApp.swift
@@ -129,6 +129,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     coordinator?.applicationWillTerminate()
   }
 
+  func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+    guard didFinishLaunching else { return true }
+    let showsMenuBarIcon = UserDefaults.standard.object(forKey: PreferencesKeys.showMenuBarIcon) as? Bool ?? true
+    guard !showsMenuBarIcon else { return true }
+
+    AppStatusBarController.shared.openPreferencesWindow(tab: .general)
+    return false
+  }
+
   private enum DatabaseLaunchRecoveryAction {
     case repair
     case reset

--- a/Snapzy/Features/Preferences/Components/PreferencesGeneralSettingsView.swift
+++ b/Snapzy/Features/Preferences/Components/PreferencesGeneralSettingsView.swift
@@ -10,6 +10,7 @@ import Sparkle
 
 struct GeneralSettingsView: View {
   @AppStorage(PreferencesKeys.playSounds) private var playSounds = true
+  @AppStorage(PreferencesKeys.showMenuBarIcon) private var showMenuBarIcon = true
   @AppStorage(PreferencesKeys.exportLocation) private var exportLocation = ""
   @Environment(\.openWindow) private var openWindow
   @ObservedObject private var themeManager = ThemeManager.shared
@@ -35,6 +36,14 @@ struct GeneralSettingsView: View {
         SettingRow(icon: "speaker.wave.2", title: L10n.PreferencesGeneral.playSoundsTitle, description: L10n.PreferencesGeneral.playSoundsDescription) {
           Toggle("", isOn: $playSounds)
             .labelsHidden()
+        }
+
+        SettingRow(icon: "menubar.rectangle", title: L10n.PreferencesGeneral.menuBarIconTitle, description: L10n.PreferencesGeneral.menuBarIconDescription) {
+          Toggle("", isOn: $showMenuBarIcon)
+            .labelsHidden()
+            .onChange(of: showMenuBarIcon) { newValue in
+              AppStatusBarController.shared.setMenuBarIconVisible(newValue)
+            }
         }
       }
 

--- a/Snapzy/Resources/Localization/Features/Settings.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Settings.xcstrings
@@ -4463,6 +4463,28 @@
         }
       }
     },
+    "preferences-general.menu-bar-icon-description": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Access Snapzy from the menu bar. When hidden, open Snapzy again to show settings."
+          }
+        }
+      }
+    },
+    "preferences-general.menu-bar-icon-title": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show menu bar icon"
+          }
+        }
+      }
+    },
     "preferences-general.play-sounds-description": {
       "extractionState": "stale",
       "localizations": {

--- a/Snapzy/Shared/Localization/L10n.swift
+++ b/Snapzy/Shared/Localization/L10n.swift
@@ -1867,6 +1867,16 @@ enum L10n {
       defaultValue: "Audio feedback for captures",
       comment: "General preferences setting description"
     )
+    static let menuBarIconTitle = string(
+      "preferences-general.menu-bar-icon-title",
+      defaultValue: "Show menu bar icon",
+      comment: "General preferences setting title"
+    )
+    static let menuBarIconDescription = string(
+      "preferences-general.menu-bar-icon-description",
+      defaultValue: "Access Snapzy from the menu bar. When hidden, open Snapzy again to show settings.",
+      comment: "General preferences setting description"
+    )
     static let themeTitle = string(
       "preferences-general.theme-title",
       defaultValue: "Theme",


### PR DESCRIPTION
Hey again!

Small follow-up PR. Since Snapzy can already be driven mostly from shortcuts, I wanted to make the menu bar icon optional for people who prefer a cleaner menu bar, especially considering macOS 27 makes it harder for third-party menu bar managers to operate.

What it does:
- Adds a new option in Settings → General: “Show menu bar icon”
- When disabled, Snapzy removes its menu bar status item
- If the icon is hidden and Snapzy is already running, opening the app again brings up Settings so there’s still an easy way back in
- The default stays unchanged: the menu bar icon is visible unless the user turns it off

This is intentionally a small preference-level change, not a behavior change for existing users. It keeps the current menu bar workflow by default, but lets keyboard-heavy users hide the icon once they have their shortcuts set up.

Happy to adjust the wording or placement if you’d prefer it somewhere else.

Thanks!