### PR TITLE
fix(i18n): polish Simplified and Traditional Chinese localization

### DIFF
--- a/Snapzy/Resources/Localization/Features/Annotate.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Annotate.xcstrings
@@ -510,13 +510,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "注释"
+            "value": "标注"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "注釋"
+            "value": "標註"
           }
         }
       }
@@ -1875,13 +1875,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "或截屏进行注释"
+            "value": "或截取截图后标注"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "或截屏進行注釋"
+            "value": "或擷取螢幕截圖後標註"
           }
         }
       }
@@ -2359,13 +2359,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "结晶"
+            "value": "星点胶带"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "結晶"
+            "value": "星點膠帶"
           }
         },
         "es": {
@@ -2424,13 +2424,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "使用结晶图案效果遮盖敏感信息"
+            "value": "薰衣草色星点纸胶带"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "使用結晶圖案效果遮蓋敏感資訊"
+            "value": "薰衣草色星點紙膠帶"
           }
         },
         "es": {
@@ -3565,13 +3565,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "适合 (%@)"
+            "value": "适合画布（%@）"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "適合 (%@)"
+            "value": "符合畫布（%@）"
           }
         }
       }
@@ -3789,13 +3789,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "半色调"
+            "value": "格纹胶带"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "半色調"
+            "value": "格紋膠帶"
           }
         },
         "es": {
@@ -3854,13 +3854,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "使用经典漫画书风格半色调圆点遮盖敏感信息"
+            "value": "奶油色格纹纸胶带"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "使用經典漫畫書風格半色調圓點遮蓋敏感資訊"
+            "value": "奶油色格紋紙膠帶"
           }
         },
         "es": {
@@ -4150,13 +4150,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "该图像使用透明背景剪切。保存为 JPEG 会将透明度拼合为不透明背景。使用 PNG 或 WebP 来保持透明度。"
+            "value": "此图片已移除背景并保留透明区域。保存为 JPEG 会把透明区域填充为不透明背景。请使用 PNG 或 WebP 保留透明背景。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "該圖像使用透明背景剪切。保存為 JPEG 會將透明度拼合為不透明背景。使用 PNG 或 WebP 來保持透明度。"
+            "value": "此圖片已移除背景並保留透明區域。儲存為 JPEG 會將透明區域填滿為不透明背景。請使用 PNG 或 WebP 保留透明背景。"
           }
         }
       }
@@ -4215,13 +4215,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "JPEG 删除透明度"
+            "value": "JPEG 不支持透明背景"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "JPEG 刪除透明度"
+            "value": "JPEG 不支援透明背景"
           }
         }
       }
@@ -4410,13 +4410,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "注释"
+            "value": "标注"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "注釋"
+            "value": "標註"
           }
         }
       }
@@ -4605,13 +4605,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "移动所选区域 (Space + 鼠标拖动)"
+            "value": "移动选区（空格键 + 拖动鼠标）"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "移動所選區域 (Space + 滑鼠拖動)"
+            "value": "移動選取範圍（空白鍵 + 拖曳滑鼠）"
           }
         }
       }
@@ -4865,13 +4865,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "打开侧边栏以获取更多注释控件"
+            "value": "打开侧边栏，查看更多标注工具"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "打開側邊欄以獲取更多注釋控件"
+            "value": "打開側邊欄，查看更多標註工具"
           }
         }
       }
@@ -5255,13 +5255,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "用于编辑敏感内容的像素化模糊"
+            "value": "用像素化模糊遮挡敏感内容"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "用於編輯敏感內容的像素化模糊"
+            "value": "用像素化模糊遮擋敏感內容"
           }
         }
       }
@@ -5284,13 +5284,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "点彩画法"
+            "value": "网格胶带"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "點彩畫法"
+            "value": "網格膠帶"
           }
         },
         "es": {
@@ -5349,13 +5349,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "使用由微小圆点组成的艺术点彩画法效果遮盖敏感内容"
+            "value": "蜜桃色网格纸胶带"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "使用由微小圓點組成的藝術點彩畫法效果遮蓋敏感內容"
+            "value": "蜜桃色網格紙膠帶"
           }
         },
         "es": {
@@ -5710,13 +5710,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "删除背景（在设置中禁用自动裁剪）"
+            "value": "移除背景（已在“设置”中关闭自动裁剪）"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "刪除背景（在設置中禁用自動裁剪）"
+            "value": "移除背景（已在「設定」中關閉自動裁切）"
           }
         }
       }
@@ -5775,13 +5775,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "删除背景（安全时自动裁剪）"
+            "value": "移除背景（适合时自动裁剪）"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "刪除背景（安全時自動裁剪）"
+            "value": "移除背景（適合時自動裁切）"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/Capture.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Capture.xcstrings
@@ -2525,13 +2525,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "成功拖放到 other 应用后自动关闭 标注 编辑器"
+            "value": "成功拖放到其他应用后，自动关闭标注编辑器"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "成功拖放到其他 App 後自動關閉 標註 編輯器"
+            "value": "成功拖放到其他 App 後，自動關閉標註編輯器"
           }
         }
       }
