### PR TITLE
fix: allow cask install on macOS newer than Ventura

### DIFF
--- a/Casks/snapzy.rb
+++ b/Casks/snapzy.rb
@@ -7,7 +7,7 @@ cask "snapzy" do
   desc "Native macOS screenshots, recording, annotation, and editing from the menu bar"
   homepage "https://github.com/duongductrong/Snapzy"
 
-  depends_on macos: :ventura
+  depends_on macos: ">= :ventura"
 
   app "Snapzy.app"
 


### PR DESCRIPTION
## Summary
- Change `depends_on macos:` in `Casks/snapzy.rb` from `:ventura` to `">= :ventura"`
- Restores the constraint from "Ventura only" to "Ventura or newer" (effectively reverting the change from #238)

## Before / After

### Before
- With `depends_on macos: :ventura`, `brew install --cask snapzy` fails on any macOS other than Ventura:
  Error: This software does not run on macOS versions other than Ventura.

### After
- Installs successfully on Ventura and all newer versions (Sonoma / Sequoia / Tahoe, etc.).

## Notes
- `brew style` reports no offense on the `depends_on` line, confirming `">= :ventura"` is not a deprecated stanza — the #238 change to `:ventura` was an over-correction.

Fixes #372 