### PR TITLE
[Feature]: Screenshot Stitching / Combine Images (closes #354)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,12 +163,21 @@ Snapzy registers the `snapzy://` URL scheme so launchers and automation tools ca
 | Screen recording      | `snapzy://record/screen`          |
 | Application recording | `snapzy://record/application`     |
 | Open Annotate         | `snapzy://open/annotate`          |
+| Combine images        | `snapzy://open/combine`           |
 | Open Video Editor     | `snapzy://open/video-editor`      |
 | Open Cloud Uploads    | `snapzy://open/cloud-uploads`     |
 | Open Capture History  | `snapzy://open/history`           |
 | Show shortcuts list   | `snapzy://show/shortcuts`         |
 | Open Settings         | `snapzy://settings`               |
 | Open Settings tab     | `snapzy://settings?tab=annotate`  |
+
+`snapzy://open/combine` opens the image picker. Automation tools can skip the
+picker by passing two or more URL-encoded local paths as repeated `file`
+parameters:
+
+```bash
+open 'snapzy://open/combine?file=/tmp/first.png&file=/tmp/second.png'
+```
 
 ## Development
 

--- a/Snapzy/App/AppStatusBarController.swift
+++ b/Snapzy/App/AppStatusBarController.swift
@@ -492,6 +492,17 @@ final class AppStatusBarController: ObservableObject {
     annotateItem.isEnabled = true
     menu?.addItem(annotateItem)
 
+    let combineImagesItem = NSMenuItem(
+      title: L10n.Combine.open,
+      action: #selector(openCombineImagesAction),
+      keyEquivalent: ""
+    )
+    combineImagesItem.target = self
+    combineImagesItem.image = NSImage(
+      systemSymbolName: "rectangle.3.group", accessibilityDescription: nil)
+    combineImagesItem.isEnabled = true
+    menu?.addItem(combineImagesItem)
+
     let editVideoItem = NSMenuItem(
       title: L10n.Menu.editVideo,
       action: #selector(editVideoAction),
@@ -675,6 +686,11 @@ final class AppStatusBarController: ObservableObject {
   @objc private func openAnnotateAction() {
     logMenuAction("openAnnotate")
     AnnotateManager.shared.openEmptyAnnotation()
+  }
+
+  @objc private func openCombineImagesAction() {
+    logMenuAction("openCombineImages")
+    CombineImagesCoordinator.shared.presentPicker()
   }
 
   @objc private func editVideoAction() {

--- a/Snapzy/App/SnapzyDeepLinkHandler.swift
+++ b/Snapzy/App/SnapzyDeepLinkHandler.swift
@@ -74,6 +74,13 @@ struct SnapzyDeepLinkHandler {
     case .openAnnotate:
       AnnotateManager.shared.openEmptyAnnotation()
       NSApp.activate(ignoringOtherApps: true)
+    case .openCombine(let fileURLs):
+      if fileURLs.count >= 2 {
+        AnnotateManager.shared.openCombineImages(urls: fileURLs)
+      } else {
+        CombineImagesCoordinator.shared.presentPicker()
+      }
+      NSApp.activate(ignoringOtherApps: true)
     case .openVideoEditor:
       VideoEditorManager.shared.openEmptyEditor()
       NSApp.activate(ignoringOtherApps: true)
@@ -104,6 +111,7 @@ enum SnapzyDeepLinkAction: Equatable {
   case recordScreen
   case recordApplication
   case openAnnotate
+  case openCombine([URL])
   case openVideoEditor
   case openCloudUploads
   case openHistory
@@ -145,6 +153,8 @@ enum SnapzyDeepLinkAction: Equatable {
       self = .recordApplication
     case "open/annotate", "annotate", "open-annotate":
       self = .openAnnotate
+    case "open/combine", "combine", "combine-images", "open-combine":
+      self = .openCombine(Self.combineFileURLs(from: components))
     case "open/video-editor", "video-editor", "edit-video", "open-video-editor":
       self = .openVideoEditor
     case "open/cloud-uploads", "cloud-uploads", "uploads", "open-uploads":
@@ -178,12 +188,25 @@ enum SnapzyDeepLinkAction: Equatable {
     case .recordScreen: return "recordScreen"
     case .recordApplication: return "recordApplication"
     case .openAnnotate: return "openAnnotate"
+    case .openCombine(let fileURLs): return "openCombine(\(fileURLs.count))"
     case .openVideoEditor: return "openVideoEditor"
     case .openCloudUploads: return "openCloudUploads"
     case .openHistory: return "openHistory"
     case .showShortcuts: return "showShortcuts"
     case .openSettings(let tab): return "openSettings(\(String(describing: tab)))"
     }
+  }
+
+  private static func combineFileURLs(from components: URLComponents?) -> [URL] {
+    components?.queryItems?
+      .filter { $0.name.lowercased() == "file" }
+      .compactMap { item in
+        guard let value = item.value, !value.isEmpty else { return nil }
+        if let url = URL(string: value), url.isFileURL {
+          return url.standardizedFileURL
+        }
+        return URL(fileURLWithPath: (value as NSString).expandingTildeInPath).standardizedFileURL
+      } ?? []
   }
 
   private static func preferencesTab(from components: URLComponents?, pathParts: [String]) -> PreferencesTab? {

--- a/Snapzy/Features/Annotate/AnnotateManager.swift
+++ b/Snapzy/Features/Annotate/AnnotateManager.swift
@@ -229,6 +229,30 @@ final class AnnotateManager {
     controller.handleManualOpenClipboardImageBehavior()
   }
 
+  func openCombineImages(urls: [URL]) {
+    guard urls.count >= 2, NSScreen.screens.isEmpty == false else { return }
+    becomeRegularApp()
+
+    let controller = AnnotateWindowController(combineImageURLs: urls)
+    let controllerID = UUID()
+    manualWindowControllers[controllerID] = controller
+
+    if let window = controller.window {
+      NotificationCenter.default.addObserver(
+        forName: NSWindow.willCloseNotification,
+        object: window,
+        queue: .main
+      ) { [weak self] _ in
+        MainActor.assumeIsolated {
+          self?.manualWindowControllers.removeValue(forKey: controllerID)
+          self?.becomeAccessoryAppIfNeeded()
+        }
+      }
+    }
+
+    controller.showWindow()
+  }
+
   // MARK: - Session Cache
 
   /// Save annotation session data for re-editing

--- a/Snapzy/Features/Annotate/AnnotateState.swift
+++ b/Snapzy/Features/Annotate/AnnotateState.swift
@@ -230,6 +230,120 @@ final class AnnotateState: ObservableObject {
   @Published var isPinned: Bool = false
   @Published private(set) var dragToAppPreparationState: DragToAppPreparationState
 
+  // MARK: - Combine Images
+
+  static let combineBaseLayerID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+
+  @Published private(set) var isCombineMode = false
+  @Published private(set) var combineMode: CombineImagesMode = .autoStitch
+  @Published private(set) var combineDirection: CombineImagesDirection = .smart
+  @Published private(set) var combineResolvedDirection: CombineImagesDirection = .horizontal
+  @Published private(set) var combineGap: CGFloat = 0
+  @Published private(set) var combineContentBounds: CGRect = .zero
+  @Published var frozenCombineContentBounds: CGRect?
+  let combineSnapTolerance: CGFloat = 14
+
+  private var freeCombineBoundsByAnnotationID: [UUID: CGRect] = [:]
+
+  var effectiveContentBounds: CGRect {
+    guard isCombineMode else { return sourceImageBounds }
+    return frozenCombineContentBounds ?? combineContentBounds
+  }
+
+  var combineImageCount: Int {
+    1 + annotations.reduce(into: 0) { count, annotation in
+      if case .embeddedImage = annotation.type { count += 1 }
+    }
+  }
+
+  func moveCombineImage(at index: Int, by offset: Int) {
+    guard isCombineMode, offset != 0, let sourceImage else { return }
+    let slots = annotations.compactMap { annotation -> UUID? in
+      guard case .embeddedImage(let assetID) = annotation.type else { return nil }
+      return assetID
+    }
+    var orderedImages = [sourceImage] + slots.compactMap { embeddedImageAssets[$0] }
+    guard orderedImages.count == slots.count + 1,
+          orderedImages.indices.contains(index) else { return }
+    let destination = index + offset
+    guard orderedImages.indices.contains(destination) else { return }
+
+    pushRotationUndo(currentRotationSnapshot())
+    let moved = orderedImages.remove(at: index)
+    orderedImages.insert(moved, at: destination)
+    self.sourceImage = orderedImages[0]
+    for (slotIndex, assetID) in slots.enumerated() {
+      embeddedImageAssets[assetID] = orderedImages[slotIndex + 1]
+      embeddedImageSourceData.removeValue(forKey: assetID)
+      embeddedImageSnapshotCacheData.removeValue(forKey: assetID)
+      embeddedImageCGImageCache.removeValue(forKey: assetID)
+    }
+    hasUnsavedChanges = true
+    refreshCombineLayout()
+  }
+
+  func activateCombineMode(preferredMode: CombineImagesMode = .autoStitch) {
+    guard hasImage else { return }
+    if !isCombineMode {
+      isCombineMode = true
+      showSidebar = true
+      selectedTool = .selection
+      captureCurrentFreeCombineBounds()
+    }
+    setCombineMode(preferredMode)
+  }
+
+  func deactivateCombineMode() {
+    guard isCombineMode else { return }
+    isCombineMode = false
+    combineContentBounds = sourceImageBounds
+    frozenCombineContentBounds = nil
+  }
+
+  func setCombineMode(_ mode: CombineImagesMode) {
+    guard isCombineMode else { return }
+    guard combineMode != mode else {
+      refreshCombineLayout()
+      return
+    }
+
+    if combineMode == .freeCanvas {
+      captureCurrentFreeCombineBounds()
+    }
+    combineMode = mode
+    switch mode {
+    case .autoStitch:
+      applyAutomaticCombineLayout()
+    case .freeCanvas:
+      restoreFreeCombineBounds()
+    }
+  }
+
+  func setCombineDirection(_ direction: CombineImagesDirection) {
+    combineDirection = direction
+    if isCombineMode, combineMode == .autoStitch {
+      applyAutomaticCombineLayout()
+    }
+  }
+
+  func setCombineGap(_ gap: CGFloat) {
+    combineGap = max(0, gap)
+    if isCombineMode, combineMode == .autoStitch {
+      applyAutomaticCombineLayout()
+    } else if isCombineMode {
+      updateCombineContentBounds()
+    }
+  }
+
+  func refreshCombineLayout() {
+    guard isCombineMode else { return }
+    if combineMode == .autoStitch {
+      applyAutomaticCombineLayout()
+    } else {
+      updateCombineContentBounds()
+    }
+  }
+
   static let minimumZoomLevel: CGFloat = 0.25
   static let defaultMaximumZoomLevel: CGFloat = 4.0
   static let hardMaximumZoomLevel: CGFloat = 16.0
@@ -1318,6 +1432,8 @@ final class AnnotateState: ObservableObject {
     let imageSize = normalizedCanvasImageSize(for: image)
     guard imageSize.width > 0, imageSize.height > 0 else { return }
 
+    activateCombineMode(preferredMode: combineMode)
+
     let placementBounds = importedImagePlacementBounds(for: imageSize)
     let assetId = UUID()
 
@@ -1334,6 +1450,8 @@ final class AnnotateState: ObservableObject {
       properties: AnnotationProperties(strokeColor: .clear, fillColor: .clear, strokeWidth: 1)
     )
     annotations.append(item)
+    freeCombineBoundsByAnnotationID[item.id] = placementBounds
+    refreshCombineLayout()
     selectedAnnotationId = item.id
     editingTextAnnotationId = nil
     selectedTool = .selection
@@ -1435,6 +1553,14 @@ final class AnnotateState: ObservableObject {
     embeddedImageSourceData.removeAll()
     embeddedImageSnapshotCacheData.removeAll()
     embeddedImageCGImageCache.removeAll()
+    isCombineMode = false
+    combineMode = .autoStitch
+    combineDirection = .smart
+    combineResolvedDirection = .horizontal
+    combineGap = 0
+    combineContentBounds = CGRect(origin: .zero, size: image.size)
+    frozenCombineContentBounds = nil
+    freeCombineBoundsByAnnotationID.removeAll()
     selectedAnnotationId = nil
     editingTextAnnotationId = nil
     undoStack.removeAll()
@@ -1885,7 +2011,81 @@ final class AnnotateState: ObservableObject {
     return CGSize(width: rep.pixelsWide, height: rep.pixelsHigh)
   }
 
+  private func combineLayoutItems() -> [CombineImagesLayoutItem] {
+    var items = [
+      CombineImagesLayoutItem(
+        id: Self.combineBaseLayerID,
+        size: CGSize(width: imageWidth, height: imageHeight)
+      )
+    ]
+    for annotation in annotations {
+      guard case .embeddedImage(let assetID) = annotation.type,
+            let image = embeddedImageAssets[assetID] else { continue }
+      let size = normalizedCanvasImageSize(for: image)
+      guard size.width > 0, size.height > 0 else { continue }
+      items.append(CombineImagesLayoutItem(id: annotation.id, size: size))
+    }
+    return items
+  }
+
+  private func applyAutomaticCombineLayout() {
+    guard isCombineMode, hasImage else { return }
+    let result = CombineImagesLayout.layout(
+      items: combineLayoutItems(),
+      direction: combineDirection,
+      gap: combineGap
+    )
+    combineResolvedDirection = result.direction
+    for index in annotations.indices {
+      guard case .embeddedImage = annotations[index].type,
+            let bounds = result.boundsByID[annotations[index].id] else { continue }
+      annotations[index].bounds = bounds
+    }
+    combineContentBounds = result.contentBounds.isEmpty ? sourceImageBounds : result.contentBounds
+  }
+
+  private func captureCurrentFreeCombineBounds() {
+    for annotation in annotations {
+      guard case .embeddedImage = annotation.type else { continue }
+      freeCombineBoundsByAnnotationID[annotation.id] = annotation.bounds
+    }
+  }
+
+  private func restoreFreeCombineBounds() {
+    for index in annotations.indices {
+      guard case .embeddedImage = annotations[index].type else { continue }
+      if let bounds = freeCombineBoundsByAnnotationID[annotations[index].id] {
+        annotations[index].bounds = bounds
+      } else {
+        freeCombineBoundsByAnnotationID[annotations[index].id] = annotations[index].bounds
+      }
+    }
+    updateCombineContentBounds()
+  }
+
+  private func updateCombineContentBounds() {
+    guard isCombineMode else {
+      combineContentBounds = sourceImageBounds
+      return
+    }
+    let imageBounds = annotations.compactMap { annotation -> CGRect? in
+      guard case .embeddedImage = annotation.type else { return nil }
+      return annotation.bounds
+    }
+    combineContentBounds = imageBounds.reduce(sourceImageBounds) { $0.union($1) }
+  }
+
   private func importedImagePlacementBounds(for imageSize: CGSize) -> CGRect {
+    if isCombineMode {
+      let baseHeight = max(imageHeight, 1)
+      let scale = baseHeight / max(imageSize.height, 1)
+      let targetSize = CGSize(width: imageSize.width * scale, height: baseHeight)
+      return CGRect(
+        origin: CGPoint(x: combineContentBounds.maxX + combineGap, y: combineContentBounds.minY),
+        size: targetSize
+      )
+    }
+
     let drawingBounds: CGRect
     if let cropRect = cropRect, !isCropActive {
       drawingBounds = cropRect
@@ -2057,6 +2257,7 @@ final class AnnotateState: ObservableObject {
        !annotations.contains(where: { $0.id == editingTextAnnotationId }) {
       self.editingTextAnnotationId = nil
     }
+    refreshCombineLayout()
   }
 
   private func applyRotationSnapshot(_ snapshot: RotationSnapshot) {
@@ -2528,6 +2729,12 @@ final class AnnotateState: ObservableObject {
       annotations[index].properties.strokeWidth = AnnotationProperties.controlValue(forCounterDiameter: diameter)
     default:
       break
+    }
+
+    if isCombineMode, combineMode == .freeCanvas,
+       case .embeddedImage = annotations[index].type {
+      freeCombineBoundsByAnnotationID[id] = annotations[index].bounds
+      updateCombineContentBounds()
     }
   }
 
@@ -4153,8 +4360,10 @@ final class AnnotateState: ObservableObject {
     ])
     saveState()
     annotations.removeAll { selectedIds.contains($0.id) }
+    selectedIds.forEach { freeCombineBoundsByAnnotationID.removeValue(forKey: $0) }
     pruneUnusedEmbeddedAssets()
     updateImportWarningIfNeeded()
+    refreshCombineLayout()
     deselectAnnotation()
   }
 

--- a/Snapzy/Features/Annotate/CombineImagesCoordinator.swift
+++ b/Snapzy/Features/Annotate/CombineImagesCoordinator.swift
@@ -1,0 +1,23 @@
+import AppKit
+import UniformTypeIdentifiers
+
+@MainActor
+final class CombineImagesCoordinator {
+  static let shared = CombineImagesCoordinator()
+
+  private init() {}
+
+  func presentPicker() {
+    let panel = NSOpenPanel()
+    panel.title = L10n.Combine.pickerTitle
+    panel.message = L10n.Combine.pickerMessage
+    panel.prompt = L10n.Combine.pickerConfirm
+    panel.allowedContentTypes = [.png, .jpeg, .webP, .gif, .tiff, .heic]
+    panel.allowsMultipleSelection = true
+    panel.canChooseDirectories = false
+
+    guard panel.runModal() == .OK, panel.urls.count >= 2 else { return }
+    AnnotateManager.shared.openCombineImages(urls: panel.urls)
+  }
+}
+

--- a/Snapzy/Features/Annotate/CombineImagesLayout.swift
+++ b/Snapzy/Features/Annotate/CombineImagesLayout.swift
@@ -1,0 +1,110 @@
+import CoreGraphics
+import Foundation
+
+enum CombineImagesMode: String, CaseIterable {
+  case autoStitch
+  case freeCanvas
+}
+
+enum CombineImagesDirection: String, CaseIterable {
+  case smart
+  case horizontal
+  case vertical
+}
+
+struct CombineImagesLayoutItem: Equatable {
+  let id: UUID
+  let size: CGSize
+}
+
+struct CombineImagesLayoutResult: Equatable {
+  let direction: CombineImagesDirection
+  let boundsByID: [UUID: CGRect]
+  let contentBounds: CGRect
+}
+
+enum CombineImagesLayout {
+  static func resolveDirection(
+    requested: CombineImagesDirection,
+    items: [CombineImagesLayoutItem],
+    gap: CGFloat = 0
+  ) -> CombineImagesDirection {
+    guard requested == .smart else { return requested }
+    guard let first = items.first, first.size.width > 0, first.size.height > 0 else {
+      return .horizontal
+    }
+
+    let horizontalWidth = items.reduce(CGFloat.zero) { total, item in
+      total + scaledSize(item.size, matchingHeight: first.size.height).width
+    } + gap * CGFloat(max(items.count - 1, 0))
+    let horizontalAspect = horizontalWidth / first.size.height
+
+    let verticalHeight = items.reduce(CGFloat.zero) { total, item in
+      total + scaledSize(item.size, matchingWidth: first.size.width).height
+    } + gap * CGFloat(max(items.count - 1, 0))
+    let verticalAspect = first.size.width / verticalHeight
+
+    // Prefer the arrangement closest to a useful landscape canvas while avoiding
+    // extremely long strips in either direction.
+    let preferredAspect: CGFloat = 1.35
+    let horizontalDistance = abs(log(max(horizontalAspect, 0.0001) / preferredAspect))
+    let verticalDistance = abs(log(max(verticalAspect, 0.0001) / preferredAspect))
+    return horizontalDistance <= verticalDistance ? .horizontal : .vertical
+  }
+
+  static func layout(
+    items: [CombineImagesLayoutItem],
+    direction requestedDirection: CombineImagesDirection,
+    gap: CGFloat
+  ) -> CombineImagesLayoutResult {
+    guard let first = items.first, first.size.width > 0, first.size.height > 0 else {
+      return CombineImagesLayoutResult(
+        direction: requestedDirection == .vertical ? .vertical : .horizontal,
+        boundsByID: [:],
+        contentBounds: .zero
+      )
+    }
+
+    let direction = resolveDirection(requested: requestedDirection, items: items, gap: gap)
+    let safeGap = max(0, gap)
+    var cursor: CGFloat = 0
+    var boundsByID: [UUID: CGRect] = [:]
+
+    for item in items where item.size.width > 0 && item.size.height > 0 {
+      let targetSize: CGSize
+      let origin: CGPoint
+      switch direction {
+      case .horizontal, .smart:
+        targetSize = scaledSize(item.size, matchingHeight: first.size.height)
+        origin = CGPoint(x: cursor, y: 0)
+        cursor += targetSize.width + safeGap
+      case .vertical:
+        targetSize = scaledSize(item.size, matchingWidth: first.size.width)
+        origin = CGPoint(x: 0, y: cursor)
+        cursor += targetSize.height + safeGap
+      }
+      boundsByID[item.id] = CGRect(origin: origin, size: targetSize)
+    }
+
+    let allBounds = Array(boundsByID.values)
+    let contentBounds = allBounds.dropFirst().reduce(allBounds.first ?? .zero) { $0.union($1) }
+    return CombineImagesLayoutResult(
+      direction: direction,
+      boundsByID: boundsByID,
+      contentBounds: contentBounds
+    )
+  }
+
+  private static func scaledSize(_ size: CGSize, matchingHeight height: CGFloat) -> CGSize {
+    guard size.height > 0 else { return .zero }
+    let scale = height / size.height
+    return CGSize(width: size.width * scale, height: height)
+  }
+
+  private static func scaledSize(_ size: CGSize, matchingWidth width: CGFloat) -> CGSize {
+    guard size.width > 0 else { return .zero }
+    let scale = width / size.width
+    return CGSize(width: width, height: size.height * scale)
+  }
+}
+

--- a/Snapzy/Features/Annotate/CombineSnapping.swift
+++ b/Snapzy/Features/Annotate/CombineSnapping.swift
@@ -1,0 +1,69 @@
+import CoreGraphics
+import Foundation
+
+enum CombineSnapping {
+  static func resolve(
+    draggedBounds: CGRect,
+    candidateBounds: [CGRect],
+    gap: CGFloat,
+    tolerance: CGFloat
+  ) -> CGRect? {
+    var best: (bounds: CGRect, distance: CGFloat)?
+    let safeGap = max(0, gap)
+
+    for candidate in candidateBounds {
+      let xTargets = [
+        candidate.minX - safeGap - draggedBounds.width,
+        candidate.maxX + safeGap
+      ]
+      let yTargets = [
+        candidate.minY - safeGap - draggedBounds.height,
+        candidate.maxY + safeGap
+      ]
+
+      for x in xTargets {
+        let distance = abs(draggedBounds.minX - x)
+        guard distance <= tolerance else { continue }
+        let alignedY = nearestAlignment(
+          currentMin: draggedBounds.minY,
+          currentMax: draggedBounds.maxY,
+          candidateMin: candidate.minY,
+          candidateMax: candidate.maxY,
+          tolerance: tolerance
+        ) ?? draggedBounds.minY
+        let bounds = CGRect(x: x.rounded(), y: alignedY.rounded(), width: draggedBounds.width, height: draggedBounds.height)
+        if best == nil || distance < best!.distance { best = (bounds, distance) }
+      }
+
+      for y in yTargets {
+        let distance = abs(draggedBounds.minY - y)
+        guard distance <= tolerance else { continue }
+        let alignedX = nearestAlignment(
+          currentMin: draggedBounds.minX,
+          currentMax: draggedBounds.maxX,
+          candidateMin: candidate.minX,
+          candidateMax: candidate.maxX,
+          tolerance: tolerance
+        ) ?? draggedBounds.minX
+        let bounds = CGRect(x: alignedX.rounded(), y: y.rounded(), width: draggedBounds.width, height: draggedBounds.height)
+        if best == nil || distance < best!.distance { best = (bounds, distance) }
+      }
+    }
+    return best?.bounds
+  }
+
+  private static func nearestAlignment(
+    currentMin: CGFloat,
+    currentMax: CGFloat,
+    candidateMin: CGFloat,
+    candidateMax: CGFloat,
+    tolerance: CGFloat
+  ) -> CGFloat? {
+    let options = [
+      (candidateMin, abs(currentMin - candidateMin)),
+      (candidateMax - (currentMax - currentMin), abs(currentMax - candidateMax))
+    ]
+    return options.min(by: { $0.1 < $1.1 }).flatMap { $0.1 <= tolerance ? $0.0 : nil }
+  }
+}
+

--- a/Snapzy/Features/Annotate/Components/AnnotateCanvasDrawingView.swift
+++ b/Snapzy/Features/Annotate/Components/AnnotateCanvasDrawingView.swift
@@ -378,7 +378,9 @@ final class DrawingCanvasNSView: NSView {
 
   /// Clamp point to the active drawing bounds. Applied expanded crops become drawable canvas.
   private func clampToCanvasBounds(_ point: CGPoint) -> CGPoint {
-    let bounds = state.activeAnnotationBounds.standardized
+    let bounds = state.isCombineMode
+      ? state.effectiveContentBounds.standardized
+      : state.activeAnnotationBounds.standardized
     return CGPoint(
       x: max(bounds.minX, min(point.x, bounds.maxX)),
       y: max(bounds.minY, min(point.y, bounds.maxY))
@@ -394,6 +396,9 @@ final class DrawingCanvasNSView: NSView {
   // MARK: - Mouse Events
 
   override func mouseDown(with event: NSEvent) {
+    if state.isCombineMode {
+      state.frozenCombineContentBounds = state.combineContentBounds
+    }
     let displayPoint = convert(event.locationInWindow, from: nil)
     let imagePoint = interactionPoint(from: displayPoint)
     dragStart = imagePoint // Store in image coords
@@ -424,7 +429,8 @@ final class DrawingCanvasNSView: NSView {
     // Check if clicking on a selected annotation's handle (use display coords for handles)
     if let selectedId = state.selectedAnnotationId,
        let annotation = state.annotations.first(where: { $0.id == selectedId }),
-       annotation.supportsResize {
+       annotation.supportsResize,
+       canResizeAnnotation(annotation) {
       if let handle = hitTestHandle(at: displayPoint, for: annotation, inDisplayCoordinates: true) {
         isResizingAnnotation = true
         resizingAnnotationId = selectedId
@@ -497,6 +503,13 @@ final class DrawingCanvasNSView: NSView {
   }
 
   private func beginAnnotationDrag(anchor annotation: AnnotationItem, at imagePoint: CGPoint) {
+    if state.isCombineMode, state.combineMode == .autoStitch,
+       case .embeddedImage = annotation.type {
+      state.setSelectedAnnotationIds([annotation.id])
+      needsDisplay = true
+      return
+    }
+
     let activeIds: Set<UUID> = if state.isAnnotationSelected(annotation.id), !state.selectedAnnotationIds.isEmpty {
       state.selectedAnnotationIds
     } else {
@@ -519,6 +532,12 @@ final class DrawingCanvasNSView: NSView {
     )
     NSCursor.closedHand.set()
     needsDisplay = true
+  }
+
+  private func canResizeAnnotation(_ annotation: AnnotationItem) -> Bool {
+    guard state.isCombineMode, state.combineMode == .autoStitch else { return true }
+    if case .embeddedImage = annotation.type { return false }
+    return true
   }
 
   private func beginAreaSelection(at imagePoint: CGPoint) {
@@ -576,7 +595,17 @@ final class DrawingCanvasNSView: NSView {
         case .lineEnd:
           state.updateLineEndpoint(id: resizeId, end: imagePoint)
         default:
-          let newBounds = calculateResizedBounds(handle: handle, currentPoint: imagePoint)
+          let isEmbeddedImage = state.annotations.first(where: { $0.id == resizeId }).map {
+            if case .embeddedImage = $0.type { return true }
+            return false
+          } ?? false
+          let proportional = event.modifierFlags.contains(.shift)
+            || (state.isCombineMode && isEmbeddedImage)
+          let newBounds = calculateResizedBounds(
+            handle: handle,
+            currentPoint: imagePoint,
+            proportional: proportional
+          )
           state.updateAnnotationBounds(id: resizeId, bounds: newBounds)
         }
       }
@@ -629,6 +658,26 @@ final class DrawingCanvasNSView: NSView {
           )
           state.updateAnnotationBounds(id: id, bounds: newBounds)
         }
+
+        if state.isCombineMode,
+           state.combineMode == .freeCanvas,
+           activeIds.count == 1,
+           let draggedID = activeIds.first,
+           let dragged = state.annotations.first(where: { $0.id == draggedID }),
+           case .embeddedImage = dragged.type {
+          let candidates = [state.sourceImageBounds] + state.annotations.compactMap { annotation -> CGRect? in
+            guard annotation.id != draggedID, case .embeddedImage = annotation.type else { return nil }
+            return annotation.bounds
+          }
+          if let snapped = CombineSnapping.resolve(
+            draggedBounds: dragged.bounds,
+            candidateBounds: candidates,
+            gap: state.combineGap,
+            tolerance: state.combineSnapTolerance
+          ) {
+            state.updateAnnotationBounds(id: draggedID, bounds: snapped)
+          }
+        }
       }
       needsDisplay = true
       return
@@ -656,6 +705,9 @@ final class DrawingCanvasNSView: NSView {
   }
 
   override func mouseUp(with event: NSEvent) {
+    if state.isCombineMode {
+      state.frozenCombineContentBounds = nil
+    }
     let displayPoint = convert(event.locationInWindow, from: nil)
     let imagePoint = interactionPoint(from: displayPoint)
 
@@ -737,7 +789,11 @@ final class DrawingCanvasNSView: NSView {
     needsDisplay = true
   }
 
-  private func calculateResizedBounds(handle: ResizeHandle, currentPoint: CGPoint) -> CGRect {
+  private func calculateResizedBounds(
+    handle: ResizeHandle,
+    currentPoint: CGPoint,
+    proportional: Bool = false
+  ) -> CGRect {
     let minSize: CGFloat = 20
     var newBounds = originalBounds
 
@@ -772,7 +828,34 @@ final class DrawingCanvasNSView: NSView {
       break
     }
 
-    return newBounds
+    guard proportional, originalBounds.width > 0, originalBounds.height > 0 else {
+      return newBounds
+    }
+
+    let aspectRatio = originalBounds.width / originalBounds.height
+    if newBounds.width / max(newBounds.height, 1) > aspectRatio {
+      newBounds.size.width = newBounds.height * aspectRatio
+    } else {
+      newBounds.size.height = newBounds.width / aspectRatio
+    }
+
+    switch handle {
+    case .topLeft:
+      newBounds.origin.x = originalBounds.maxX - newBounds.width
+      newBounds.origin.y = originalBounds.minY
+    case .topRight:
+      newBounds.origin.x = originalBounds.minX
+      newBounds.origin.y = originalBounds.minY
+    case .bottomLeft:
+      newBounds.origin.x = originalBounds.maxX - newBounds.width
+      newBounds.origin.y = originalBounds.maxY - newBounds.height
+    case .bottomRight:
+      newBounds.origin.x = originalBounds.minX
+      newBounds.origin.y = originalBounds.maxY - newBounds.height
+    default:
+      break
+    }
+    return newBounds.standardized
   }
 
   // MARK: - Annotation Creation

--- a/Snapzy/Features/Annotate/Components/AnnotateCanvasView.swift
+++ b/Snapzy/Features/Annotate/Components/AnnotateCanvasView.swift
@@ -188,10 +188,13 @@ struct AnnotateCanvasView: View {
     let alignmentSpace: CGFloat = state.imageAlignment != .center ? 40 : 0
 
     let imageBounds = state.sourceImageBounds
+    let combineBounds = state.effectiveContentBounds
     let cropBounds = state.cropRect?.standardized
 
     let fitBounds: CGRect
-    if let cropBounds, !state.isCropActive {
+    if state.isCombineMode {
+      fitBounds = combineBounds
+    } else if let cropBounds, !state.isCropActive {
       fitBounds = cropBounds
     } else {
       fitBounds = imageBounds
@@ -199,18 +202,22 @@ struct AnnotateCanvasView: View {
 
     // Scale is tied to the currently fitted image/crop, not to the live crop rect.
     // This keeps crop dimensions predictable while users drag handles outward.
-    let fitLogicalCanvasSize = state.aspectRatio.canvasSize(
-      for: fitBounds.size,
-      padding: currentPadding,
-      alignmentSpace: alignmentSpace,
-      orientation: state.aspectRatioOrientation
-    )
+    let fitLogicalCanvasSize = state.isCombineMode
+      ? CGSize(width: fitBounds.width + currentPadding * 2, height: fitBounds.height + currentPadding * 2)
+      : state.aspectRatio.canvasSize(
+        for: fitBounds.size,
+        padding: currentPadding,
+        alignmentSpace: alignmentSpace,
+        orientation: state.aspectRatioOrientation
+      )
     let scaleX = availableWidth / fitLogicalCanvasSize.width
     let scaleY = availableHeight / fitLogicalCanvasSize.height
     let scale = min(scaleX, scaleY, 1.0)
 
     let foregroundBounds: CGRect
-    if let cropBounds {
+    if state.isCombineMode {
+      foregroundBounds = combineBounds
+    } else if let cropBounds {
       if state.isCropActive {
         foregroundBounds = cropWorkspaceBounds(
           for: imageBounds,
@@ -224,12 +231,14 @@ struct AnnotateCanvasView: View {
       foregroundBounds = imageBounds
     }
 
-    let logicalCanvasSize = state.aspectRatio.canvasSize(
-      for: foregroundBounds.size,
-      padding: currentPadding,
-      alignmentSpace: alignmentSpace,
-      orientation: state.aspectRatioOrientation
-    )
+    let logicalCanvasSize = state.isCombineMode
+      ? CGSize(width: foregroundBounds.width + currentPadding * 2, height: foregroundBounds.height + currentPadding * 2)
+      : state.aspectRatio.canvasSize(
+        for: foregroundBounds.size,
+        padding: currentPadding,
+        alignmentSpace: alignmentSpace,
+        orientation: state.aspectRatioOrientation
+      )
 
     // Background = logical canvas * scale (includes padding + alignment space)
     let bgWidth = logicalCanvasSize.width * scale
@@ -243,7 +252,7 @@ struct AnnotateCanvasView: View {
     let foregroundWidth = foregroundBounds.width * scale
     let foregroundHeight = foregroundBounds.height * scale
     let foregroundDisplaySize = CGSize(width: foregroundWidth, height: foregroundHeight)
-    let offset = state.imageOffset(
+    let offset = state.isCombineMode ? .zero : state.imageOffset(
       for: CGSize(width: bgWidth, height: bgHeight),
       imageDisplaySize: foregroundDisplaySize,
       displayPadding: currentPadding * scale
@@ -288,6 +297,10 @@ struct AnnotateCanvasView: View {
           .offset(x: offset.x, y: offset.y)
         }
       }
+      .modifier(CombineCanvasClipModifier(
+        isEnabled: state.isCombineMode,
+        cornerRadius: state.effectiveCornerRadius * scale
+      ))
       .scaleEffect(state.zoomLevel)
       .offset(x: state.panOffset.width, y: state.panOffset.height)
     }
@@ -579,6 +592,20 @@ struct AnnotateCanvasView: View {
       return false
     }
     return supportedImageTypes.contains { type.conforms(to: $0) }
+  }
+}
+
+private struct CombineCanvasClipModifier: ViewModifier {
+  let isEnabled: Bool
+  let cornerRadius: CGFloat
+
+  @ViewBuilder
+  func body(content: Content) -> some View {
+    if isEnabled {
+      content.clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+    } else {
+      content
+    }
   }
 }
 

--- a/Snapzy/Features/Annotate/Components/AnnotateCanvasView.swift
+++ b/Snapzy/Features/Annotate/Components/AnnotateCanvasView.swift
@@ -14,6 +14,50 @@ private struct AnnotateViewportMetrics: Equatable {
   let fitScale: CGFloat
 }
 
+struct AnnotateDroppedImage {
+  let image: NSImage
+  let data: Data?
+}
+
+enum AnnotateImageDropLoader {
+  @discardableResult
+  static func load(
+    from provider: NSItemProvider,
+    completion: @escaping (AnnotateDroppedImage?) -> Void
+  ) -> Bool {
+    if provider.canLoadObject(ofClass: NSImage.self) {
+      provider.loadObject(ofClass: NSImage.self) { object, _ in
+        guard let image = object as? NSImage else {
+          completion(nil)
+          return
+        }
+        completion(AnnotateDroppedImage(image: image, data: image.tiffRepresentation))
+      }
+      return true
+    }
+
+    guard provider.hasItemConformingToTypeIdentifier(UTType.image.identifier) else {
+      return false
+    }
+
+    provider.loadFileRepresentation(forTypeIdentifier: UTType.image.identifier) { url, error in
+      guard error == nil, let url else {
+        completion(nil)
+        return
+      }
+
+      defer { try? FileManager.default.removeItem(at: url) }
+      guard let data = try? Data(contentsOf: url),
+            let image = NSImage(data: data) else {
+        completion(nil)
+        return
+      }
+      completion(AnnotateDroppedImage(image: image, data: data))
+    }
+    return true
+  }
+}
+
 /// Canvas view for displaying and annotating the image
 struct AnnotateCanvasView: View {
   @ObservedObject var state: AnnotateState
@@ -529,56 +573,26 @@ struct AnnotateCanvasView: View {
   /// Handle dropped image files
   private func handleDrop(providers: [NSItemProvider]) -> Bool {
     for provider in providers {
-      // Try file URL first
-      if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
-        provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier) { item, error in
-          guard error == nil,
-                let data = item as? Data,
-                let url = URL(dataRepresentation: data, relativeTo: nil) else {
-            Task { @MainActor in
-              showError("Failed to load file")
-            }
-            return
-          }
-
-          // Validate file type
-          guard Self.isValidImageFile(url: url) else {
-            Task { @MainActor in
-              showError("Unsupported format. Use PNG, JPG, GIF, TIFF, BMP, or HEIC")
-            }
-            return
-          }
-
+      let didAccept = AnnotateImageDropLoader.load(from: provider) { droppedImage in
+        guard let droppedImage else {
           Task { @MainActor in
-            if !state.importImage(from: url) {
-              showError("Failed to import image")
-            }
+            showError("Failed to load image data")
+          }
+          return
+        }
+
+        Task { @MainActor in
+          if !state.importImage(
+            droppedImage.image,
+            sourceURL: nil,
+            sourceData: droppedImage.data
+          ) {
+            showError("Failed to import image")
           }
         }
-        return true
+        return
       }
-
-      // Try loading image data directly
-      for imageType in Self.supportedImageTypes {
-        if provider.hasItemConformingToTypeIdentifier(imageType.identifier) {
-          provider.loadDataRepresentation(forTypeIdentifier: imageType.identifier) { data, error in
-            guard let data = data,
-                  let image = NSImage(data: data) else {
-              Task { @MainActor in
-                showError("Failed to load image data")
-              }
-              return
-            }
-
-            Task { @MainActor in
-              if !state.importImage(image, sourceURL: nil, sourceData: data) {
-                showError("Failed to import image")
-              }
-            }
-          }
-          return true
-        }
-      }
+      if didAccept { return true }
     }
 
     // No valid provider found

--- a/Snapzy/Features/Annotate/Components/AnnotateCombineControlsView.swift
+++ b/Snapzy/Features/Annotate/Components/AnnotateCombineControlsView.swift
@@ -16,7 +16,7 @@ struct AnnotateCombineModePicker: View {
     }
     .pickerStyle(.segmented)
     .labelsHidden()
-    .frame(width: 210)
+    .frame(maxWidth: .infinity)
   }
 }
 
@@ -25,6 +25,13 @@ struct AnnotateCombineControlsView: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: Spacing.md) {
+      VStack(alignment: .leading, spacing: Spacing.sm) {
+        SidebarSectionHeader(title: L10n.Combine.mode)
+        AnnotateCombineModePicker(state: state)
+      }
+
+      Divider().background(Color(nsColor: .separatorColor))
+
       directionSection
 
       Divider().background(Color(nsColor: .separatorColor))

--- a/Snapzy/Features/Annotate/Components/AnnotateCombineControlsView.swift
+++ b/Snapzy/Features/Annotate/Components/AnnotateCombineControlsView.swift
@@ -1,0 +1,149 @@
+import SwiftUI
+
+struct AnnotateCombineModePicker: View {
+  @ObservedObject var state: AnnotateState
+
+  var body: some View {
+    Picker(
+      L10n.Combine.mode,
+      selection: Binding(
+        get: { state.combineMode },
+        set: { state.setCombineMode($0) }
+      )
+    ) {
+      Text(L10n.Combine.autoStitch).tag(CombineImagesMode.autoStitch)
+      Text(L10n.Combine.freeCanvas).tag(CombineImagesMode.freeCanvas)
+    }
+    .pickerStyle(.segmented)
+    .labelsHidden()
+    .frame(width: 210)
+  }
+}
+
+struct AnnotateCombineControlsView: View {
+  @ObservedObject var state: AnnotateState
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: Spacing.md) {
+      directionSection
+
+      Divider().background(Color(nsColor: .separatorColor))
+
+      imageOrderSection
+
+      Divider().background(Color(nsColor: .separatorColor))
+
+      VStack(alignment: .leading, spacing: Spacing.sm) {
+        SidebarSectionHeader(title: L10n.Combine.spacing)
+        CompactSliderRow(
+          label: L10n.Combine.imageGap,
+          value: Binding(
+            get: { state.combineGap },
+            set: { state.setCombineGap($0) }
+          ),
+          range: 0 ... 80
+        )
+      }
+      .disabled(state.combineMode == .freeCanvas)
+      .opacity(state.combineMode == .freeCanvas ? 0.45 : 1)
+
+      Divider().background(Color(nsColor: .separatorColor))
+    }
+  }
+
+  private var imageOrderSection: some View {
+    VStack(alignment: .leading, spacing: Spacing.sm) {
+      HStack {
+        SidebarSectionHeader(title: L10n.Combine.images)
+        Spacer()
+        Text("\(state.combineImageCount)")
+          .font(Typography.labelSmall)
+          .foregroundColor(SidebarColors.labelSecondary)
+      }
+
+      ForEach(0 ..< state.combineImageCount, id: \.self) { index in
+        HStack(spacing: Spacing.xs) {
+          Image(systemName: "photo")
+            .foregroundColor(.accentColor)
+          Text(L10n.Combine.image(index + 1))
+            .font(Typography.labelSmall)
+          Spacer()
+          Button {
+            state.moveCombineImage(at: index, by: -1)
+          } label: {
+            Image(systemName: "chevron.up")
+          }
+          .buttonStyle(.borderless)
+          .disabled(index == 0)
+          .help(L10n.Combine.moveEarlier)
+
+          Button {
+            state.moveCombineImage(at: index, by: 1)
+          } label: {
+            Image(systemName: "chevron.down")
+          }
+          .buttonStyle(.borderless)
+          .disabled(index == state.combineImageCount - 1)
+          .help(L10n.Combine.moveLater)
+        }
+        .padding(.horizontal, Spacing.sm)
+        .padding(.vertical, 6)
+        .background(
+          RoundedRectangle(cornerRadius: Size.radiusSm)
+            .fill(SidebarColors.itemDefault)
+        )
+      }
+    }
+  }
+
+  private var directionSection: some View {
+    VStack(alignment: .leading, spacing: Spacing.sm) {
+      HStack {
+        SidebarSectionHeader(title: L10n.Combine.arrangement)
+        Spacer()
+        if state.combineDirection == .smart {
+          Text(state.combineResolvedDirection == .horizontal ? L10n.Combine.horizontal : L10n.Combine.vertical)
+            .font(Typography.labelSmall)
+            .foregroundColor(SidebarColors.labelSecondary)
+        }
+      }
+
+      HStack(spacing: Spacing.xs) {
+        directionButton(.smart, title: L10n.Combine.smart, icon: "sparkles")
+        directionButton(.horizontal, title: L10n.Combine.horizontal, icon: "rectangle.split.3x1")
+        directionButton(.vertical, title: L10n.Combine.vertical, icon: "rectangle.split.1x2")
+      }
+    }
+    .disabled(state.combineMode == .freeCanvas)
+    .opacity(state.combineMode == .freeCanvas ? 0.45 : 1)
+  }
+
+  private func directionButton(
+    _ direction: CombineImagesDirection,
+    title: String,
+    icon: String
+  ) -> some View {
+    Button {
+      state.setCombineDirection(direction)
+    } label: {
+      VStack(spacing: 4) {
+        Image(systemName: icon)
+          .font(.system(size: 12, weight: .medium))
+        Text(title)
+          .font(Typography.labelSmall)
+          .lineLimit(1)
+      }
+      .frame(maxWidth: .infinity, minHeight: 38)
+      .foregroundColor(state.combineDirection == direction ? .white : SidebarColors.labelSecondary)
+      .background(
+        RoundedRectangle(cornerRadius: Size.radiusSm)
+          .fill(state.combineDirection == direction ? Color.accentColor.opacity(0.75) : SidebarColors.itemDefault)
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: Size.radiusSm)
+          .stroke(state.combineDirection == direction ? Color.accentColor : Color.clear, lineWidth: 1)
+      )
+    }
+    .buttonStyle(.plain)
+  }
+}

--- a/Snapzy/Features/Annotate/Components/AnnotateSidebarView.swift
+++ b/Snapzy/Features/Annotate/Components/AnnotateSidebarView.swift
@@ -26,6 +26,11 @@ private struct AnnotateSidebarSnapshot: Equatable {
   let selectedCanvasPresetId: UUID?
   let isSelectedCanvasPresetDirty: Bool
   let defaultCanvasPresetId: UUID?
+  let isCombineMode: Bool
+  let combineMode: CombineImagesMode
+  let combineDirection: CombineImagesDirection
+  let combineResolvedDirection: CombineImagesDirection
+  let combineGap: CGFloat
 
   init(state: AnnotateState) {
     editorMode = state.editorMode
@@ -45,6 +50,11 @@ private struct AnnotateSidebarSnapshot: Equatable {
     selectedCanvasPresetId = state.selectedCanvasPresetId
     isSelectedCanvasPresetDirty = state.isSelectedCanvasPresetDirty
     defaultCanvasPresetId = state.defaultCanvasPresetId
+    isCombineMode = state.isCombineMode
+    combineMode = state.combineMode
+    combineDirection = state.combineDirection
+    combineResolvedDirection = state.combineResolvedDirection
+    combineGap = state.combineGap
   }
 }
 
@@ -66,6 +76,10 @@ struct AnnotateSidebarView: View, Equatable {
   var body: some View {
     ScrollView(.vertical, showsIndicators: true) {
       VStack(alignment: .leading, spacing: Spacing.md) {
+        if state.isCombineMode {
+          AnnotateCombineControlsView(state: state)
+        }
+
         presetControlsSection
 
         // Compact gradient section
@@ -86,10 +100,14 @@ struct AnnotateSidebarView: View, Equatable {
         slidersSection
 
         // Ratio section
-        ratioSection
+        if !state.isCombineMode {
+          ratioSection
+        }
 
         // Alignment section
-        alignmentSection
+        if !state.isCombineMode {
+          alignmentSection
+        }
 
         // Mockup section (shown when mockup mode is active)
         if state.editorMode == .mockup {

--- a/Snapzy/Features/Annotate/Components/AnnotateToolbarView.swift
+++ b/Snapzy/Features/Annotate/Components/AnnotateToolbarView.swift
@@ -44,7 +44,6 @@ struct AnnotateToolbarView: View {
         }
         .help(L10n.Combine.pickerTitle)
 
-        AnnotateCombineModePicker(state: state)
         ToolbarDivider()
       }
 

--- a/Snapzy/Features/Annotate/Components/AnnotateToolbarView.swift
+++ b/Snapzy/Features/Annotate/Components/AnnotateToolbarView.swift
@@ -37,6 +37,17 @@ struct AnnotateToolbarView: View {
 
       ToolbarDivider()
 
+      if state.isCombineMode {
+        ToolbarButton(icon: "photo.badge.plus", isSelected: false) {
+          guard let window = NSApp.keyWindow else { return }
+          NotificationCenter.default.post(name: .annotateAddImage, object: window)
+        }
+        .help(L10n.Combine.pickerTitle)
+
+        AnnotateCombineModePicker(state: state)
+        ToolbarDivider()
+      }
+
       Spacer()
 
       registeredActionButtons
@@ -230,7 +241,12 @@ struct AnnotateToolbarView: View {
   // MARK: - Actions
 
   private func saveAs() {
-    AnnotateExporter.saveAs(state: state, closeWindow: true)
+    if state.isCombineMode {
+      guard let window = NSApp.keyWindow else { return }
+      NotificationCenter.default.post(name: .annotateSave, object: window)
+    } else {
+      AnnotateExporter.saveAs(state: state, closeWindow: true)
+    }
   }
 
   private func done() {

--- a/Snapzy/Features/Annotate/Managers/AnnotateWindow.swift
+++ b/Snapzy/Features/Annotate/Managers/AnnotateWindow.swift
@@ -16,6 +16,7 @@ extension Notification.Name {
   static let annotateCloudUpload = Notification.Name("annotateCloudUpload")
   static let annotateAutoRedactSensitiveData = Notification.Name("annotateAutoRedactSensitiveData")
   static let annotatePasteImage = Notification.Name("annotatePasteImage")
+  static let annotateAddImage = Notification.Name("annotateAddImage")
   static let annotateTogglePin = Notification.Name("annotateTogglePin")
   static let annotateDragStarted = Notification.Name("annotateDragStarted")
   static let annotateDragEnded = Notification.Name("annotateDragEnded")

--- a/Snapzy/Features/Annotate/Managers/AnnotateWindowController.swift
+++ b/Snapzy/Features/Annotate/Managers/AnnotateWindowController.swift
@@ -143,6 +143,16 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
     setupSourceURLObservation()
   }
 
+  convenience init(combineImageURLs: [URL]) {
+    self.init()
+    guard let firstURL = combineImageURLs.first,
+          state.importImage(from: firstURL) else { return }
+    for url in combineImageURLs.dropFirst() {
+      _ = state.importImage(from: url)
+    }
+    state.activateCombineMode(preferredMode: .autoStitch)
+  }
+
   /// URL-only initializer for post-capture auto-open flow
   init(url: URL, sessionData: AnnotationSessionData? = nil) {
     self.quickAccessItemId = nil
@@ -639,6 +649,16 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
     }
 
     NotificationCenter.default.addObserver(
+      forName: .annotateAddImage,
+      object: window,
+      queue: .main
+    ) { [weak self] _ in
+      MainActor.assumeIsolated {
+        self?.performAddImages()
+      }
+    }
+
+    NotificationCenter.default.addObserver(
       forName: .annotateAutoRedactSensitiveData,
       object: window,
       queue: .main
@@ -799,6 +819,22 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
     return false
   }
 
+  private func performAddImages() {
+    guard let window else { return }
+    let panel = NSOpenPanel()
+    panel.title = L10n.Combine.pickerTitle
+    panel.prompt = L10n.Combine.pickerConfirm
+    panel.allowedContentTypes = [.png, .jpeg, .webP, .gif, .tiff, .heic]
+    panel.allowsMultipleSelection = true
+    panel.canChooseDirectories = false
+    panel.beginSheetModal(for: window) { [weak self] response in
+      guard response == .OK, let self else { return }
+      for url in panel.urls {
+        _ = self.state.importImage(from: url)
+      }
+    }
+  }
+
   private func importPasteboardImage(_ candidate: PasteboardImageCandidate) -> Bool {
     switch candidate {
     case .file(let url):
@@ -814,6 +850,11 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
   /// If previously uploaded to cloud, gate behind overwrite confirmation.
   private func performSave() {
     guard state.hasImage else { return }
+
+    if state.isCombineMode {
+      performCombineSave()
+      return
+    }
 
     // Cloud gate: if the rendered output differs from the uploaded file, require overwrite confirmation.
     if requiresCloudOverwriteConfirmation {
@@ -884,6 +925,7 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
       }
       if AnnotateExporter.save(state: self.state, to: url) {
         self.state.markAsSaved()
+        SoundManager.play("Pop")
         // Dismiss Quick Access card if present
         if let itemId = self.quickAccessItemId {
           QuickAccessManager.shared.dismissCard(id: itemId)
@@ -908,11 +950,38 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
   }
 
   private func generateFileName() -> String {
+    if state.isCombineMode {
+      let formatter = DateFormatter()
+      formatter.dateFormat = "yyyyMMdd-HHmmss"
+      return "combined-\(formatter.string(from: Date())).png"
+    }
     guard let url = state.sourceURL else { return L10n.AnnotateUI.defaultAnnotatedFileName }
     let baseName = url.deletingPathExtension().lastPathComponent
     // Use the source file's extension so the default matches the configured format
     let ext = url.pathExtension.isEmpty ? "png" : url.pathExtension
     return "\(baseName)_annotated.\(ext)"
+  }
+
+  private func performCombineSave() {
+    guard let window else { return }
+    let alert = NSAlert()
+    alert.messageText = L10n.Combine.saveTitle
+    alert.informativeText = L10n.Combine.saveMessage
+    alert.alertStyle = .informational
+    alert.addButton(withTitle: L10n.Combine.saveToFile)
+    alert.addButton(withTitle: L10n.Combine.copyToClipboard)
+    alert.addButton(withTitle: L10n.Common.cancel)
+    alert.beginSheetModal(for: window) { [weak self] response in
+      guard let self else { return }
+      switch response {
+      case .alertFirstButtonReturn:
+        self.performSaveAs()
+      case .alertSecondButtonReturn:
+        self.executeCopy()
+      default:
+        break
+      }
+    }
   }
 
   /// Copy = render once, copy to clipboard, update thumbnail, close, save in background.

--- a/Snapzy/Features/Annotate/Services/AnnotateExporter.swift
+++ b/Snapzy/Features/Annotate/Services/AnnotateExporter.swift
@@ -375,23 +375,27 @@ final class AnnotateExporter {
 
     // Determine effective bounds (crop or full image)
     let effectiveBounds: CGRect
-    if let cropRect = state.cropRect {
+    if state.isCombineMode {
+      effectiveBounds = state.effectiveContentBounds
+    } else if let cropRect = state.cropRect {
       effectiveBounds = cropRect
     } else {
       effectiveBounds = CGRect(origin: .zero, size: sourceImage.size)
     }
 
-    let padding = state.backgroundStyle != .none ? state.padding : 0
+    let padding = state.isCombineMode ? state.padding : (state.backgroundStyle != .none ? state.padding : 0)
 
     // Add alignment space for non-center alignments (matches preview)
     let alignmentSpace: CGFloat = state.imageAlignment != .center ? 40 : 0
 
-    let totalSize: NSSize = state.aspectRatio.canvasSize(
-      for: effectiveBounds.size,
-      padding: padding,
-      alignmentSpace: alignmentSpace,
-      orientation: state.aspectRatioOrientation
-    )
+    let totalSize: NSSize = state.isCombineMode
+      ? NSSize(width: effectiveBounds.width + padding * 2, height: effectiveBounds.height + padding * 2)
+      : state.aspectRatio.canvasSize(
+        for: effectiveBounds.size,
+        padding: padding,
+        alignmentSpace: alignmentSpace,
+        orientation: state.aspectRatioOrientation
+      )
     outputSizeDescription = "\(Int(totalSize.width))x\(Int(totalSize.height))"
 
     // Render at pixel resolution using NSBitmapImageRep for Retina quality
@@ -433,7 +437,7 @@ final class AnnotateExporter {
     let destX: CGFloat
     let destY: CGFloat
 
-    switch state.imageAlignment {
+    switch state.isCombineMode ? ImageAlignment.center : state.imageAlignment {
     case .center:
       destX = totalExtraWidth / 2
       destY = totalExtraHeight / 2
@@ -481,8 +485,9 @@ final class AnnotateExporter {
       in: context
     )
 
-    // Reset clip
-    context.resetClip()
+    if !state.isCombineMode {
+      context.resetClip()
+    }
 
     // Unified Spotlight overlay pass (drawn below other annotations, above base image).
     // Opacity sourced from per-item properties so exported image matches the on-screen appearance.
@@ -527,6 +532,10 @@ final class AnnotateExporter {
         imageY: destY
       )
       renderer.draw(offsetAnnotation)
+    }
+
+    if state.isCombineMode {
+      context.resetClip()
     }
 
     NSGraphicsContext.restoreGraphicsState()

--- a/Snapzy/Resources/Localization/Features/Combine.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Combine.xcstrings
@@ -1,0 +1,468 @@
+{
+  "sourceLanguage": "en",
+  "version": "1.0",
+  "strings": {
+    "combine.arrangement": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrangement"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "排列"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "排列"
+          }
+        }
+      }
+    },
+    "combine.auto-stitch": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto Stitch"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动拼接"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動拼接"
+          }
+        }
+      }
+    },
+    "combine.copy-to-clipboard": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy to Clipboard"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制到剪贴板"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製到剪貼簿"
+          }
+        }
+      }
+    },
+    "combine.free-canvas": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Free Canvas"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自由画布"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自由畫布"
+          }
+        }
+      }
+    },
+    "combine.horizontal": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Horizontal"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "横向"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "橫向"
+          }
+        }
+      }
+    },
+    "combine.image-gap": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Image Gap"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "图片间距"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "圖片間距"
+          }
+        }
+      }
+    },
+    "combine.image-index": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Image %d"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "图片 %d"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "圖片 %d"
+          }
+        }
+      }
+    },
+    "combine.images": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Images"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "图片"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "圖片"
+          }
+        }
+      }
+    },
+    "combine.mode": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Combine mode"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拼图模式"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拼圖模式"
+          }
+        }
+      }
+    },
+    "combine.move-earlier": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move Earlier"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "向前移动"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "向前移動"
+          }
+        }
+      }
+    },
+    "combine.move-later": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move Later"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "向后移动"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "向後移動"
+          }
+        }
+      }
+    },
+    "combine.open": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Combine Images"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拼图"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拼圖"
+          }
+        }
+      }
+    },
+    "combine.picker-confirm": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Combine"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开始拼图"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開始拼圖"
+          }
+        }
+      }
+    },
+    "combine.picker-message": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select two or more images."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请选择至少两张图片。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請選擇至少兩張圖片。"
+          }
+        }
+      }
+    },
+    "combine.picker-title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose Images to Combine"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择要拼接的图片"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇要拼接的圖片"
+          }
+        }
+      }
+    },
+    "combine.save-message": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose how to export the stitched result."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择如何导出拼接后的图片。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇如何匯出拼接後的圖片。"
+          }
+        }
+      }
+    },
+    "combine.save-title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save Combined Image"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存拼图"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "儲存拼圖"
+          }
+        }
+      }
+    },
+    "combine.save-to-file": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save to File…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存为文件…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "儲存為檔案…"
+          }
+        }
+      }
+    },
+    "combine.smart": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Smart"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "智能"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "智慧"
+          }
+        }
+      }
+    },
+    "combine.spacing": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spacing"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "间距"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "間距"
+          }
+        }
+      }
+    },
+    "combine.vertical": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vertical"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "纵向"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "縱向"
+          }
+        }
+      }
+    }
+  }
+}

