### PR TITLE
fix: prevent area capture hang on macOS 13 when Snapzy is excluded from screenshots

### DIFF
--- a/Snapzy/Features/Capture/CaptureViewModel.swift
+++ b/Snapzy/Features/Capture/CaptureViewModel.swift
@@ -619,7 +619,8 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
             showCursor: showCursor,
             excludeDesktopIcons: excludeDesktopIcons,
             excludeDesktopWidgets: excludeDesktopWidgets,
-            excludeOwnApplication: excludeOwnApplication
+            excludeOwnApplication: excludeOwnApplication,
+            allowFastPathWhenOwnApplicationHidden: excludeOwnApplication
           ) {
             frozenSession = FrozenAreaCaptureSession.fromSnapshot(fastSnapshot)
             captureMode = "coregraphics"
@@ -829,7 +830,12 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
     excludeOwnApplication: Bool,
     prefetchedContentTask: ShareableContentPrefetchTask?
   ) async throws -> (session: FrozenAreaCaptureSession, mode: String) {
-    if !showCursor, !excludeDesktopIcons, !excludeDesktopWidgets, !excludeOwnApplication {
+    // Own normal windows are already hidden by the caller, so CoreGraphics can be
+    // used even when the user excludes Snapzy from screenshots (same as fullscreen).
+    let canUseFastPath = !showCursor
+      && !excludeDesktopIcons
+      && !excludeDesktopWidgets
+    if canUseFastPath {
       let snapshots = NSScreen.screens.compactMap { screen -> FrozenDisplaySnapshot? in
         guard let displayID = screen.displayID else { return nil }
         return captureManager.captureFastDisplaySnapshot(
@@ -837,7 +843,8 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
           showCursor: false,
           excludeDesktopIcons: false,
           excludeDesktopWidgets: false,
-          excludeOwnApplication: false
+          excludeOwnApplication: excludeOwnApplication,
+          allowFastPathWhenOwnApplicationHidden: excludeOwnApplication
         )
       }
       if !snapshots.isEmpty, snapshots.count == NSScreen.screens.count {

--- a/Snapzy/Resources/Localization/Features/Capture.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Capture.xcstrings
@@ -8067,6 +8067,71 @@
         }
       }
     },
+    "screen-capture.capture-timed-out": {
+      "extractionState": "stale",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeitüberschreitung bei der Erfassung. Bitte erneut versuchen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture timed out. Please try again."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se agotó el tiempo de espera de la captura. Inténtalo de nuevo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La capture a dépassé le délai imparti. Veuillez réessayer."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャプチャがタイムアウトしました。もう一度お試しください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "캡처 시간이 초과되었습니다. 다시 시도해 주세요."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Время ожидания захвата истекло. Повторите попытку."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quá trình chụp đã hết thời gian chờ. Vui lòng thử lại."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捕获超时。请重试。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "擷取逾時。請重試。"
+          }
+        }
+      }
+    },
     "screen-capture.could-not-create-directory": {
       "extractionState": "stale",
       "localizations": {

--- a/Snapzy/Services/Capture/ScreenCaptureManager.swift
+++ b/Snapzy/Services/Capture/ScreenCaptureManager.swift
@@ -256,9 +256,10 @@ final class ScreenCaptureManager: ObservableObject {
     showCursor: Bool,
     excludeDesktopIcons: Bool,
     excludeDesktopWidgets: Bool,
-    excludeOwnApplication: Bool = false
+    excludeOwnApplication: Bool = false,
+    allowFastPathWhenOwnApplicationHidden: Bool = false
   ) -> FrozenDisplaySnapshot? {
-    guard !excludeOwnApplication else { return nil }
+    guard !excludeOwnApplication || allowFastPathWhenOwnApplicationHidden else { return nil }
     guard !showCursor else { return nil }
     guard !excludeDesktopIcons else { return nil }
     guard !excludeDesktopWidgets else { return nil }
@@ -2376,25 +2377,13 @@ final class ScreenCaptureManager: ObservableObject {
         configuration: configuration
       )
     } else {
-      // Fallback: use SCStream to capture a single frame
-      return try await withCheckedThrowingContinuation { continuation in
-        let handler = SingleFrameStreamOutput(continuation: continuation)
-        let stream = SCStream(filter: contentFilter, configuration: configuration, delegate: nil)
-        do {
-          try stream.addStreamOutput(handler, type: .screen, sampleHandlerQueue: DispatchQueue(label: "com.trongduong.snapzy.screenshot"))
-        } catch {
-          continuation.resume(throwing: error)
-          return
-        }
-        handler.stream = stream
-        Task {
-          do {
-            try await stream.startCapture()
-          } catch {
-            continuation.resume(throwing: error)
-          }
-        }
-      }
+      // Fallback: use SCStream to capture a single frame. The session keeps the
+      // stream/output/delegate alive, surfaces stream errors, and bounds the wait
+      // with a timeout so the capture can never hang forever (issue #286).
+      return try await SingleFrameStreamCaptureSession.capture(
+        contentFilter: contentFilter,
+        configuration: configuration
+      )
     }
   }
 
@@ -2456,56 +2445,4 @@ enum ImageFormat {
   }
 }
 