@@ -12212,13 +12212,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "启动Capture锁定第一帧"
+            "value": "开始截取以锁定第一帧"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "啓動Capture鎖定第一幀"
+            "value": "開始擷取以鎖定第一個畫面"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/Recording.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Recording.xcstrings
@@ -5060,13 +5060,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "无法添加麦克风写入器输入"
+            "value": "无法添加麦克风音频输入"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "無法添加麥克風寫入器輸入"
+            "value": "無法加入麥克風音訊輸入"
           }
         }
       }
@@ -5125,13 +5125,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "无法添加系统音频编写器输入"
+            "value": "无法添加系统音频输入"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "無法添加系統音頻編寫器輸入"
+            "value": "無法加入系統音訊輸入"
           }
         }
       }
@@ -5190,13 +5190,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "无法添加视频编写器输入"
+            "value": "无法添加视频输入"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "無法添加影片編寫器輸入"
+            "value": "無法加入影片輸入"
           }
         }
       }
@@ -5385,13 +5385,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "找不到显示"
+            "value": "未找到显示器"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "找不到顯示"
+            "value": "找不到顯示器"
           }
         }
       }
@@ -5645,13 +5645,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "安装失败：%@"
+            "value": "初始化失败：%@"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "安裝失敗：%@"
+            "value": "初始化失敗：%@"
           }
         }
       }
@@ -5905,13 +5905,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Snapzy 需要保存文件夹权限才能继续。请在入门中选择一个文件夹或立即授予它。"
+            "value": "Snapzy 需要访问保存文件夹才能继续。请在引导中选择文件夹，或现在授予访问权限。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Snapzy 需要保存檔案夾權限才能繼續。請在入門中選擇一個檔案夾或立即授予它。"
+            "value": "Snapzy 需要存取儲存資料夾才能繼續。請在引導流程中選擇資料夾，或立即授予存取權限。"
           }
         }
       }
@@ -5970,13 +5970,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "需要保存位置访问权限"
+            "value": "需要访问保存位置"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "需要保存位置訪問權限"
+            "value": "需要存取儲存位置"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/VideoEditor.xcstrings
+++ b/Snapzy/Resources/Localization/Features/VideoEditor.xcstrings
@@ -380,13 +380,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Volume"
+            "value" : "音量"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Volume"
+            "value" : "音量"
           }
         }
       }
@@ -3370,13 +3370,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "较低的值让人感觉更平静。当光标改变方向时，值越高反应越快。"
+            "value" : "数值较低时，镜头跟随更平缓；数值较高时，光标转向后跟随更快。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "較低的值讓人感覺更平靜。當光標改變方向時，值越高反應越快。"
+            "value" : "數值較低時，鏡頭跟隨更平緩；數值較高時，游標轉向後跟隨更快。"
           }
         }
       }
@@ -4148,13 +4148,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "小鼠样品"
+            "value" : "鼠标采样点"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "小鼠樣品"
+            "value" : "滑鼠取樣點"
           }
         }
       }
@@ -4278,13 +4278,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Microphone"
+            "value" : "麦克风"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Microphone"
+            "value" : "麥克風"
           }
         }
       }
@@ -4343,13 +4343,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mic"
+            "value" : "麦克风"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mic"
+            "value" : "麥克風"
           }
         }
       }
@@ -4798,13 +4798,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "按 Z 在播放头处添加缩放，或单击时间线中的缩放项目。"
+            "value" : "按 Z 可在播放头位置添加缩放，或点按时间线中的缩放片段。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "按 Z 在播放頭處添加縮放，或單擊時間線中的縮放項目。"
+            "value" : "按 Z 可在播放頭位置加入縮放，或點按時間軸中的縮放片段。"
           }
         }
       }
@@ -5058,13 +5058,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "替换原来的"
+            "value" : "替换原文件"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "替換原來的"
+            "value" : "取代原始檔案"
           }
         }
       }
@@ -5188,13 +5188,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "调整框架大小..."
+            "value" : "正在调整画面尺寸..."
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "調整框架大小..."
+            "value" : "正在調整畫面尺寸..."
           }
         }
       }
@@ -6161,13 +6161,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "显示视频信息（一）"
+            "value" : "显示视频信息（I）"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "顯示影片信息（一）"
+            "value" : "顯示影片資訊（I）"
           }
         }
       }
@@ -6356,13 +6356,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "光滑的"
+            "value" : "平滑"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "光滑的"
+            "value" : "平滑"
           }
         }
       }
@@ -6486,13 +6486,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "System Audio"
+            "value" : "系统音频"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "System Audio"
+            "value" : "系統音訊"
           }
         }
       }
@@ -6551,13 +6551,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sys"
+            "value" : "系统"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sys"
+            "value" : "系統"
           }
         }
       }
@@ -6746,13 +6746,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "适用于该编辑器中的所有缩放项目。进入或离开变焦时，较高的值会让人感觉更平静。"
+            "value" : "此设置会应用到编辑器中的所有缩放片段。数值越高，进入或退出缩放时的过渡越平缓。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "適用於該編輯器中的所有縮放項目。進入或離開變焦時，較高的值會讓人感覺更平靜。"
+            "value" : "此設定會套用到編輯器中的所有縮放片段。數值越高，進入或退出縮放時的轉場越平緩。"
           }
         }
       }
