### PR TITLE
fix: make scrolling capture reliable on mixed-scale external displays

### DIFF
--- a/Snapzy/Services/Capture/AreaSelectionWindow.swift
+++ b/Snapzy/Services/Capture/AreaSelectionWindow.swift
@@ -1041,25 +1041,6 @@ final class AreaSelectionController: NSObject {
     // Invalidate cursor rects before the next event
     window.overlayView.refreshCursor()
     
-    // WindowServer fundamentally refuses to assign native cursor ownership to a newly-key window
-    // of an inactive application unless a hardware click occurs. We bypass this by posting a
-    // synthetic hardware click via CGEvent exactly at the current mouse position.
-    window.overlayView.ignoreNextSyntheticClick = true
-    window.overlayView.ignoreNextSyntheticMouseUp = true
-    
-    if let source = CGEventSource(stateID: .hidSystemState),
-       let currentEvent = CGEvent(source: nil) {
-      let cgMousePos = currentEvent.location
-      
-      let mouseDown = CGEvent(mouseEventSource: source, mouseType: .leftMouseDown, mouseCursorPosition: cgMousePos, mouseButton: .left)
-      let mouseUp = CGEvent(mouseEventSource: source, mouseType: .leftMouseUp, mouseCursorPosition: cgMousePos, mouseButton: .left)
-      
-      DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-        mouseDown?.post(tap: .cghidEventTap)
-        mouseUp?.post(tap: .cghidEventTap)
-      }
-    }
-
     DiagnosticLogger.shared.log(
       .debug,
       .capture,
@@ -1075,6 +1056,7 @@ final class AreaSelectionController: NSObject {
 
   private func resetCallbacks() {
     isPresenting = false
+    dismissesAfterSelection = true
     stopPointerTracking()
     lumaRecapturingTask?.cancel()
     lumaRecapturingTask = nil
@@ -2873,14 +2855,7 @@ final class AreaSelectionOverlayView: NSView {
 
   // MARK: - Mouse Events
 
-  var ignoreNextSyntheticClick = false
-
   override func mouseDown(with event: NSEvent) {
-    if ignoreNextSyntheticClick {
-      ignoreNextSyntheticClick = false
-      return
-    }
-    
     let point = convert(event.locationInWindow, from: nil)
     currentMousePosition = point
     if let areaWindow = self.window as? AreaSelectionWindow {
@@ -2940,14 +2915,7 @@ final class AreaSelectionOverlayView: NSView {
   }
 
 
-  var ignoreNextSyntheticMouseUp = false
-
   override func mouseUp(with event: NSEvent) {
-    if ignoreNextSyntheticMouseUp {
-      ignoreNextSyntheticMouseUp = false
-      return
-    }
-    
     let point = convert(event.locationInWindow, from: nil)
     currentMousePosition = point
     delegate?.overlayViewDidRequestDisplayActivation(self)

--- a/Snapzy/Services/Capture/ScrollingCapture/ScrollingCaptureCommitFrameNormalizer.swift
+++ b/Snapzy/Services/Capture/ScrollingCapture/ScrollingCaptureCommitFrameNormalizer.swift
@@ -1,0 +1,49 @@
+//
+//  ScrollingCaptureCommitFrameNormalizer.swift
+//  Snapzy
+//
+//  Keeps every frame submitted to the scrolling stitcher at one pixel scale.
+//
+
+import CoreGraphics
+
+enum ScrollingCaptureCommitFrameNormalizer {
+
+  static func normalize(
+    _ image: CGImage,
+    logicalSize: CGSize,
+    sourceScaleFactor: CGFloat,
+    minimumOutputScaleFactor: CGFloat,
+    colorSpaceName: CFString?
+  ) -> CGImage? {
+    let outputScaleFactor = max(sourceScaleFactor, minimumOutputScaleFactor)
+    guard outputScaleFactor.isFinite,
+          outputScaleFactor > 0,
+          logicalSize.width.isFinite,
+          logicalSize.width > 0,
+          logicalSize.height.isFinite,
+          logicalSize.height > 0
+    else {
+      return nil
+    }
+
+    let targetWidth = max(1, Int((logicalSize.width * outputScaleFactor).rounded()))
+    let targetHeight = max(1, Int((logicalSize.height * outputScaleFactor).rounded()))
+    if image.width == targetWidth, image.height == targetHeight {
+      return image
+    }
+
+    let normalized = FrozenAreaCaptureSession.imageByPromotingScaleIfNeeded(
+      image,
+      logicalSize: logicalSize,
+      sourceScaleFactor: sourceScaleFactor,
+      minimumOutputScaleFactor: minimumOutputScaleFactor,
+      colorSpaceName: colorSpaceName
+    ).image
+    guard normalized.width == targetWidth, normalized.height == targetHeight else {
+      return nil
+    }
+
+    return normalized
+  }
+}

--- a/Snapzy/Services/Capture/ScrollingCapture/ScrollingCaptureCoordinator.swift
+++ b/Snapzy/Services/Capture/ScrollingCapture/ScrollingCaptureCoordinator.swift
@@ -9,6 +9,7 @@ import AppKit
 import ApplicationServices
 import Combine
 import Foundation
+import ScreenCaptureKit
 
 @MainActor
 final class ScrollingCaptureCoordinator {
@@ -910,7 +911,7 @@ final class ScrollingCaptureCoordinator {
 
         guard !Task.isCancelled else { return }
         self.preparedCaptureContext = context
-        self.captureScaleFactor = context.scaleFactor
+        self.captureScaleFactor = max(context.scaleFactor, context.minimumOutputScaleFactor)
       } catch {
         if error is CancellationError { return }
         DiagnosticLogger.shared.log(
@@ -948,7 +949,7 @@ final class ScrollingCaptureCoordinator {
       prefetchedContentTask: prefetchedContentTask
     )
     preparedCaptureContext = context
-    captureScaleFactor = context.scaleFactor
+    captureScaleFactor = max(context.scaleFactor, context.minimumOutputScaleFactor)
     return context
   }
 
@@ -973,6 +974,7 @@ final class ScrollingCaptureCoordinator {
   }
 
   private func captureFrameForCommit() async throws -> CommitFrame? {
+    let context = try await ensurePreparedCaptureContext()
     let streamFrame: ScrollingCaptureFrame?
     if let lastCommittedSequenceNumber = liveFrameRing.lastCommittedSequenceNumber {
       streamFrame = liveFrameRing.latestFrame(after: lastCommittedSequenceNumber)
@@ -980,7 +982,8 @@ final class ScrollingCaptureCoordinator {
       streamFrame = liveFrameRing.latest
     }
 
-    if let streamFrame {
+    if let streamFrame,
+       let normalizedImage = normalizeCommitFrame(streamFrame.image, context: context) {
       let now = ProcessInfo.processInfo.systemUptime
       let isDuplicate = liveFrameRing.lastCommittedSequenceNumber
         .map { streamFrame.sequenceNumber <= $0 } ?? false
@@ -991,7 +994,7 @@ final class ScrollingCaptureCoordinator {
         isDuplicateFrame: isDuplicate
       )
       let commitFrame = CommitFrame(
-        image: streamFrame.image,
+        image: normalizedImage,
         sequenceNumber: streamFrame.sequenceNumber,
         source: .stream,
         frameAgeMs: frameAgeMs,
@@ -999,6 +1002,19 @@ final class ScrollingCaptureCoordinator {
       )
       logScrollingCaptureCommitFrameSelected(commitFrame)
       return commitFrame
+    }
+
+    if let streamFrame {
+      logScrollingCaptureDebug(
+        "commit-frame-normalization-failed",
+        context: [
+          "source": "stream",
+          "inputSize": "\(streamFrame.image.width)x\(streamFrame.image.height)",
+          "logicalSize": "\(Int(context.logicalCropSize.width))x\(Int(context.logicalCropSize.height))",
+          "sourceScale": Self.formattedDebugDouble(Double(context.scaleFactor)),
+          "outputScale": Self.formattedDebugDouble(Double(captureScaleFactor))
+        ]
+      )
     }
 
     guard let capturedImage = try await capturePreparedAreaForSession() else {
@@ -1012,13 +1028,26 @@ final class ScrollingCaptureCoordinator {
       )
       return nil
     }
+    guard let normalizedImage = normalizeCommitFrame(capturedImage, context: context) else {
+      logScrollingCaptureDebug(
+        "commit-frame-normalization-failed",
+        context: [
+          "source": "still-fallback",
+          "inputSize": "\(capturedImage.width)x\(capturedImage.height)",
+          "logicalSize": "\(Int(context.logicalCropSize.width))x\(Int(context.logicalCropSize.height))",
+          "sourceScale": Self.formattedDebugDouble(Double(context.scaleFactor)),
+          "outputScale": Self.formattedDebugDouble(Double(captureScaleFactor))
+        ]
+      )
+      return nil
+    }
     sessionMetrics.recordCommitFrameSelected(
       source: .stillFallback,
       frameAgeMs: nil,
       isDuplicateFrame: false
     )
     let commitFrame = CommitFrame(
-      image: capturedImage,
+      image: normalizedImage,
       sequenceNumber: nil,
       source: .stillFallback,
       frameAgeMs: nil,
@@ -1026,6 +1055,19 @@ final class ScrollingCaptureCoordinator {
     )
     logScrollingCaptureCommitFrameSelected(commitFrame)
     return commitFrame
+  }
+
+  private func normalizeCommitFrame(
+    _ image: CGImage,
+    context: ScreenCaptureManager.PreparedAreaCaptureContext
+  ) -> CGImage? {
+    ScrollingCaptureCommitFrameNormalizer.normalize(
+      image,
+      logicalSize: context.logicalCropSize,
+      sourceScaleFactor: context.scaleFactor,
+      minimumOutputScaleFactor: context.minimumOutputScaleFactor,
+      colorSpaceName: context.configuration.colorSpaceName
+    )
   }
 
   private func startLiveRefreshLoopIfNeeded() {
@@ -1107,7 +1149,8 @@ final class ScrollingCaptureCoordinator {
         context: [
           "sourceRect": "\(Int(context.sourceRect.width))x\(Int(context.sourceRect.height))",
           "outputSize": "\(context.outputWidth)x\(context.outputHeight)",
-          "scale": Self.formattedDebugDouble(Double(captureScaleFactor)),
+          "streamScale": Self.formattedDebugDouble(Double(context.scaleFactor)),
+          "commitScale": Self.formattedDebugDouble(Double(captureScaleFactor)),
           "ringFrames": "\(liveFrameRing.frames.count)"
         ]
       )

--- a/SnapzyTests/Services/Capture/AreaSelectionModelsTests.swift
+++ b/SnapzyTests/Services/Capture/AreaSelectionModelsTests.swift
@@ -169,6 +169,20 @@ final class AreaSelectionControllerTests: XCTestCase {
     XCTAssertFalse(controller.isPresenting, "cancelSelection must clear isPresenting via resetCallbacks")
   }
 
+  func testCancelSelection_restoresDismissesAfterSelectionDefault() {
+    let controller = AreaSelectionController.shared
+    controller.startSelection(mode: .recording, backdrops: [:]) { _ in }
+    controller.setDismissesAfterSelection(false)
+    defer { controller.setDismissesAfterSelection(true) }
+
+    controller.cancelSelection()
+
+    XCTAssertTrue(
+      controller.dismissesAfterSelection,
+      "a cancelled live selection must not leak its dismiss policy into the next capture session"
+    )
+  }
+
   func testIsPresenting_falseAfterCompletion() throws {
     // completeSelection funnels through the same resetCallbacks teardown. Drive it with a REAL
     // pooled overlay window (the production success path) so the flag is verified on completion

--- a/SnapzyTests/Services/Capture/AreaSelectionMultiMonitorReconciliationTests.swift
+++ b/SnapzyTests/Services/Capture/AreaSelectionMultiMonitorReconciliationTests.swift
@@ -157,6 +157,49 @@ final class AreaSelectionMultiMonitorReconciliationTests: AreaSelectionOverlayTe
     )
   }
 
+  func testScrollingSelection_firstPhysicalMouseDownStartsManualSelection() throws {
+    let controller = AreaSelectionController.shared
+    controller.startSelection(mode: .scrollingCapture) { _, _ in }
+    defer { controller.cancelSelection() }
+
+    let timer = try XCTUnwrap(pointerTrackingTimer(of: controller))
+    timer.fire()
+
+    let windowPool = try XCTUnwrap(
+      Mirror(reflecting: controller).children
+        .first(where: { $0.label == "windowPool" })?.value
+        as? [CGDirectDisplayID: AreaSelectionWindow]
+    )
+    let mouseLocation = NSEvent.mouseLocation
+    let pointerWindow = try XCTUnwrap(
+      windowPool.values.first(where: { $0.frame.contains(mouseLocation) })
+    )
+    let overlayView = pointerWindow.overlayView
+    overlayView.setSelectionEnabled(true)
+    overlayView.setInteractionMode(.manualRegion, resetSelection: false)
+    overlayView.resetSelection()
+
+    let mouseDown = try XCTUnwrap(
+      NSEvent.mouseEvent(
+        with: .leftMouseDown,
+        location: CGPoint(x: 120, y: 120),
+        modifierFlags: [],
+        timestamp: ProcessInfo.processInfo.systemUptime,
+        windowNumber: pointerWindow.windowNumber,
+        context: nil,
+        eventNumber: 1,
+        clickCount: 1,
+        pressure: 1
+      )
+    )
+    overlayView.mouseDown(with: mouseDown)
+
+    XCTAssertTrue(
+      overlayView.isManualSelectionInProgress,
+      "Pointer promotion must not reserve and swallow the user's first real mouse-down"
+    )
+  }
+
   /// Frozen sessions (non-empty `selectionBackdrops`) activate the app, which already routes cursor
   /// handling across displays, so the pointer-tracking timer must NOT be installed — avoiding
   /// redundant key churn.

--- a/SnapzyTests/Services/Capture/ScrollingCaptureCommitFrameNormalizerTests.swift
+++ b/SnapzyTests/Services/Capture/ScrollingCaptureCommitFrameNormalizerTests.swift
@@ -1,0 +1,46 @@
+//
+//  ScrollingCaptureCommitFrameNormalizerTests.swift
+//  SnapzyTests
+//
+//  Regression tests for mixed-density scrolling-capture commit frames.
+//
+
+import CoreGraphics
+import XCTest
+@testable import Snapzy
+
+final class ScrollingCaptureCommitFrameNormalizerTests: XCTestCase {
+
+  func testNormalize_promotesNativeExternalDisplayFrameToSessionOutputScale() throws {
+    let image = try XCTUnwrap(TestImageFactory.scrollingFrame(width: 100, height: 50))
+
+    let normalized = try XCTUnwrap(
+      ScrollingCaptureCommitFrameNormalizer.normalize(
+        image,
+        logicalSize: CGSize(width: 100, height: 50),
+        sourceScaleFactor: 1,
+        minimumOutputScaleFactor: 2,
+        colorSpaceName: nil
+      )
+    )
+
+    XCTAssertEqual(normalized.width, 200)
+    XCTAssertEqual(normalized.height, 100)
+  }
+
+  func testNormalize_returnsAlreadyNormalizedFrameWithoutResizing() throws {
+    let image = try XCTUnwrap(TestImageFactory.scrollingFrame(width: 200, height: 100))
+
+    let normalized = try XCTUnwrap(
+      ScrollingCaptureCommitFrameNormalizer.normalize(
+        image,
+        logicalSize: CGSize(width: 100, height: 50),
+        sourceScaleFactor: 1,
+        minimumOutputScaleFactor: 2,
+        colorSpaceName: nil
+      )
+    )
+
+    XCTAssertTrue((normalized as AnyObject) === (image as AnyObject))
+  }
+}


### PR DESCRIPTION
## Summary
Fix scrolling capture failures on mixed-scale display configurations, particularly when capturing from a 1x external display connected to a Mac with a 2x built-in display.

This also fixes two related area-selection issues:
- The selection overlay could remain visible after capture or cancellation.
- The first drag used to select a scrolling capture region could be ignored.

## Problem
The initial still frame was generated at the scrolling session's output scale, while subsequent ScreenCaptureKit frames remained at the external display's native scale.

For example:
- Initial frame: `2562×1680`
- Live stream frame: `1281×840`

Because the stitcher requires consistent frame dimensions, it rejected every live frame with `ignored-alignment-failed`, resulting in `appended=0`.

Area selection also had two lifecycle problems:
1. `dismissesAfterSelection` could remain disabled after a cancelled live selection and affect later capture sessions.
2. Cross-display pointer promotion injected synthetic mouse events and marked the next mouse-down and mouse-up for suppression. If the synthetic events were not routed back to the overlay, the user's first real drag was discarded.

## Testing
An unsigned Debug build completed successfully with:
```sh
xcodebuild \
  -project Snapzy.xcodeproj \
  -scheme Snapzy \
  -configuration Debug \
  -destination 'platform=macOS' \
  CODE_SIGN_IDENTITY= \
  CODE_SIGNING_REQUIRED=NO \
  CODE_SIGNING_ALLOWED=NO \
  build
```

Fixes #371 