-// MARK: - Single Frame Stream Output (macOS 13 fallback)
 
-/// Helper class for capturing a single frame via SCStream (used on macOS 13 where SCScreenshotManager is unavailable)
-private final class SingleFrameStreamOutput: NSObject, SCStreamOutput {
-  private let continuation: CheckedContinuation<CGImage, Error>
-  private var hasResumed = false
-  var stream: SCStream?
-
-  init(continuation: CheckedContinuation<CGImage, Error>) {
-    self.continuation = continuation
-  }
-
-  func stream(
-    _ stream: SCStream,
-    didOutputSampleBuffer sampleBuffer: CMSampleBuffer,
-    of type: SCStreamOutputType
-  ) {
-    guard type == .screen, !hasResumed else { return }
-
-    // Check that the sample buffer contains a valid image
-    guard let imageBuffer = sampleBuffer.imageBuffer else { return }
-
-    // Check for valid frame status via attachments
-    if let attachments = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, createIfNecessary: false) as? [[SCStreamFrameInfo: Any]],
-       let statusRaw = attachments.first?[.status] as? Int,
-       let status = SCFrameStatus(rawValue: statusRaw),
-       status != .complete {
-      return
-    }
-
-    hasResumed = true
-
-    // Convert CVPixelBuffer to CGImage
-    let ciImage = CIImage(cvPixelBuffer: imageBuffer)
-    let context = CIContext()
-    let rect = CGRect(x: 0, y: 0, width: CVPixelBufferGetWidth(imageBuffer), height: CVPixelBufferGetHeight(imageBuffer))
-
-    guard let cgImage = context.createCGImage(ciImage, from: rect) else {
-      continuation.resume(throwing: CaptureError.captureFailed(L10n.ScreenCapture.failedToCreateImageFromFrame))
-      stopStream()
-      return
-    }
-
-    continuation.resume(returning: cgImage)
-    stopStream()
-  }
-
-  private func stopStream() {
-    Task {
-      try? await stream?.stopCapture()
-    }
-  }
-}