--- a/Snapzy/Resources/Localization/Shared/Common.xcstrings
+++ b/Snapzy/Resources/Localization/Shared/Common.xcstrings
@@ -1,27 +1,6 @@
 {
   "sourceLanguage": "en",
   "strings": {
-    "combine.arrangement": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Arrangement"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"排列"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"排列"}}}},
-    "combine.auto-stitch": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Auto Stitch"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"自动拼接"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"自動拼接"}}}},
-    "combine.copy-to-clipboard": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Copy to Clipboard"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"复制到剪贴板"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"複製到剪貼簿"}}}},
-    "combine.free-canvas": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Free Canvas"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"自由画布"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"自由畫布"}}}},
-    "combine.horizontal": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Horizontal"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"横向"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"橫向"}}}},
-    "combine.image-gap": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Image Gap"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"图片间距"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"圖片間距"}}}},
-    "combine.image-index": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Image %d"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"图片 %d"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"圖片 %d"}}}},
-    "combine.images": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Images"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"图片"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"圖片"}}}},
-    "combine.mode": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Combine mode"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"拼图模式"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"拼圖模式"}}}},
-    "combine.move-earlier": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Move Earlier"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"向前移动"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"向前移動"}}}},
-    "combine.move-later": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Move Later"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"向后移动"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"向後移動"}}}},
-    "combine.open": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Combine Images"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"拼图"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"拼圖"}}}},
-    "combine.picker-confirm": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Combine"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"开始拼图"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"開始拼圖"}}}},
-    "combine.picker-message": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Select two or more images."}},"zh-Hans":{"stringUnit":{"state":"translated","value":"请选择至少两张图片。"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"請選擇至少兩張圖片。"}}}},
-    "combine.picker-title": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Choose Images to Combine"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"选择要拼接的图片"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"選擇要拼接的圖片"}}}},
-    "combine.save-message": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Choose how to export the stitched result."}},"zh-Hans":{"stringUnit":{"state":"translated","value":"选择如何导出拼接后的图片。"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"選擇如何匯出拼接後的圖片。"}}}},
-    "combine.save-title": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Save Combined Image"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"保存拼图"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"儲存拼圖"}}}},
-    "combine.save-to-file": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Save to File…"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"保存为文件…"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"儲存為檔案…"}}}},
-    "combine.smart": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Smart"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"智能"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"智慧"}}}},
-    "combine.spacing": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Spacing"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"间距"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"間距"}}}},
-    "combine.vertical": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Vertical"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"纵向"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"縱向"}}}},
     "action.capture-active-window": {
       "extractionState": "stale",
       "localizations": {

--- a/Snapzy/Resources/Localization/Shared/Common.xcstrings
+++ b/Snapzy/Resources/Localization/Shared/Common.xcstrings
@@ -1,6 +1,27 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "combine.arrangement": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Arrangement"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"排列"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"排列"}}}},
+    "combine.auto-stitch": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Auto Stitch"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"自动拼接"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"自動拼接"}}}},
+    "combine.copy-to-clipboard": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Copy to Clipboard"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"复制到剪贴板"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"複製到剪貼簿"}}}},
+    "combine.free-canvas": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Free Canvas"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"自由画布"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"自由畫布"}}}},
+    "combine.horizontal": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Horizontal"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"横向"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"橫向"}}}},
+    "combine.image-gap": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Image Gap"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"图片间距"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"圖片間距"}}}},
+    "combine.image-index": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Image %d"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"图片 %d"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"圖片 %d"}}}},
+    "combine.images": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Images"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"图片"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"圖片"}}}},
+    "combine.mode": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Combine mode"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"拼图模式"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"拼圖模式"}}}},
+    "combine.move-earlier": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Move Earlier"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"向前移动"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"向前移動"}}}},
+    "combine.move-later": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Move Later"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"向后移动"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"向後移動"}}}},
+    "combine.open": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Combine Images"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"拼图"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"拼圖"}}}},
+    "combine.picker-confirm": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Combine"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"开始拼图"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"開始拼圖"}}}},
+    "combine.picker-message": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Select two or more images."}},"zh-Hans":{"stringUnit":{"state":"translated","value":"请选择至少两张图片。"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"請選擇至少兩張圖片。"}}}},
+    "combine.picker-title": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Choose Images to Combine"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"选择要拼接的图片"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"選擇要拼接的圖片"}}}},
+    "combine.save-message": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Choose how to export the stitched result."}},"zh-Hans":{"stringUnit":{"state":"translated","value":"选择如何导出拼接后的图片。"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"選擇如何匯出拼接後的圖片。"}}}},
+    "combine.save-title": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Save Combined Image"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"保存拼图"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"儲存拼圖"}}}},
+    "combine.save-to-file": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Save to File…"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"保存为文件…"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"儲存為檔案…"}}}},
+    "combine.smart": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Smart"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"智能"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"智慧"}}}},
+    "combine.spacing": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Spacing"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"间距"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"間距"}}}},
+    "combine.vertical": {"localizations":{"en":{"stringUnit":{"state":"translated","value":"Vertical"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"纵向"}},"zh-Hant":{"stringUnit":{"state":"translated","value":"縱向"}}}},
     "action.capture-active-window": {
       "extractionState": "stale",
       "localizations": {

--- a/Snapzy/Resources/Localization/manifest.json
+++ b/Snapzy/Resources/Localization/manifest.json
@@ -128,6 +128,12 @@
         "permission-row.",
         "preferences-permissions."
       ]
+    },
+    {
+      "file": "Features/Combine.xcstrings",
+      "prefixes": [
+        "combine."
+      ]
     }
   ]
 }

--- a/Snapzy/Shared/Localization/L10n.swift
+++ b/Snapzy/Shared/Localization/L10n.swift
@@ -10,6 +10,7 @@ import Foundation
 enum L10n {
   private nonisolated static let tableMappings: [(prefix: String, tableName: String)] = [
     ("action.", "Common"),
+    ("combine.", "Common"),
     ("menu.", "Menubar"),
     ("common.", "Common"),
     ("whats-new.", "WhatsNew"),
@@ -725,6 +726,32 @@ enum L10n {
       defaultValue: "Quit Snapzy",
       comment: "Status bar menu item title for quitting the app"
     )
+  }
+
+  enum Combine {
+    static let mode = string("combine.mode", defaultValue: "Combine mode", comment: "Label for combine mode picker")
+    static let autoStitch = string("combine.auto-stitch", defaultValue: "Auto Stitch", comment: "Automatic image stitching mode")
+    static let freeCanvas = string("combine.free-canvas", defaultValue: "Free Canvas", comment: "Free image arrangement mode")
+    static let arrangement = string("combine.arrangement", defaultValue: "Arrangement", comment: "Combine arrangement section title")
+    static let spacing = string("combine.spacing", defaultValue: "Spacing", comment: "Combine spacing section title")
+    static let imageGap = string("combine.image-gap", defaultValue: "Image Gap", comment: "Gap between combined images")
+    static let images = string("combine.images", defaultValue: "Images", comment: "Combined image list title")
+    static func image(_ index: Int) -> String {
+      format("combine.image-index", defaultValue: "Image %d", comment: "Combined image list item", index)
+    }
+    static let moveEarlier = string("combine.move-earlier", defaultValue: "Move Earlier", comment: "Move combined image earlier")
+    static let moveLater = string("combine.move-later", defaultValue: "Move Later", comment: "Move combined image later")
+    static let smart = string("combine.smart", defaultValue: "Smart", comment: "Smart combine direction")
+    static let horizontal = string("combine.horizontal", defaultValue: "Horizontal", comment: "Horizontal combine direction")
+    static let vertical = string("combine.vertical", defaultValue: "Vertical", comment: "Vertical combine direction")
+    static let open = string("combine.open", defaultValue: "Combine Images", comment: "Open combine images action")
+    static let pickerTitle = string("combine.picker-title", defaultValue: "Choose Images to Combine", comment: "Combine image picker title")
+    static let pickerMessage = string("combine.picker-message", defaultValue: "Select two or more images.", comment: "Combine image picker message")
+    static let pickerConfirm = string("combine.picker-confirm", defaultValue: "Combine", comment: "Combine image picker confirmation")
+    static let saveTitle = string("combine.save-title", defaultValue: "Save Combined Image", comment: "Combine save dialog title")
+    static let saveMessage = string("combine.save-message", defaultValue: "Choose how to export the stitched result.", comment: "Combine save dialog message")
+    static let saveToFile = string("combine.save-to-file", defaultValue: "Save to File…", comment: "Save combined image to file")
+    static let copyToClipboard = string("combine.copy-to-clipboard", defaultValue: "Copy to Clipboard", comment: "Copy combined image to clipboard")
   }
 
   enum Common {

--- a/Snapzy/Shared/Localization/L10n.swift
+++ b/Snapzy/Shared/Localization/L10n.swift
@@ -10,7 +10,7 @@ import Foundation
 enum L10n {
   private nonisolated static let tableMappings: [(prefix: String, tableName: String)] = [
     ("action.", "Common"),
-    ("combine.", "Common"),
+    ("combine.", "Combine"),
     ("menu.", "Menubar"),
     ("common.", "Common"),
     ("whats-new.", "WhatsNew"),

--- a/SnapzyTests/App/SnapzyDeepLinkHandlerTests.swift
+++ b/SnapzyTests/App/SnapzyDeepLinkHandlerTests.swift
@@ -23,6 +23,7 @@ final class SnapzyDeepLinkHandlerTests: XCTestCase {
       ("snapzy://record/screen", .recordScreen),
       ("snapzy://record/application", .recordApplication),
       ("snapzy://open/annotate", .openAnnotate),
+      ("snapzy://open/combine", .openCombine([])),
       ("snapzy://open/video-editor", .openVideoEditor),
       ("snapzy://open/cloud-uploads", .openCloudUploads),
       ("snapzy://open/history", .openHistory),
@@ -34,6 +35,37 @@ final class SnapzyDeepLinkHandlerTests: XCTestCase {
       let url = try XCTUnwrap(URL(string: urlString))
       XCTAssertEqual(SnapzyDeepLinkAction(url: url), expectedAction, urlString)
     }
+  }
+
+  func testCombineAliasesParseExpectedAction() throws {
+    let aliases = [
+      "snapzy://combine",
+      "snapzy://combine-images",
+      "snapzy://open-combine",
+    ]
+
+    for urlString in aliases {
+      let url = try XCTUnwrap(URL(string: urlString))
+      XCTAssertEqual(SnapzyDeepLinkAction(url: url), .openCombine([]), urlString)
+    }
+  }
+
+  func testCombineRouteParsesRepeatedFileParameters() throws {
+    var components = try XCTUnwrap(URLComponents(string: "snapzy://open/combine"))
+    components.queryItems = [
+      URLQueryItem(name: "file", value: "/tmp/first image.png"),
+      URLQueryItem(name: "file", value: "file:///tmp/second.jpg"),
+      URLQueryItem(name: "ignored", value: "/tmp/not-used.png"),
+    ]
+
+    let url = try XCTUnwrap(components.url)
+    XCTAssertEqual(
+      SnapzyDeepLinkAction(url: url),
+      .openCombine([
+        URL(fileURLWithPath: "/tmp/first image.png"),
+        URL(fileURLWithPath: "/tmp/second.jpg"),
+      ])
+    )
   }
 
   func testApplicationCaptureAliasesParseExpectedAction() throws {

--- a/SnapzyTests/Features/Annotate/AnnotateExportSaveTests.swift
+++ b/SnapzyTests/Features/Annotate/AnnotateExportSaveTests.swift
@@ -83,6 +83,20 @@ final class AnnotateExportSaveTests: XCTestCase {
     XCTAssertEqual(rendered.size.height, 160, accuracy: 0.0001)
   }
 
+  func testRenderFinalImageUsesCombinedBoundsGapAndPadding() throws {
+    let state = makeAnnotateState()
+    state.loadImage(try makeImage(width: 200, height: 100))
+    state.importImage(try makeImage(width: 100, height: 100))
+    state.setCombineDirection(.horizontal)
+    state.setCombineGap(10)
+    state.padding = 24
+
+    let rendered = try XCTUnwrap(AnnotateExporter.renderFinalImage(state: state))
+
+    XCTAssertEqual(rendered.size.width, 358, accuracy: 0.001)
+    XCTAssertEqual(rendered.size.height, 148, accuracy: 0.001)
+  }
+
   // MARK: - saveToOriginal (writes to state.sourceURL)
 
   func testSaveToOriginalWritesReadableFileAndReturnsTrue() throws {

--- a/SnapzyTests/Features/Annotate/AnnotateImageDropLoaderTests.swift
+++ b/SnapzyTests/Features/Annotate/AnnotateImageDropLoaderTests.swift
@@ -1,0 +1,58 @@
+import AppKit
+import UniformTypeIdentifiers
+import XCTest
+@testable import Snapzy
+
+final class AnnotateImageDropLoaderTests: XCTestCase {
+  func testLoadsImageObjectProvider() throws {
+    let image = try makeImage(width: 24, height: 16)
+    let provider = NSItemProvider(object: image)
+    let loaded = expectation(description: "image object loaded")
+
+    XCTAssertTrue(AnnotateImageDropLoader.load(from: provider) { result in
+      XCTAssertEqual(result?.image.size, image.size)
+      loaded.fulfill()
+    })
+
+    wait(for: [loaded], timeout: 2)
+  }
+
+  func testLoadsFileRepresentationProvider() throws {
+    let image = try makeImage(width: 30, height: 20)
+    let data = try XCTUnwrap(image.tiffRepresentation)
+    let sourceURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("snapzy-drop-\(UUID().uuidString).tiff")
+    try data.write(to: sourceURL)
+    defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+    let provider = NSItemProvider()
+    provider.registerFileRepresentation(
+      forTypeIdentifier: UTType.tiff.identifier,
+      fileOptions: [],
+      visibility: .all
+    ) { completion in
+      completion(sourceURL, false, nil)
+      return nil
+    }
+
+    let loaded = expectation(description: "file representation loaded")
+    XCTAssertTrue(AnnotateImageDropLoader.load(from: provider) { result in
+      XCTAssertNotNil(result?.image)
+      XCTAssertFalse(result?.data?.isEmpty ?? true)
+      loaded.fulfill()
+    })
+
+    wait(for: [loaded], timeout: 2)
+  }
+
+  func testRejectsProviderWithoutImageContent() {
+    XCTAssertFalse(AnnotateImageDropLoader.load(from: NSItemProvider()) { _ in
+      XCTFail("Completion should not run for an unsupported provider")
+    })
+  }
+
+  private func makeImage(width: Int, height: Int) throws -> NSImage {
+    let cgImage = try XCTUnwrap(TestImageFactory.solidColor(width: width, height: height))
+    return NSImage(cgImage: cgImage, size: NSSize(width: width, height: height))
+  }
+}

--- a/SnapzyTests/Features/Annotate/AnnotateImageOpsTests.swift
+++ b/SnapzyTests/Features/Annotate/AnnotateImageOpsTests.swift
@@ -106,6 +106,55 @@ final class AnnotateImageOpsTests: XCTestCase {
     }
     XCTAssertEqual(state.selectedTool, .selection)
     XCTAssertTrue(state.hasUnsavedChanges)
+    XCTAssertTrue(state.isCombineMode)
+  }
+
+  func testCombineImportPlacesSecondImageFlushRightInHorizontalMode() throws {
+    let state = makeAnnotateState()
+    state.loadImage(try makeImage(width: 400, height: 300))
+    state.importImage(try makeImage(width: 200, height: 100))
+    state.setCombineDirection(.horizontal)
+
+    let imported = try XCTUnwrap(state.annotations.first)
+    XCTAssertEqual(imported.bounds.minX, 400, accuracy: 0.001)
+    XCTAssertEqual(imported.bounds.minY, 0, accuracy: 0.001)
+    XCTAssertEqual(imported.bounds.height, 300, accuracy: 0.001)
+    XCTAssertEqual(state.combineContentBounds.width, 1000, accuracy: 0.001)
+  }
+
+  func testCombineModeSwitchRestoresFreeCanvasBounds() throws {
+    let state = makeAnnotateState()
+    state.loadImage(try makeImage(width: 400, height: 300))
+    state.importImage(try makeImage(width: 200, height: 100))
+    state.setCombineMode(.freeCanvas)
+
+    let importedID = try XCTUnwrap(state.annotations.first?.id)
+    let freeBounds = CGRect(x: 90, y: -40, width: 240, height: 120)
+    state.updateAnnotationBounds(id: importedID, bounds: freeBounds)
+    state.setCombineMode(.autoStitch)
+    XCTAssertNotEqual(state.annotations.first?.bounds, freeBounds)
+
+    state.setCombineMode(.freeCanvas)
+    XCTAssertEqual(state.annotations.first?.bounds, freeBounds)
+  }
+
+  func testCombineImageOrderCanMoveImportedImageBeforeBase() throws {
+    let state = makeAnnotateState()
+    state.loadImage(try makeImage(width: 400, height: 300))
+    state.importImage(try makeImage(width: 200, height: 100))
+
+    state.moveCombineImage(at: 1, by: -1)
+
+    XCTAssertEqual(state.sourceImage?.size, NSSize(width: 200, height: 100))
+    guard case .embeddedImage(let assetID) = try XCTUnwrap(state.annotations.first).type else {
+      return XCTFail("Expected imported image layer")
+    }
+    XCTAssertEqual(state.embeddedImage(for: assetID)?.size, NSSize(width: 400, height: 300))
+    XCTAssertEqual(state.combineImageCount, 2)
+
+    state.undo()
+    XCTAssertEqual(state.sourceImage?.size, NSSize(width: 400, height: 300))
+    XCTAssertEqual(state.embeddedImage(for: assetID)?.size, NSSize(width: 200, height: 100))
   }
 
   // MARK: - addImportedImage size guard

--- a/SnapzyTests/Features/Annotate/CombineImagesLayoutTests.swift
+++ b/SnapzyTests/Features/Annotate/CombineImagesLayoutTests.swift
@@ -1,0 +1,58 @@
+import CoreGraphics
+import XCTest
+@testable import Snapzy
+
+final class CombineImagesLayoutTests: XCTestCase {
+  func testHorizontalLayoutMatchesBaseHeightAndHasExactGap() throws {
+    let baseID = UUID()
+    let secondID = UUID()
+    let result = CombineImagesLayout.layout(
+      items: [
+        CombineImagesLayoutItem(id: baseID, size: CGSize(width: 400, height: 300)),
+        CombineImagesLayoutItem(id: secondID, size: CGSize(width: 200, height: 100))
+      ],
+      direction: .horizontal,
+      gap: 12
+    )
+
+    let base = try XCTUnwrap(result.boundsByID[baseID])
+    let second = try XCTUnwrap(result.boundsByID[secondID])
+    XCTAssertEqual(base, CGRect(x: 0, y: 0, width: 400, height: 300))
+    XCTAssertEqual(second.height, 300, accuracy: 0.001)
+    XCTAssertEqual(second.width, 600, accuracy: 0.001)
+    XCTAssertEqual(second.minX - base.maxX, 12, accuracy: 0.001)
+  }
+
+  func testVerticalLayoutMatchesBaseWidthAndHasNoGapByDefault() throws {
+    let baseID = UUID()
+    let secondID = UUID()
+    let result = CombineImagesLayout.layout(
+      items: [
+        CombineImagesLayoutItem(id: baseID, size: CGSize(width: 300, height: 200)),
+        CombineImagesLayoutItem(id: secondID, size: CGSize(width: 600, height: 200))
+      ],
+      direction: .vertical,
+      gap: 0
+    )
+
+    let base = try XCTUnwrap(result.boundsByID[baseID])
+    let second = try XCTUnwrap(result.boundsByID[secondID])
+    XCTAssertEqual(second.width, 300, accuracy: 0.001)
+    XCTAssertEqual(second.height, 100, accuracy: 0.001)
+    XCTAssertEqual(second.minY, base.maxY, accuracy: 0.001)
+  }
+
+  func testSmartDirectionChoosesHorizontalForPortraitScreenshots() {
+    let items = (0 ..< 3).map { _ in
+      CombineImagesLayoutItem(id: UUID(), size: CGSize(width: 1170, height: 2532))
+    }
+    XCTAssertEqual(CombineImagesLayout.resolveDirection(requested: .smart, items: items), .horizontal)
+  }
+
+  func testSmartDirectionChoosesVerticalForWideScreenshots() {
+    let items = (0 ..< 3).map { _ in
+      CombineImagesLayoutItem(id: UUID(), size: CGSize(width: 1600, height: 900))
+    }
+    XCTAssertEqual(CombineImagesLayout.resolveDirection(requested: .smart, items: items), .vertical)
+  }
+}

--- a/SnapzyTests/Features/Annotate/CombineSnappingTests.swift
+++ b/SnapzyTests/Features/Annotate/CombineSnappingTests.swift
@@ -1,0 +1,34 @@
+import CoreGraphics
+import XCTest
+@testable import Snapzy
+
+final class CombineSnappingTests: XCTestCase {
+  func testSnapsToRightEdgeWithoutGap() throws {
+    let result = try XCTUnwrap(CombineSnapping.resolve(
+      draggedBounds: CGRect(x: 506, y: 1, width: 200, height: 300),
+      candidateBounds: [CGRect(x: 0, y: 0, width: 500, height: 300)],
+      gap: 0,
+      tolerance: 14
+    ))
+    XCTAssertEqual(result.origin, CGPoint(x: 500, y: 0))
+  }
+
+  func testRespectsConfiguredGap() throws {
+    let result = try XCTUnwrap(CombineSnapping.resolve(
+      draggedBounds: CGRect(x: 514, y: 0, width: 200, height: 300),
+      candidateBounds: [CGRect(x: 0, y: 0, width: 500, height: 300)],
+      gap: 8,
+      tolerance: 14
+    ))
+    XCTAssertEqual(result.minX, 508)
+  }
+
+  func testDoesNotSnapOutsideTolerance() {
+    XCTAssertNil(CombineSnapping.resolve(
+      draggedBounds: CGRect(x: 530, y: 0, width: 200, height: 300),
+      candidateBounds: [CGRect(x: 0, y: 0, width: 500, height: 300)],
+      gap: 0,
+      tolerance: 14
+    ))
+  }
+}


### PR DESCRIPTION
## Summary
Implements screenshot stitching / Combine Images, as requested in #354.

- Multi-image combine with side-by-side default layout (equal-height when same-size, proportional scaling otherwise)
- Entry points: drag a 2nd image / paste (⌘V) / dedicated toolbar button to open a file picker
- Edge snapping with the base image as the primary snap target; Shift for proportional resize
- Save sheet (Save to File / Copy to Clipboard / Cancel) — no silent window close / data loss
- Export matches preview (corner-radius clip applied to all layers, including stitched images)

## Test plan
- Built and run locally as a dev build; the stitching flow was verified manually with no bugs found.
- Added unit tests: `CombineSnappingTests`, `CombineImagesLayoutTests`.

## Related
Closes #354
