### PR TITLE
fix: support Fn key in shortcut recording and matching

### DIFF
--- a/Snapzy/Features/Annotate/Services/AnnotateShortcutManager.swift
+++ b/Snapzy/Features/Annotate/Services/AnnotateShortcutManager.swift
@@ -347,6 +347,7 @@ final class AnnotateShortcutManager: ObservableObject {
     if config.modifiers & UInt32(shiftKey) != 0 { expected.insert(.shift) }
     if config.modifiers & UInt32(optionKey) != 0 { expected.insert(.option) }
     if config.modifiers & UInt32(controlKey) != 0 { expected.insert(.control) }
+    if config.modifiers & ShortcutConfig.functionCarbonModifier != 0 { expected.insert(.function) }
     return flags == expected
   }
 }

--- a/Snapzy/Services/Capture/CaptureOverlayShortcutSettings.swift
+++ b/Snapzy/Services/Capture/CaptureOverlayShortcutSettings.swift
@@ -55,7 +55,6 @@ struct CaptureOverlayShortcut: Equatable, Codable {
   }
 
   func matches(_ event: NSEvent) -> Bool {
-    guard !event.modifierFlags.contains(.function) else { return false }
     guard UInt32(event.keyCode) == keyCode else { return false }
     return Self.carbonModifiers(from: event) == modifiers
   }
@@ -76,7 +75,7 @@ struct CaptureOverlayShortcut: Equatable, Codable {
   }
 
   private static func isAllowedSingleKey(_ event: NSEvent) -> Bool {
-    guard event.modifierFlags.intersection([.command, .control, .option, .shift, .function]).isEmpty else {
+    guard event.modifierFlags.intersection([.command, .control, .option, .shift]).isEmpty else {
       return false
     }
     guard let character = event.charactersIgnoringModifiers?.lowercased().first else {

--- a/Snapzy/Services/Shortcuts/KeyboardShortcutManager.swift
+++ b/Snapzy/Services/Shortcuts/KeyboardShortcutManager.swift
@@ -13,6 +13,10 @@ struct ShortcutConfig: Equatable, Codable {
   let keyCode: UInt32
   let modifiers: UInt32
 
+  /// Custom bit used to store the Fn modifier flag.
+  /// Carbon does not provide a native Fn constant, so we use an otherwise-unused bit internally.
+  static let functionCarbonModifier: UInt32 = 0x2000
+
   /// Memberwise initializer
   init(keyCode: UInt32, modifiers: UInt32) {
     self.keyCode = keyCode
@@ -116,6 +120,7 @@ struct ShortcutConfig: Equatable, Codable {
     if modifiers & UInt32(shiftKey) != 0 { parts.append("⇧") }
     if modifiers & UInt32(optionKey) != 0 { parts.append("⌥") }
     if modifiers & UInt32(controlKey) != 0 { parts.append("⌃") }
+    if modifiers & Self.functionCarbonModifier != 0 { parts.append("fn") }
 
     let keyChar = Self.keyCodeToDisplayString(keyCode)
 
@@ -130,6 +135,7 @@ struct ShortcutConfig: Equatable, Codable {
     if modifiers & UInt32(shiftKey) != 0 { parts.append("⇧") }
     if modifiers & UInt32(optionKey) != 0 { parts.append("⌥") }
     if modifiers & UInt32(controlKey) != 0 { parts.append("⌃") }
+    if modifiers & Self.functionCarbonModifier != 0 { parts.append("fn") }
     parts.append(Self.keyCodeToDisplayString(keyCode))
     return parts
   }
@@ -144,6 +150,9 @@ struct ShortcutConfig: Equatable, Codable {
     if event.modifierFlags.contains(.shift) { carbonModifiers |= UInt32(shiftKey) }
     if event.modifierFlags.contains(.option) { carbonModifiers |= UInt32(optionKey) }
     if event.modifierFlags.contains(.control) { carbonModifiers |= UInt32(controlKey) }
+    if event.modifierFlags.contains(.function) {
+      carbonModifiers |= Self.functionCarbonModifier
+    }
 
     // Require at least one modifier
     guard carbonModifiers != 0 else { return nil }
@@ -248,6 +257,7 @@ struct ShortcutConfig: Equatable, Codable {
     case kVK_End: return "↘"
     case kVK_PageUp: return "⇞"
     case kVK_PageDown: return "⇟"
+    case 0x3F: return "fn"
     default: return "?"
     }
   }
@@ -1421,9 +1431,15 @@ final class KeyboardShortcutManager {
   ) {
     guard isShortcutEnabled(for: kind), let config else { return }
 
+    // Carbon does not support the Fn modifier, so strip it.
+    // If Fn was the only modifier, skip registration entirely since
+    // a modifier-less hotkey would fire on every key press.
+    let cleanModifiers = config.modifiers & ~ShortcutConfig.functionCarbonModifier
+    guard cleanModifiers != 0 else { return }
+
     let status = RegisterEventHotKey(
       config.keyCode,
-      config.modifiers,
+      cleanModifiers,
       hotkeyID,
       GetApplicationEventTarget(),
       0,
@@ -1451,9 +1467,14 @@ final class KeyboardShortcutManager {
   ) {
     guard isShortcutEnabled(for: parentKind), let config else { return }
 
+    // Carbon does not support the Fn modifier, so strip it.
+    // If Fn was the only modifier, skip registration entirely.
+    let cleanModifiers = config.modifiers & ~ShortcutConfig.functionCarbonModifier
+    guard cleanModifiers != 0 else { return }
+
     let status = RegisterEventHotKey(
       config.keyCode,
-      config.modifiers,
+      cleanModifiers,
       hotkeyID,
       GetApplicationEventTarget(),
       0,


### PR DESCRIPTION
## What changed

Added Fn (`.function`) modifier support across the shortcut system so users can record and use the Fn/globe key in keyboard shortcuts.

### Changes

**`KeyboardShortcutManager.swift` — `ShortcutConfig`**
- Added `functionCarbonModifier` constant (`0x2000`) — Carbon has no native Fn constant, so we use a custom bit internally
- `init(from:event:)` now recognizes `.function` modifier flag from NSEvent
- `displayString` / `displayParts` render `"fn"` when Fn modifier is set
- `keyCodeToString` handles `0x3F` (kVK_Function / globe key) → `"fn"`
- `registerShortcutIfNeeded` / `registerOverlayShortcutIfNeeded` strip the Fn bit before Carbon registration and skip if Fn was the only modifier (preventing a modifier‑less hotkey that would fire on every key press)

**`CaptureOverlayShortcutSettings.swift`**
- `matches(_:)` — removed `guard !event.modifierFlags.contains(.function)` that rejected Fn‑modified events
- `isAllowedSingleKey` — removed `.function` from the forbidden‑modifiers list so Fn+letter can be recorded as a single‑key shortcut

**`AnnotateShortcutManager.matchesShortcut(_:event:)`**
- Added `.function` flag comparison to properly match annotated action shortcuts that include Fn

### Limitations
- Carbon `RegisterEventHotKey` does not support Fn as a modifier. When Fn is the only modifier (e.g., `Fn+F1`), the shortcut is displayed but **not** registered globally (registering with zero modifiers would fire on every key press). When Fn is combined with other modifiers (e.g., `Fn+Cmd+F1`), the shortcut is registered with the other modifiers only — Fn is stripped.

### Testing
- [x] Build succeeds via `xcodebuild`
- [x] Debug app launches and runs
- [x] Shortcut recorder in Settings now accepts Fn + key presses
- [x] Display shows `fn` keycap correctly


Closes #305