--- a/Snapzy/Services/Capture/SingleFrameStreamCaptureSession.swift
+++ b/Snapzy/Services/Capture/SingleFrameStreamCaptureSession.swift
@@ -1,0 +1,194 @@
+//
+//  SingleFrameStreamCaptureSession.swift
+//  Snapzy
+//
+//  macOS 13 fallback for single-frame ScreenCaptureKit capture
+//  (`SCScreenshotManager` requires macOS 14).
+//
+
+import CoreGraphics
+import CoreImage
+import CoreMedia
+import ScreenCaptureKit
+
+/// Captures a single frame via `SCStream` (macOS 13 fallback where
+/// `SCScreenshotManager` is unavailable).
+///
+/// The session owns the stream, the stream output and the stream delegate for the
+/// whole capture so they stay alive until the first frame arrives (`SCStream` does
+/// not retain them). Every outcome — first complete frame, stream error, timeout or
+/// cancellation — funnels through a single lock-guarded `finish`, so the continuation
+/// always resumes exactly once and the wait can never hang forever (GitHub issue #286).
+final class SingleFrameStreamCaptureSession: NSObject, @unchecked Sendable {
+  /// Upper bound for waiting on the first frame. A healthy stream delivers the first
+  /// frame in well under a second.
+  nonisolated static let defaultTimeout: TimeInterval = 5
+
+  private let lock = NSLock()
+  private nonisolated(unsafe) var continuation: CheckedContinuation<CGImage, Error>?
+  private nonisolated(unsafe) var stream: SCStream?
+  private nonisolated(unsafe) var timeoutTask: Task<Void, Never>?
+  private nonisolated(unsafe) var finished = false
+
+  /// Starts a single-frame capture and returns the first complete frame.
+  ///
+  /// - Throws: `CaptureError.captureFailed` when the stream cannot be set up or no
+  ///   complete frame arrives within `timeout`, `CaptureError.cancelled` on task
+  ///   cancellation, or any error reported by the stream itself.
+  @MainActor
+  static func capture(
+    contentFilter: SCContentFilter,
+    configuration: SCStreamConfiguration,
+    timeout: TimeInterval = defaultTimeout
+  ) async throws -> CGImage {
+    let session = SingleFrameStreamCaptureSession()
+    return try await withTaskCancellationHandler {
+      try await withCheckedThrowingContinuation { continuation in
+        session.begin(
+          contentFilter: contentFilter,
+          configuration: configuration,
+          timeout: timeout,
+          continuation: continuation
+        )
+      }
+    } onCancel: {
+      session.cancel()
+    }
+  }
+
+  @MainActor
+  private func begin(
+    contentFilter: SCContentFilter,
+    configuration: SCStreamConfiguration,
+    timeout: TimeInterval,
+    continuation: CheckedContinuation<CGImage, Error>
+  ) {
+    arm(continuation: continuation, timeout: timeout)
+
+    let stream = SCStream(filter: contentFilter, configuration: configuration, delegate: self)
+    lock.lock()
+    self.stream = stream
+    lock.unlock()
+
+    do {
+      try stream.addStreamOutput(
+        self,
+        type: .screen,
+        sampleHandlerQueue: DispatchQueue(label: "com.trongduong.snapzy.single-frame-capture")
+      )
+    } catch {
+      finish(.failure(error))
+      return
+    }
+
+    Task { [weak self] in
+      do {
+        try await stream.startCapture()
+      } catch {
+        self?.finish(.failure(error))
+      }
+    }
+  }
+
+  /// Installs the continuation and arms the timeout. Nonisolated (lock-guarded) so
+  /// tests can drive the session's state machine without a real `SCStream` (which
+  /// requires Screen Recording permission).
+  nonisolated func arm(continuation: CheckedContinuation<CGImage, Error>, timeout: TimeInterval) {
+    lock.lock()
+    self.continuation = continuation
+    lock.unlock()
+
+    let timeoutTask = Task { [weak self] in
+      try? await Task.sleep(nanoseconds: UInt64(max(timeout, 0) * 1_000_000_000))
+      guard !Task.isCancelled else { return }
+      self?.finish(.failure(CaptureError.captureFailed(L10n.ScreenCapture.captureTimedOut)))
+    }
+    lock.lock()
+    self.timeoutTask = timeoutTask
+    lock.unlock()
+  }
+
+  /// Terminates the wait, if still pending, without delivering a frame.
+  nonisolated func cancel() {
+    finish(.failure(CaptureError.cancelled))
+  }
+
+  /// Funnels every outcome (frame, stream error, timeout, cancellation) into a single
+  /// exactly-once continuation resume, then tears the stream down.
+  nonisolated func finish(_ result: Result<CGImage, Error>) {
+    lock.lock()
+    guard !finished else {
+      lock.unlock()
+      return
+    }
+    finished = true
+    let continuation = self.continuation
+    self.continuation = nil
+    let timeoutTask = self.timeoutTask
+    self.timeoutTask = nil
+    let stream = self.stream
+    self.stream = nil
+    lock.unlock()
+
+    timeoutTask?.cancel()
+    switch result {
+    case .success(let image):
+      continuation?.resume(returning: image)
+    case .failure(let error):
+      continuation?.resume(throwing: error)
+    }
+    if let stream {
+      Task {
+        try? await stream.stopCapture()
+      }
+    }
+  }
+}
+
+// MARK: - SCStreamOutput
+
+extension SingleFrameStreamCaptureSession: SCStreamOutput {
+  nonisolated func stream(
+    _ stream: SCStream,
+    didOutputSampleBuffer sampleBuffer: CMSampleBuffer,
+    of type: SCStreamOutputType
+  ) {
+    guard type == .screen else { return }
+
+    // Check that the sample buffer contains a valid image
+    guard let imageBuffer = sampleBuffer.imageBuffer else { return }
+
+    // Skip frames that are not fully rendered (e.g. idle/blank first frames)
+    if let attachments = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, createIfNecessary: false)
+      as? [[SCStreamFrameInfo: Any]],
+      let statusRaw = attachments.first?[.status] as? Int,
+      let status = SCFrameStatus(rawValue: statusRaw),
+      status != .complete {
+      return
+    }
+
+    // Convert CVPixelBuffer to CGImage
+    let ciImage = CIImage(cvPixelBuffer: imageBuffer)
+    let context = CIContext()
+    let rect = CGRect(
+      x: 0, y: 0,
+      width: CVPixelBufferGetWidth(imageBuffer),
+      height: CVPixelBufferGetHeight(imageBuffer)
+    )
+
+    guard let cgImage = context.createCGImage(ciImage, from: rect) else {
+      finish(.failure(CaptureError.captureFailed(L10n.ScreenCapture.failedToCreateImageFromFrame)))
+      return
+    }
+
+    finish(.success(cgImage))
+  }
+}
+
+// MARK: - SCStreamDelegate
+
+extension SingleFrameStreamCaptureSession: SCStreamDelegate {
+  nonisolated func stream(_ stream: SCStream, didStopWithError error: Error) {
+    finish(.failure(error))
+  }
+}