@@ -7396,13 +7396,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "缩放项目"
+            "value" : "缩放片段"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "縮放項目"
+            "value" : "縮放片段"
           }
         }
       }
@@ -8566,13 +8566,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "加速或减速某一区域（延时）"
+            "value" : "加速或减速一段画面（延时摄影）"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "加速或減速某一區域（縮時）"
+            "value" : "加速或減速一段畫面（縮時）"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Shared/Common.xcstrings
+++ b/Snapzy/Resources/Localization/Shared/Common.xcstrings
@@ -55,13 +55,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "捕获活动窗口"
+            "value": "截取当前窗口"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "擷取使用中的視窗"
+            "value": "擷取目前視窗"
           }
         }
       }
@@ -185,13 +185,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "标记截屏"
+            "value": "截图并标注"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "標記截圖"
+            "value": "截圖並標註"
           }
         }
       }
@@ -250,7 +250,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "全屏截屏"
+            "value": "全屏截图"
           }
         },
         "zh-Hant": {
@@ -279,13 +279,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "智能元素截图"
+            "value": "智能元素截取"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "智慧元素截圖"
+            "value": "智慧元素擷取"
           }
         },
         "es": {
@@ -900,13 +900,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "显示快速访问浮层"
+            "value": "显示快速访问面板"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "顯示快速存取浮層"
+            "value": "顯示快速取用面板"
           }
         }
       }
@@ -1030,13 +1030,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "应用程序身份是健康的。"
+            "value": "应用身份正常。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "應用程序身份是健康的。"
+            "value": "App 身分正常。"
           }
         }
       }
@@ -1160,13 +1160,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "在授予权限之前，在 /Applications 中安装 Snapzy。当前路径：%@"
+            "value": "请先将 Snapzy 安装到 /Applications，再授予权限。当前路径：%@"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "在授予權限之前，在 /Applications 中安裝 Snapzy。當前路徑：%@"
+            "value": "請先將 Snapzy 安裝到 /Applications，再授予權限。目前路徑：%@"
           }
         }
       }
@@ -1225,13 +1225,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "此应用程序仍然具有 macOS 隔离标志。使用安装程序脚本重新安装或在授予权限之前删除隔离区。"
+            "value": "此应用仍带有 macOS 隔离标记。请重新运行安装脚本，或先移除隔离标记再授予权限。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "此應用程序仍然具有 macOS 隔離標誌。使用安裝程序腳本重新安裝或在授予權限之前刪除隔離區。"
+            "value": "此 App 仍帶有 macOS 隔離標記。請重新執行安裝腳本，或先移除隔離標記再授予權限。"
           }
         }
       }
@@ -1680,13 +1680,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "纵横比"
+            "value": "宽高比"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "縱橫比"
+            "value": "寬高比"
           }
         }
       }
@@ -2850,13 +2850,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "禁用"
+            "value": "停用"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "禁用"
+            "value": "停用"
           }
         }
       }
@@ -3695,13 +3695,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "免费"
+            "value": "自由"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "免費"
+            "value": "自由"
           }
         }
       }
@@ -5001,7 +5001,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "打開設置"
+            "value": "開啟設定"
           }
         }
       }
@@ -6236,7 +6236,7 @@
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "保存"
+            "value": "儲存"
           }
         }
       }
@@ -7400,13 +7400,13 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "重新录制 / Restart"
+            "value": "重新录制 / 重新开始"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "重新錄製 / Restart"
+            "value": "重新錄製 / 重新開始"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Shared/Permissions.xcstrings
+++ b/Snapzy/Resources/Localization/Shared/Permissions.xcstrings
@@ -575,13 +575,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "必填"
+            "value" : "必需"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "必填"
+            "value" : "必要"
           }
         }
       }


### PR DESCRIPTION
Closes #356

## Summary

This PR improves user-facing localization for **Simplified Chinese (`zh-Hans`) and Traditional Chinese (`zh-Hant`) only**.

It does not change English, Thai, or any other locale.

The updates focus on the parts of Snapzy where wording needs to describe an image-editing or screen-capture action precisely: capture, annotation, scrolling capture, recording, and video editing.

## What changed

- Replaced literal or misleading translations with clear, task-oriented Chinese wording.
- Standardized core terms, including screenshot capture, annotation, recording, saving, settings, and cloud-related messages.
- Corrected Traditional Chinese wording that mixed in Simplified Chinese forms or Mainland-oriented vocabulary.
- Localized previously untranslated audio and video-editor labels.
- Corrected the crop option `Free` so it means an unconstrained ratio, not free of charge.

## Scope

- 109 localized values across 6 catalog files.
- Only `zh-Hans` and `zh-Hant` values were changed.
- No feature behavior, layout, or other-language strings were changed.

## Verification

- Confirmed every changed value is in the approved Chinese review table.
- Ran the localization consistency check successfully.
- Built the macOS app successfully and confirmed representative Simplified and Traditional Chinese strings are present in the generated app resources.