### PR TITLE
Fix "stroke" localization strings for Spanish and French

### DIFF
--- a/Snapzy/Resources/Localization/Shared/Common.xcstrings
+++ b/Snapzy/Resources/Localization/Shared/Common.xcstrings
@@ -6649,13 +6649,13 @@
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Accidente cerebrovascular"
+            "value": "Trazo"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Accident vasculaire cérébral"
+            "value": "Tracé"
           }
         },
         "ja": {


### PR DESCRIPTION
Fix "stroke" localization.

Correct the Spanish and French translations to use the drawing meaning of "stroke" instead of the medical one.