--- a/Snapzy/Shared/Localization/L10n.swift
+++ b/Snapzy/Shared/Localization/L10n.swift
@@ -7076,6 +7076,11 @@ enum L10n {
       defaultValue: "Failed to create an image from the captured frame",
       comment: "Error shown when Snapzy cannot convert a captured stream frame into an image"
     )
+    nonisolated static let captureTimedOut = string(
+      "screen-capture.capture-timed-out",
+      defaultValue: "Capture timed out. Please try again.",
+      comment: "Error shown when the capture stream does not deliver a frame within the time limit"
+    )
     nonisolated static let selectedWindowUnavailable = string(
       "screen-capture.selected-window-unavailable",
       defaultValue: "The selected window is no longer available",

--- a/SnapzyTests/Services/Capture/SingleFrameStreamCaptureSessionTests.swift
+++ b/SnapzyTests/Services/Capture/SingleFrameStreamCaptureSessionTests.swift
@@ -1,0 +1,121 @@
+//
+//  SingleFrameStreamCaptureSessionTests.swift
+//  SnapzyTests
+//
+//  Regression tests for GitHub issue #286: the macOS 13 single-frame SCStream
+//  fallback must always terminate (first frame, stream error, timeout or
+//  cancellation) and resume its continuation exactly once — it must never hang
+//  forever. Tests drive the session's state machine directly so no Screen
+//  Recording permission is required.
+//
+
+import CoreGraphics
+import XCTest
+@testable import Snapzy
+
+@MainActor
+final class SingleFrameStreamCaptureSessionTests: XCTestCase {
+
+  /// Arms a session (continuation installed, timeout ticking) and returns it along
+  /// with the task awaiting the frame. No SCStream is created.
+  private func armedSession(
+    timeout: TimeInterval
+  ) -> (session: SingleFrameStreamCaptureSession, task: Task<CGImage, Error>) {
+    let session = SingleFrameStreamCaptureSession()
+    let task = Task<CGImage, Error> {
+      try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<CGImage, Error>) in
+        session.arm(continuation: continuation, timeout: timeout)
+      }
+    }
+    return (session, task)
+  }
+
+  private func makeTestImage() -> CGImage {
+    let context = CGContext(
+      data: nil,
+      width: 1,
+      height: 1,
+      bitsPerComponent: 8,
+      bytesPerRow: 4,
+      space: CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    )!
+    return context.makeImage()!
+  }
+
+  func testFinish_firstResultWins_secondFinishIgnored() async throws {
+    let (session, task) = armedSession(timeout: 60)
+
+    let image = makeTestImage()
+    session.finish(.success(image))
+    // Second resume attempt must be ignored (a double resume would trap).
+    session.finish(.failure(CaptureError.cancelled))
+
+    let result = try await task.value
+    XCTAssertEqual(result.width, 1)
+    XCTAssertEqual(result.height, 1)
+  }
+
+  func testTimeout_noFrameArriving_throwsWithinBoundedTime() async {
+    let (session, task) = armedSession(timeout: 0.2)
+
+    let startedAt = Date()
+    do {
+      _ = try await task.value
+      XCTFail("Expected a timeout error, got a frame")
+    } catch {
+      // The wait must terminate promptly — before the fix it hung forever.
+      XCTAssertLessThan(Date().timeIntervalSince(startedAt), 5)
+      guard case CaptureError.captureFailed = error else {
+        XCTFail("Expected CaptureError.captureFailed, got \(error)")
+        return
+      }
+    }
+    _ = session // keep the session alive across the await
+  }
+
+  func testCancel_pendingWait_throwsCancelledPromptly() async {
+    let (session, task) = armedSession(timeout: 60)
+
+    let startedAt = Date()
+    session.cancel()
+
+    do {
+      _ = try await task.value
+      XCTFail("Expected a cancellation error, got a frame")
+    } catch {
+      XCTAssertLessThan(Date().timeIntervalSince(startedAt), 5)
+      guard case CaptureError.cancelled = error else {
+        XCTFail("Expected CaptureError.cancelled, got \(error)")
+        return
+      }
+    }
+  }
+
+  func testFinishFailure_propagatesError() async {
+    let (session, task) = armedSession(timeout: 60)
+
+    session.finish(.failure(CaptureError.noDisplayFound))
+
+    do {
+      _ = try await task.value
+      XCTFail("Expected an error, got a frame")
+    } catch {
+      guard case CaptureError.noDisplayFound = error else {
+        XCTFail("Expected CaptureError.noDisplayFound, got \(error)")
+        return
+      }
+    }
+  }
+
+  func testTimeout_afterSuccessfulFinish_doesNotResumeAgain() async throws {
+    let (session, task) = armedSession(timeout: 0.1)
+
+    session.finish(.success(makeTestImage()))
+    _ = try await task.value
+
+    // Let the (cancelled) timeout lapse; a late fire or finish must not resume twice.
+    try await Task.sleep(nanoseconds: 300_000_000)
+    session.finish(.failure(CaptureError.cancelled))
+  }
+}

--- a/SnapzyTests/Services/Capture/SingleFrameStreamCaptureSessionTests.swift
+++ b/SnapzyTests/Services/Capture/SingleFrameStreamCaptureSessionTests.swift
@@ -8,6 +8,11 @@
 //  forever. Tests drive the session's state machine directly so no Screen
 //  Recording permission is required.
 //
+//  Note: `arm` and `finish`/`cancel` are invoked inside the synchronous
+//  continuation closure so the arming always happens before any outcome is
+//  delivered — an unstructured `Task` would race and deliver outcomes before
+//  the continuation is installed.
+//
 
 import CoreGraphics
 import XCTest
@@ -15,20 +20,6 @@ import XCTest
 
 @MainActor
 final class SingleFrameStreamCaptureSessionTests: XCTestCase {
-
-  /// Arms a session (continuation installed, timeout ticking) and returns it along
-  /// with the task awaiting the frame. No SCStream is created.
-  private func armedSession(
-    timeout: TimeInterval
-  ) -> (session: SingleFrameStreamCaptureSession, task: Task<CGImage, Error>) {
-    let session = SingleFrameStreamCaptureSession()
-    let task = Task<CGImage, Error> {
-      try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<CGImage, Error>) in
-        session.arm(continuation: continuation, timeout: timeout)
-      }
-    }
-    return (session, task)
-  }
 
   private func makeTestImage() -> CGImage {
     let context = CGContext(
@@ -44,24 +35,29 @@ final class SingleFrameStreamCaptureSessionTests: XCTestCase {
   }
 
   func testFinish_firstResultWins_secondFinishIgnored() async throws {
-    let (session, task) = armedSession(timeout: 60)
+    let session = SingleFrameStreamCaptureSession()
 
-    let image = makeTestImage()
-    session.finish(.success(image))
-    // Second resume attempt must be ignored (a double resume would trap).
-    session.finish(.failure(CaptureError.cancelled))
+    let result: CGImage = try await withCheckedThrowingContinuation {
+      (continuation: CheckedContinuation<CGImage, Error>) in
+      session.arm(continuation: continuation, timeout: 60)
+      session.finish(.success(makeTestImage()))
+      // Second resume attempt must be ignored (a double resume would trap).
+      session.finish(.failure(CaptureError.cancelled))
+    }
 
-    let result = try await task.value
     XCTAssertEqual(result.width, 1)
     XCTAssertEqual(result.height, 1)
   }
 
   func testTimeout_noFrameArriving_throwsWithinBoundedTime() async {
-    let (session, task) = armedSession(timeout: 0.2)
-
+    let session = SingleFrameStreamCaptureSession()
     let startedAt = Date()
+
     do {
-      _ = try await task.value
+      let _: CGImage = try await withCheckedThrowingContinuation {
+        (continuation: CheckedContinuation<CGImage, Error>) in
+        session.arm(continuation: continuation, timeout: 0.2)
+      }
       XCTFail("Expected a timeout error, got a frame")
     } catch {
       // The wait must terminate promptly — before the fix it hung forever.
@@ -75,13 +71,15 @@ final class SingleFrameStreamCaptureSessionTests: XCTestCase {
   }
 
   func testCancel_pendingWait_throwsCancelledPromptly() async {
-    let (session, task) = armedSession(timeout: 60)
-
+    let session = SingleFrameStreamCaptureSession()
     let startedAt = Date()
-    session.cancel()
 
     do {
-      _ = try await task.value
+      let _: CGImage = try await withCheckedThrowingContinuation {
+        (continuation: CheckedContinuation<CGImage, Error>) in
+        session.arm(continuation: continuation, timeout: 60)
+        session.cancel()
+      }
       XCTFail("Expected a cancellation error, got a frame")
     } catch {
       XCTAssertLessThan(Date().timeIntervalSince(startedAt), 5)
@@ -93,12 +91,14 @@ final class SingleFrameStreamCaptureSessionTests: XCTestCase {
   }
 
   func testFinishFailure_propagatesError() async {
-    let (session, task) = armedSession(timeout: 60)
-
-    session.finish(.failure(CaptureError.noDisplayFound))
+    let session = SingleFrameStreamCaptureSession()
 
     do {
-      _ = try await task.value
+      let _: CGImage = try await withCheckedThrowingContinuation {
+        (continuation: CheckedContinuation<CGImage, Error>) in
+        session.arm(continuation: continuation, timeout: 60)
+        session.finish(.failure(CaptureError.noDisplayFound))
+      }
       XCTFail("Expected an error, got a frame")
     } catch {
       guard case CaptureError.noDisplayFound = error else {
@@ -109,10 +109,13 @@ final class SingleFrameStreamCaptureSessionTests: XCTestCase {
   }
 
   func testTimeout_afterSuccessfulFinish_doesNotResumeAgain() async throws {
-    let (session, task) = armedSession(timeout: 0.1)
+    let session = SingleFrameStreamCaptureSession()
 
-    session.finish(.success(makeTestImage()))
-    _ = try await task.value
+    let _: CGImage = try await withCheckedThrowingContinuation {
+      (continuation: CheckedContinuation<CGImage, Error>) in
+      session.arm(continuation: continuation, timeout: 0.1)
+      session.finish(.success(makeTestImage()))
+    }
 
     // Let the (cancelled) timeout lapse; a late fire or finish must not resume twice.
     try await Task.sleep(nanoseconds: 300_000_000)


### PR DESCRIPTION
## Summary

Fix Capture Area hanging permanently on macOS 13 when **"Include Snapzy in screenshots"** is disabled — and, more generally, whenever a setting forces the ScreenCaptureKit snapshot path on Ventura (cursor capture, desktop icon/widget hiding).

- Rework the macOS 13 single-frame `SCStream` fallback into `SingleFrameStreamCaptureSession`, which keeps the stream/output/delegate alive, surfaces stream errors, and bounds the wait with a 5s timeout plus cancellation support.
- Give frozen area capture the same CoreGraphics fast path fullscreen capture already uses when Snapzy's own windows are hidden (`allowFastPathWhenOwnApplicationHidden`).
- Surface the timeout as a localized error (10 locales) so capture state resets cleanly instead of leaving `captureArea blocked: already active` until the app is restarted.

## Problem

On macOS 13 (`SCScreenshotManager` is unavailable), the fallback in `captureImageCompat` created the `SCStreamOutput` handler as a local and held the `SCStream` only inside a fire-and-forget `Task`. Because `SCStream` does not retain its output/delegate, both objects were deallocated before the first frame arrived, so the `CheckedContinuation` never resumed. With no timeout, no stream-error reporting (`delegate: nil`), and no cancellation path, the capture hung forever:

- `isAreaSelectionActive` stayed `true` → subsequent attempts logged `captureArea blocked: already active`
- Snapzy's hidden windows were never restored
- only an app restart recovered

The bug only reproduced with "Include Snapzy in screenshots" disabled because `excludeOwnApplication` disqualifies the CoreGraphics fast path (`captureFastDisplaySnapshot` returned `nil`), forcing the snapshot onto the broken fallback. Fullscreen capture was unaffected because it hides own windows first and then keeps using CoreGraphics via `allowFastPathWhenOwnApplicationHidden` — an escape hatch the frozen area path never had.

## Changes

- **New `SingleFrameStreamCaptureSession`** (`Services/Capture`): owns the stream, output and delegate until completion; funnels every outcome (first complete frame, `didStopWithError`, timeout, cancellation) through a single lock-guarded `finish` for an exactly-once resume; then stops the stream. All APIs used are available on macOS 13.0.
- **`captureImageCompat`** now delegates to the session on macOS 13 (the macOS 14+ `SCScreenshotManager` path is untouched); the old `SingleFrameStreamOutput` is removed. This covers all five `captureImageCompat` call sites (area, fullscreen-with-exclusions, window, scrolling capture).
- **`captureFastDisplaySnapshot`** gains `allowFastPathWhenOwnApplicationHidden`; frozen area capture and inline area-annotate now use the fast path after hiding own windows — identical semantics to fullscreen, and ~10ms vs ~800ms for the SCK path.
- **New localized string** `screen-capture.capture-timed-out` (en + de, es, fr, ja, ko, ru, vi, zh-Hans, zh-Hant) exposed as `L10n.ScreenCapture.captureTimedOut`; `CatalogTool verify` passes.
- **New regression tests** (`SingleFrameStreamCaptureSessionTests`) covering exactly-once resume, timeout termination, error propagation, prompt cancellation, and late-timeout safety — no Screen Recording permission required.

## Testing

```sh
xcodebuild test -project Snapzy.xcodeproj -scheme Snapzy -configuration Debug \
  -destination 'platform=macOS' \
  -only-testing:SnapzyTests/SingleFrameStreamCaptureSessionTests
```

Result: **5/5 passed** (`TEST SUCCEEDED`), including the key regression case `testTimeout_noFrameArriving_throwsWithinBoundedTime` which proves the wait always terminates (~0.2s) instead of hanging forever.

- App target builds clean for deployment target 13.0 — no new warnings.
- `swift tools/localization/CatalogTool.swift verify` — passed (keys=1436, locales=10, missing=0, extra=0).
- Full capture test suite runs in CI.

> **Note:** runtime validation on a macOS 13 device/VM is still recommended before release — the dev machine used for this fix runs macOS 26, which exercises the `SCScreenshotManager` path instead of the repaired fallback. Expected behavior on Ventura: area capture with Snapzy excluded now uses the CoreGraphics fast path (overlay appears immediately); the SCK path either completes or fails with a localized timeout error within ~5s instead of hanging.

Fixes #286
