### PR TITLE
perf: Eliminate Quick Access card reappear jank on annotate save-and-close

### DIFF
--- a/Snapzy/Features/Annotate/AnnotateManager.swift
+++ b/Snapzy/Features/Annotate/AnnotateManager.swift
@@ -89,9 +89,12 @@ final class AnnotateManager {
 
   /// Switch back to accessory mode (menu bar only) if no windows open
   private func becomeAccessoryAppIfNeeded() {
-    guard windowControllers.isEmpty && manualWindowControllers.isEmpty else { return }
-    guard !VideoEditorManager.shared.hasOpenWindows else { return }
-    NSApp.revertActivationPolicyToAccessoryIfNeeded()
+    DispatchQueue.main.async { [weak self] in
+      guard let self = self else { return }
+      guard self.windowControllers.isEmpty && self.manualWindowControllers.isEmpty else { return }
+      guard !VideoEditorManager.shared.hasOpenWindows else { return }
+      NSApp.revertActivationPolicyToAccessoryIfNeeded()
+    }
   }
 
   /// Check if any annotate windows are open

--- a/Snapzy/Features/Annotate/AnnotateState.swift
+++ b/Snapzy/Features/Annotate/AnnotateState.swift
@@ -210,7 +210,7 @@ final class AnnotateState: ObservableObject {
   // MARK: - Editor Mode
 
   /// Editor mode determines whether user is annotating or applying mockup transforms
-  enum EditorMode: String, CaseIterable {
+  nonisolated enum EditorMode: String, CaseIterable {
     case annotate  // Normal annotation editing (flat image)
     case mockup    // 3D perspective transforms with controls
     case preview   // Preview combined result (hides all editing UI)
@@ -1525,6 +1525,63 @@ final class AnnotateState: ObservableObject {
     }
     embeddedImageCGImageCache[assetId] = cgImage
     return cgImage
+  }
+
+  /// Freeze every render input into a value-type snapshot so final-image rendering can run
+  /// off the main actor. Warms lazy caches (embedded CGImage) and resolves main-bound
+  /// resources (sandboxed wallpaper disk access, CI blur) before copying.
+  func makeRenderSnapshot() -> AnnotateRenderSnapshot? {
+    guard let sourceImage = effectiveSourceImage else { return nil }
+
+    // Warm the lazy CGImage cache for every embedded asset referenced by annotations,
+    // then freeze plain dictionary copies (off-main render must be read-only).
+    for annotation in annotations {
+      if case .embeddedImage(let assetId) = annotation.type {
+        _ = embeddedCGImage(for: assetId)
+      }
+    }
+
+    // Pre-resolve the background image for the active style (mirrors the exporter's
+    // resolve logic: blurred preferred when the effect is active / for .blurred style).
+    let resolvedBackgroundImage: NSImage?
+    switch backgroundStyle {
+    case .wallpaper(let url) where url.scheme != "preset":
+      resolvedBackgroundImage = isBlurredBackgroundEffectActive
+        ? blurredBackgroundImage(for: url)
+        : backgroundImage(for: url)
+    case .blurred(let url):
+      resolvedBackgroundImage = blurredBackgroundImage(for: url)
+    default:
+      resolvedBackgroundImage = nil
+    }
+
+    return AnnotateRenderSnapshot(
+      sourceImage: sourceImage,
+      editorMode: editorMode,
+      isCombineMode: isCombineMode,
+      effectiveContentBounds: effectiveContentBounds,
+      cropRect: cropRect,
+      annotations: annotations,
+      embeddedImages: embeddedImageAssets,
+      embeddedCGImages: embeddedImageCGImageCache,
+      backgroundStyle: backgroundStyle,
+      isBlurredBackgroundEffectActive: isBlurredBackgroundEffectActive,
+      blurredBackgroundEffect: blurredBackgroundEffect,
+      resolvedBackgroundImage: resolvedBackgroundImage,
+      padding: padding,
+      cornerRadius: cornerRadius,
+      shadowIntensity: shadowIntensity,
+      imageAlignment: imageAlignment,
+      aspectRatio: aspectRatio,
+      aspectRatioOrientation: aspectRatioOrientation,
+      mockupRotationX: mockupRotationX,
+      mockupRotationY: mockupRotationY,
+      mockupRotationZ: mockupRotationZ,
+      mockupPerspective: mockupPerspective,
+      mockupShadowRadius: mockupShadowRadius,
+      mockupShadowOffsetX: mockupShadowOffsetX,
+      mockupShadowOffsetY: mockupShadowOffsetY
+    )
   }
 
   func restoreEmbeddedImageAssets(from snapshot: [UUID: Data]) {
@@ -4879,7 +4936,7 @@ final class AnnotateState: ObservableObject {
   }
 }
 
-enum AnnotateTextLayout {
+nonisolated enum AnnotateTextLayout {
   static let horizontalPadding: CGFloat = 4
   static let verticalPadding: CGFloat = 4
   static let minWidth: CGFloat = 30

--- a/Snapzy/Features/Annotate/Managers/AnnotateWindowController.swift
+++ b/Snapzy/Features/Annotate/Managers/AnnotateWindowController.swift
@@ -572,58 +572,62 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
       let sessionSnapshot = makeSessionSnapshot()
       state.markAsSaved()
       saveSessionCache(sessionSnapshot)
-      
-      // Capture instant visual thumbnail from canvas view to avoid stale/blank flash
-      var instantThumbnail: NSImage? = nil
-      if let contentView = self.window?.contentView {
-        let bounds = contentView.bounds
-        if let imageRep = contentView.bitmapImageRepForCachingDisplay(in: bounds) {
-          contentView.cacheDisplay(in: bounds, to: imageRep)
-          let img = NSImage(size: bounds.size)
-          img.addRepresentation(imageRep)
-          instantThumbnail = QuickAccessManager.shared.cgScaleThumbnail(img, maxSize: 200)
-        }
-      }
-      
+
+      // Freeze all render inputs on main (warms lazy caches, resolves main-bound
+      // resources) so the background render never touches live state.
+      let renderSnapshot = state.makeRenderSnapshot()
       let itemId = quickAccessItemId
-      if let instantThumbnail = instantThumbnail, let itemId = itemId {
-        QuickAccessManager.shared.updateItemThumbnail(id: itemId, thumbnail: instantThumbnail, fullResImage: instantThumbnail)
+      let generation = itemId.map { QuickAccessManager.shared.nextThumbnailGeneration(for: $0) }
+
+      // Instant anti-flash thumbnail from the canvas region (display-res; the
+      // authoritative render replaces it in ~50-100ms). The pin window is NOT updated
+      // here — it keeps its full-res image until the real render lands.
+      if let itemId,
+         let instantThumbnail = PerfSignpost.measure("instantThumbCapture", { captureCanvasThumbnail() }) {
+        QuickAccessManager.shared.updateItemThumbnail(id: itemId, thumbnail: instantThumbnail, fullResImage: nil)
       }
-      
-      // Pre-cache source image on main thread before background task
-      if let sourceImage = state.effectiveSourceImage {
-        _ = sourceImage.cgImage(forProposedRect: nil, context: nil, hints: nil)
-      }
-      
-      let capturedState = state
+
       forceClose(perfInterval: returnInterval)
-      
+
       Task.detached(priority: .userInitiated) {
-        // Off-main full-res render
-        let renderedImage = PerfSignpost.measure("render") {
-          AnnotateExporter.renderFinalImage(state: capturedState)
+        guard let renderSnapshot else {
+          DiagnosticLogger.shared.log(.error, .annotate, "Save-and-close skipped: no render snapshot")
+          return
         }
-        
-        guard let renderedImage = renderedImage else { return }
-        
+
+        // Off-main full-res render from the frozen snapshot (mockup composites on main)
+        let renderInterval = PerfSignpost.beginInterval("render")
+        let renderedImage = await AnnotateExporter.renderFinalImage(snapshot: renderSnapshot)
+        PerfSignpost.endInterval(renderInterval)
+
+        guard let renderedImage else {
+          DiagnosticLogger.shared.log(.error, .annotate, "Save-and-close render failed; file not saved")
+          return
+        }
+
         // Off-main downscale
         let finalThumbnail = PerfSignpost.measure("thumbnailScale") {
-          QuickAccessManager.shared.cgScaleThumbnail(renderedImage, maxSize: 200)
+          QuickAccessManager.cgScaleThumbnail(renderedImage, maxSize: 200)
         }
-        
+
         // Main-actor push of authoritative thumbnail & pinned window update
-        if let itemId = itemId {
+        if let itemId {
           await MainActor.run {
-            QuickAccessManager.shared.updateItemThumbnail(id: itemId, thumbnail: finalThumbnail, fullResImage: renderedImage)
+            QuickAccessManager.shared.updateItemThumbnail(
+              id: itemId,
+              thumbnail: finalThumbnail,
+              fullResImage: renderedImage,
+              generation: generation
+            )
             QuickAccessManager.shared.markCloudStale(id: itemId)
           }
         }
-        
-        // Save to file
-        guard await AnnotateExporter.saveToFile(image: renderedImage, state: capturedState),
-              let sourceURL else { return }
-              
-        await Self.persistCommittedSession(sessionSnapshot, for: sourceURL)
+
+        // Save to file (encode off-main; scoped write + history on main)
+        guard let sourceURL,
+              await AnnotateExporter.saveToFileOffMain(image: renderedImage, sourceURL: sourceURL) else { return }
+
+        await Self.persistCommittedSessionOffMain(sessionSnapshot, for: sourceURL)
         await PostCaptureActionHandler.shared.copyEditedCaptureToClipboardIfEnabled(
           for: .screenshot,
           url: sourceURL
@@ -635,6 +639,20 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
     }
   }
 
+  /// Capture the canvas region (the edited image the user is looking at, without
+  /// toolbar/sidebar chrome) as a 200px instant thumbnail. Runs on main, ~2-5ms.
+  private func captureCanvasThumbnail() -> NSImage? {
+    guard let contentView = window?.contentView else { return nil }
+    let target = contentView.firstDescendant(ofType: DrawingCanvasNSView.self) ?? contentView
+    let rect = target.convert(target.bounds, to: contentView).integral
+    guard !rect.isEmpty,
+          let imageRep = contentView.bitmapImageRepForCachingDisplay(in: rect) else { return nil }
+    contentView.cacheDisplay(in: rect, to: imageRep)
+    let image = NSImage(size: rect.size)
+    image.addRepresentation(imageRep)
+    return QuickAccessManager.cgScaleThumbnail(image, maxSize: 200)
+  }
+
 
 
   private func forceClose(perfInterval: Any? = nil) {
@@ -643,14 +661,14 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
       PerfSignpost.endInterval(perfInterval)
       return
     }
-    
+
     // Hide window instantly
     window.alphaValue = 0
-    
+
     if let itemId = quickAccessItemId {
       QuickAccessManager.shared.setWindowOpen(id: itemId, isOpen: false)
     }
-    
+
     PerfSignpost.measure("windowClose") {
       window.close()
     }
@@ -862,7 +880,7 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
         )
         return
       }
-      await Self.persistCommittedSession(sessionSnapshot, for: sourceURL)
+      await Self.persistCommittedSessionOffMain(sessionSnapshot, for: sourceURL)
       await PostCaptureActionHandler.shared.copyEditedCaptureToClipboardIfEnabled(
         for: .screenshot,
         url: sourceURL
@@ -998,7 +1016,7 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
       Task.detached(priority: .userInitiated) {
         guard await AnnotateExporter.saveToFile(image: renderedImage, state: capturedState),
               let sourceURL else { return }
-        await Self.persistCommittedSession(sessionSnapshot, for: sourceURL)
+        await Self.persistCommittedSessionOffMain(sessionSnapshot, for: sourceURL)
         await PostCaptureActionHandler.shared.copyEditedCaptureToClipboardIfEnabled(
           for: .screenshot,
           url: sourceURL
@@ -1166,7 +1184,7 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
     Task.detached(priority: .userInitiated) {
       guard await AnnotateExporter.saveToFile(image: renderedImage, state: capturedState),
             let sourceURL else { return }
-      await Self.persistCommittedSession(sessionSnapshot, for: sourceURL)
+      await Self.persistCommittedSessionOffMain(sessionSnapshot, for: sourceURL)
     }
   }
 
@@ -1415,5 +1433,14 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
     guard let snapshot,
           AnnotationSessionStore.shared.shouldPersist(for: sourceURL) else { return }
     AnnotationSessionStore.shared.persist(snapshot, for: sourceURL)
+  }
+
+  /// Off-main variant for background save flows: the multi-MB sidecar package write
+  /// runs on the calling queue; only the cheap shouldPersist check hops to main.
+  nonisolated private static func persistCommittedSessionOffMain(_ snapshot: AnnotationSessionData?, for sourceURL: URL) async {
+    guard let snapshot else { return }
+    let shouldPersist = await MainActor.run { AnnotationSessionStore.shared.shouldPersist(for: sourceURL) }
+    guard shouldPersist else { return }
+    _ = await AnnotationSessionStore.shared.persistOffMain(snapshot, for: sourceURL)
   }
 }

--- a/Snapzy/Features/Annotate/Managers/AnnotateWindowController.swift
+++ b/Snapzy/Features/Annotate/Managers/AnnotateWindowController.swift
@@ -566,22 +566,63 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
   }
 
   private func executeSaveAndClose() {
+    let returnInterval = PerfSignpost.beginInterval("AnnotateReturn")
     if state.sourceURL != nil {
-      // Render once, update thumbnail instantly, close, save in background
       let sourceURL = state.sourceURL
       let sessionSnapshot = makeSessionSnapshot()
       state.markAsSaved()
       saveSessionCache(sessionSnapshot)
-      let renderedImage = AnnotateExporter.renderFinalImage(state: state)
-      if let renderedImage = renderedImage, let itemId = quickAccessItemId {
-        QuickAccessManager.shared.updateItemThumbnail(id: itemId, image: renderedImage)
-        QuickAccessManager.shared.markCloudStale(id: itemId)
+      
+      // Capture instant visual thumbnail from canvas view to avoid stale/blank flash
+      var instantThumbnail: NSImage? = nil
+      if let contentView = self.window?.contentView {
+        let bounds = contentView.bounds
+        if let imageRep = contentView.bitmapImageRepForCachingDisplay(in: bounds) {
+          contentView.cacheDisplay(in: bounds, to: imageRep)
+          let img = NSImage(size: bounds.size)
+          img.addRepresentation(imageRep)
+          instantThumbnail = QuickAccessManager.shared.cgScaleThumbnail(img, maxSize: 200)
+        }
       }
+      
+      let itemId = quickAccessItemId
+      if let instantThumbnail = instantThumbnail, let itemId = itemId {
+        QuickAccessManager.shared.updateItemThumbnail(id: itemId, thumbnail: instantThumbnail, fullResImage: instantThumbnail)
+      }
+      
+      // Pre-cache source image on main thread before background task
+      if let sourceImage = state.effectiveSourceImage {
+        _ = sourceImage.cgImage(forProposedRect: nil, context: nil, hints: nil)
+      }
+      
       let capturedState = state
-      forceClose()
+      forceClose(perfInterval: returnInterval)
+      
       Task.detached(priority: .userInitiated) {
+        // Off-main full-res render
+        let renderedImage = PerfSignpost.measure("render") {
+          AnnotateExporter.renderFinalImage(state: capturedState)
+        }
+        
+        guard let renderedImage = renderedImage else { return }
+        
+        // Off-main downscale
+        let finalThumbnail = PerfSignpost.measure("thumbnailScale") {
+          QuickAccessManager.shared.cgScaleThumbnail(renderedImage, maxSize: 200)
+        }
+        
+        // Main-actor push of authoritative thumbnail & pinned window update
+        if let itemId = itemId {
+          await MainActor.run {
+            QuickAccessManager.shared.updateItemThumbnail(id: itemId, thumbnail: finalThumbnail, fullResImage: renderedImage)
+            QuickAccessManager.shared.markCloudStale(id: itemId)
+          }
+        }
+        
+        // Save to file
         guard await AnnotateExporter.saveToFile(image: renderedImage, state: capturedState),
               let sourceURL else { return }
+              
         await Self.persistCommittedSession(sessionSnapshot, for: sourceURL)
         await PostCaptureActionHandler.shared.copyEditedCaptureToClipboardIfEnabled(
           for: .screenshot,
@@ -590,14 +631,18 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
       }
     } else {
       AnnotateExporter.saveAs(state: state, closeWindow: true)
+      PerfSignpost.endInterval(returnInterval)
     }
   }
 
 
 
-  private func forceClose() {
+  private func forceClose(perfInterval: Any? = nil) {
     state.hasUnsavedChanges = false
-    guard let window = self.window else { return }
+    guard let window = self.window else {
+      PerfSignpost.endInterval(perfInterval)
+      return
+    }
     
     // Hide window instantly
     window.alphaValue = 0
@@ -606,7 +651,15 @@ final class AnnotateWindowController: NSWindowController, NSWindowDelegate {
       QuickAccessManager.shared.setWindowOpen(id: itemId, isOpen: false)
     }
     
-    window.close()
+    PerfSignpost.measure("windowClose") {
+      window.close()
+    }
+
+    if let perfInterval = perfInterval {
+      DispatchQueue.main.async {
+        PerfSignpost.endInterval(perfInterval)
+      }
+    }
   }
 
   // MARK: - Keyboard Shortcuts

--- a/Snapzy/Features/Annotate/Models/AnnotateAnnotationItem.swift
+++ b/Snapzy/Features/Annotate/Models/AnnotateAnnotationItem.swift
@@ -10,7 +10,7 @@ import Foundation
 import SwiftUI
 
 /// Blur effect type for blur annotations
-enum BlurType: String, CaseIterable, Identifiable, Equatable {
+nonisolated enum BlurType: String, CaseIterable, Identifiable, Equatable {
   case pixelated
   case gaussian
   case hexagonal
@@ -51,7 +51,7 @@ enum BlurType: String, CaseIterable, Identifiable, Equatable {
   }
 }
 
-enum WatermarkStyle: String, CaseIterable, Identifiable, Equatable {
+nonisolated enum WatermarkStyle: String, CaseIterable, Identifiable, Equatable {
   case single
   case diagonal
   case tiled
@@ -84,7 +84,7 @@ enum WatermarkStyle: String, CaseIterable, Identifiable, Equatable {
   }
 }
 
-enum TextPresentation: String, CaseIterable, Identifiable, Equatable {
+nonisolated enum TextPresentation: String, CaseIterable, Identifiable, Equatable {
   case plain
   case label
   case callout
@@ -110,7 +110,7 @@ enum TextPresentation: String, CaseIterable, Identifiable, Equatable {
 
 /// Shared proportions for label and callout text. Keeping these in one place
 /// makes the editing overlay, on-canvas preview, and exported image agree.
-enum TextBubbleGeometry {
+nonisolated enum TextBubbleGeometry {
   private enum TailSide {
     case minX
     case maxX
@@ -321,25 +321,25 @@ enum TextBubbleGeometry {
   }
 }
 
-private func + (lhs: CGPoint, rhs: CGPoint) -> CGPoint {
+nonisolated private func + (lhs: CGPoint, rhs: CGPoint) -> CGPoint {
   CGPoint(x: lhs.x + rhs.x, y: lhs.y + rhs.y)
 }
 
-private func - (lhs: CGPoint, rhs: CGPoint) -> CGPoint {
+nonisolated private func - (lhs: CGPoint, rhs: CGPoint) -> CGPoint {
   CGPoint(x: lhs.x - rhs.x, y: lhs.y - rhs.y)
 }
 
-private func * (lhs: CGPoint, rhs: CGFloat) -> CGPoint {
+nonisolated private func * (lhs: CGPoint, rhs: CGFloat) -> CGPoint {
   CGPoint(x: lhs.x * rhs, y: lhs.y * rhs)
 }
 
-private func normalized(_ point: CGPoint) -> CGPoint {
+nonisolated private func normalized(_ point: CGPoint) -> CGPoint {
   let length = hypot(point.x, point.y)
   guard length > 0.0001 else { return .zero }
   return point * (1 / length)
 }
 
-enum ArrowStyle: String, CaseIterable, Identifiable, Equatable {
+nonisolated enum ArrowStyle: String, CaseIterable, Identifiable, Equatable {
   case straight
   case curvedRight
   case curvedLeft
@@ -390,7 +390,7 @@ enum ArrowStyle: String, CaseIterable, Identifiable, Equatable {
   }
 }
 
-enum ArrowBendDirection: String, CaseIterable, Identifiable, Equatable {
+nonisolated enum ArrowBendDirection: String, CaseIterable, Identifiable, Equatable {
   case primary
   case alternate
 
@@ -420,7 +420,7 @@ enum ArrowBendDirection: String, CaseIterable, Identifiable, Equatable {
   }
 }
 
-enum ArrowType: String, Codable, CaseIterable, Identifiable {
+nonisolated enum ArrowType: String, Codable, CaseIterable, Identifiable {
   case classic
   case tapered
   case outlined
@@ -469,7 +469,7 @@ enum ArrowType: String, Codable, CaseIterable, Identifiable {
 
 /// Decoration drawn at a single arrow endpoint (start or end).
 /// Applies to the `.classic` display type; tapered/outlined bake their head into the body.
-enum ArrowEndpointStyle: String, CaseIterable, Identifiable, Equatable {
+nonisolated enum ArrowEndpointStyle: String, CaseIterable, Identifiable, Equatable {
   case none
   case arrow
   case circle
@@ -493,7 +493,7 @@ enum ArrowEndpointStyle: String, CaseIterable, Identifiable, Equatable {
   }
 }
 
-struct ArrowGeometry: Equatable {
+nonisolated struct ArrowGeometry: Equatable {
   var start: CGPoint
   var end: CGPoint
   var style: ArrowStyle
@@ -851,7 +851,7 @@ struct ArrowGeometry: Equatable {
     return rect
   }
 
-  func translatedBy(dx: CGFloat, dy: CGFloat) -> ArrowGeometry {
+  nonisolated func translatedBy(dx: CGFloat, dy: CGFloat) -> ArrowGeometry {
     ArrowGeometry(
       start: CGPoint(x: start.x + dx, y: start.y + dy),
       end: CGPoint(x: end.x + dx, y: end.y + dy),
@@ -1084,7 +1084,7 @@ struct AnnotationItem: Identifiable, Equatable {
 }
 
 /// Types of annotations
-enum AnnotationType: Equatable {
+nonisolated enum AnnotationType: Equatable {
   case path([CGPoint])
   case rectangle
   case filledRectangle
@@ -1146,7 +1146,7 @@ enum AnnotationType: Equatable {
 }
 
 /// Visual properties for an annotation
-struct AnnotationProperties: Equatable {
+nonisolated struct AnnotationProperties: Equatable {
   static let controlValueRange: ClosedRange<CGFloat> = 1 ... 20
 
   var strokeColor: Color

--- a/Snapzy/Features/Annotate/Models/AnnotateAnnotationToolType.swift
+++ b/Snapzy/Features/Annotate/Models/AnnotateAnnotationToolType.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Tool types available in annotation editor
-enum AnnotationToolType: String, CaseIterable, Identifiable {
+nonisolated enum AnnotationToolType: String, CaseIterable, Identifiable {
   case selection
   case crop
   case rectangle

--- a/Snapzy/Features/Annotate/Models/AnnotateBackgroundStyle.swift
+++ b/Snapzy/Features/Annotate/Models/AnnotateBackgroundStyle.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 /// Background style types
-enum BackgroundStyle: Equatable, Sendable {
+nonisolated enum BackgroundStyle: Equatable, Sendable {
   case none
   case gradient(GradientPreset)
   case wallpaper(URL)
@@ -36,7 +36,7 @@ enum BackgroundStyle: Equatable, Sendable {
 }
 
 /// Blur presets for applying a soft effect to the selected background layer.
-enum BlurredBackgroundEffect: String, CaseIterable, Identifiable, Codable, Equatable, Sendable {
+nonisolated enum BlurredBackgroundEffect: String, CaseIterable, Identifiable, Codable, Equatable, Sendable {
   case soft
   case frosted
   case vivid
@@ -124,7 +124,7 @@ enum BlurredBackgroundEffect: String, CaseIterable, Identifiable, Codable, Equat
 }
 
 /// Predefined gradient presets
-enum GradientPreset: String, CaseIterable, Identifiable, Sendable {
+nonisolated enum GradientPreset: String, CaseIterable, Identifiable, Sendable {
   case pinkOrange
   case bluePurple
   case greenBlue
@@ -153,14 +153,14 @@ enum GradientPreset: String, CaseIterable, Identifiable, Sendable {
 }
 
 /// Image alignment within background
-enum ImageAlignment: String, CaseIterable, Sendable {
+nonisolated enum ImageAlignment: String, CaseIterable, Sendable {
   case topLeft, top, topRight
   case left, center, right
   case bottomLeft, bottom, bottomRight
 }
 
 /// Predefined wallpaper presets (abstract gradient patterns)
-enum WallpaperPreset: String, CaseIterable, Identifiable {
+nonisolated enum WallpaperPreset: String, CaseIterable, Identifiable {
   case oceanBreeze
   case sunsetGlow
   case forestMist
@@ -203,7 +203,7 @@ enum WallpaperPreset: String, CaseIterable, Identifiable {
 }
 
 /// Orientation for fixed aspect ratio presets.
-enum AspectRatioOrientation: String, CaseIterable, Identifiable, Sendable {
+nonisolated enum AspectRatioOrientation: String, CaseIterable, Identifiable, Sendable {
   case horizontal
   case vertical
 
@@ -222,7 +222,7 @@ enum AspectRatioOrientation: String, CaseIterable, Identifiable, Sendable {
 }
 
 /// Aspect ratio options for export.
-enum AspectRatioOption: String, CaseIterable, Identifiable, Sendable {
+nonisolated enum AspectRatioOption: String, CaseIterable, Identifiable, Sendable {
   case auto = "Auto"
   case free = "Free"
   case square = "1:1"

--- a/Snapzy/Features/Annotate/Models/AnnotateRenderSnapshot.swift
+++ b/Snapzy/Features/Annotate/Models/AnnotateRenderSnapshot.swift
@@ -1,0 +1,47 @@
+//
+//  AnnotateRenderSnapshot.swift
+//  Snapzy
+//
+//  Immutable value-type snapshot of everything final-image rendering needs.
+//
+
+import AppKit
+
+/// Frozen copy of every `AnnotateState` input used by `AnnotateExporter` rendering.
+/// Built on the main actor (lazy caches pre-warmed, background images pre-resolved),
+/// then consumed from any queue — rendering never touches live state.
+///
+/// Contract: the referenced `NSImage` instances are treated as immutable during render
+/// (state replaces rather than mutates them post-load).
+struct AnnotateRenderSnapshot {
+  var sourceImage: NSImage
+  var editorMode: AnnotateState.EditorMode
+  var isCombineMode: Bool
+  var effectiveContentBounds: CGRect
+  var cropRect: CGRect?
+  var annotations: [AnnotationItem]
+  var embeddedImages: [UUID: NSImage]
+  var embeddedCGImages: [UUID: CGImage]
+
+  var backgroundStyle: BackgroundStyle
+  var isBlurredBackgroundEffectActive: Bool
+  var blurredBackgroundEffect: BlurredBackgroundEffect
+  /// Wallpaper/blurred background for the active `backgroundStyle` URL, resolved on main
+  /// (cache + sandbox access + blur are main-bound). Nil for `.none`/`.gradient`/preset URLs.
+  var resolvedBackgroundImage: NSImage?
+
+  var padding: CGFloat
+  var cornerRadius: CGFloat
+  var shadowIntensity: CGFloat
+  var imageAlignment: ImageAlignment
+  var aspectRatio: AspectRatioOption
+  var aspectRatioOrientation: AspectRatioOrientation
+
+  var mockupRotationX: CGFloat
+  var mockupRotationY: CGFloat
+  var mockupRotationZ: CGFloat
+  var mockupPerspective: CGFloat
+  var mockupShadowRadius: CGFloat
+  var mockupShadowOffsetX: CGFloat
+  var mockupShadowOffsetY: CGFloat
+}

--- a/Snapzy/Features/Annotate/Models/PersistedAnnotationSession.swift
+++ b/Snapzy/Features/Annotate/Models/PersistedAnnotationSession.swift
@@ -9,7 +9,7 @@ import CoreGraphics
 import Foundation
 import SwiftUI
 
-struct PersistedAnnotationSession: Codable {
+nonisolated struct PersistedAnnotationSession: Codable {
   static let currentSchemaVersion = 1
 
   var schemaVersion: Int
@@ -44,7 +44,7 @@ struct PersistedCombineSession: Codable, Equatable {
   var freeBoundsByAnnotationID: [String: CGRect]
 }
 
-struct PersistedFileSignature: Codable, Equatable {
+nonisolated struct PersistedFileSignature: Codable, Equatable {
   var fileSize: Int64
   var modifiedAtMilliseconds: Int64
   var pathExtension: String

--- a/Snapzy/Features/Annotate/Services/AnnotateAnnotationRenderer.swift
+++ b/Snapzy/Features/Annotate/Services/AnnotateAnnotationRenderer.swift
@@ -10,7 +10,7 @@ import CoreGraphics
 import SwiftUI
 
 /// Renders annotations to a CGContext
-struct AnnotationRenderer {
+nonisolated struct AnnotationRenderer {
   private static let livePreviewFullQualityAreaThreshold: CGFloat = 120_000
 
   let context: CGContext
@@ -617,6 +617,8 @@ struct AnnotationRenderer {
 
     // Editor preview path: never do exact work inside draw(). A cache miss schedules
     // async refinement and returns immediately with a friendly placeholder.
+    // NOTE: the export path never passes a blurCacheManager, so this main-isolated
+    // cache is only touched from the interactive (main-actor) canvas.
     if let cacheManager = blurCacheManager {
       if let cachedImage = cacheManager.getCachedBlur(
         for: annotationId,
@@ -838,7 +840,7 @@ struct AnnotationRenderer {
 // MARK: - AnnotationType Extension
 
 extension AnnotationType {
-  var isHighlight: Bool {
+  nonisolated var isHighlight: Bool {
     if case .highlight = self { return true }
     return false
   }

--- a/Snapzy/Features/Annotate/Services/AnnotateBlurEffectRenderer.swift
+++ b/Snapzy/Features/Annotate/Services/AnnotateBlurEffectRenderer.swift
@@ -11,7 +11,7 @@ import CoreImage
 import Metal
 
 /// Quality tier for blur renders. Interactive work must be bounded so UI input never waits on expensive effects.
-enum BlurRenderQuality: Equatable {
+nonisolated enum BlurRenderQuality: Equatable {
   case interactive
   case settled
   case export
@@ -29,7 +29,7 @@ enum BlurRenderQuality: Equatable {
 }
 
 /// Renders pixelated blur effect for sensitive content redaction
-enum BlurEffectRenderer {
+nonisolated enum BlurEffectRenderer {
   /// Default pixel block size for blur effect
   static let defaultPixelSize: CGFloat = 12
 

--- a/Snapzy/Features/Annotate/Services/AnnotateExporter.swift
+++ b/Snapzy/Features/Annotate/Services/AnnotateExporter.swift
@@ -90,6 +90,28 @@ final class AnnotateExporter {
     }
   }
 
+  /// Off-main variant of `saveToFile`: the full-res encode runs on the calling (background)
+  /// queue — it is the most expensive step — while only the sandbox-scoped write and
+  /// history bookkeeping hop to main (both main-bound APIs, ~ms).
+  nonisolated static func saveToFileOffMain(image: NSImage, sourceURL: URL) async -> Bool {
+    DiagnosticLogger.shared.log(.info, .annotate, "Background save", context: ["file": sourceURL.lastPathComponent])
+
+    guard let data = imageData(from: image, for: sourceURL.pathExtension) else { return false }
+
+    do {
+      try await MainActor.run {
+        try SandboxFileAccessManager.shared.withScopedAccess(to: sourceURL.deletingLastPathComponent()) {
+          try data.write(to: sourceURL, options: .atomic)
+        }
+        CaptureHistoryStore.shared.markFileChanged(at: sourceURL)
+      }
+      return true
+    } catch {
+      DiagnosticLogger.shared.logError(.annotate, error, "Background save failed")
+      return false
+    }
+  }
+
   static func copyToClipboard(state: AnnotateState) {
     DiagnosticLogger.shared.log(.info, .annotate, "Copy to clipboard", context: ["annotations": "\(state.annotations.count)"])
     guard let image = renderFinalImage(state: state) else {
@@ -144,7 +166,7 @@ final class AnnotateExporter {
 
   /// Determine the pixel-to-point scale factor from the source image.
   /// Falls back to 1.0 when bitmap metadata is unavailable.
-  private static func sourceImageScale(_ sourceImage: NSImage) -> CGFloat {
+  nonisolated private static func sourceImageScale(_ sourceImage: NSImage) -> CGFloat {
     let pointWidth = sourceImage.size.width
     let pointHeight = sourceImage.size.height
     guard pointWidth > 0, pointHeight > 0 else { return 1.0 }
@@ -168,7 +190,7 @@ final class AnnotateExporter {
     return 1.0
   }
 
-  private static func bestBitmapRepresentation(in image: NSImage) -> NSBitmapImageRep? {
+  nonisolated private static func bestBitmapRepresentation(in image: NSImage) -> NSBitmapImageRep? {
     image.representations
       .compactMap { $0 as? NSBitmapImageRep }
       .max { lhs, rhs in
@@ -176,7 +198,7 @@ final class AnnotateExporter {
       }
   }
 
-  static func bestCGImage(from image: NSImage) -> CGImage? {
+  nonisolated static func bestCGImage(from image: NSImage) -> CGImage? {
     if let cgImage = bestBitmapRepresentation(in: image)?.cgImage {
       return cgImage
     }
@@ -185,7 +207,7 @@ final class AnnotateExporter {
 
   /// Convert NSImage to Data for any supported format (PNG, JPEG, WebP)
   /// Uses CGImageDestination for WebP support (macOS 14+)
-  static func imageData(from image: NSImage, for fileExtension: String) -> Data? {
+  nonisolated static func imageData(from image: NSImage, for fileExtension: String) -> Data? {
     guard let cgImage = bestCGImage(from: image) else {
       return nil
     }
@@ -218,7 +240,7 @@ final class AnnotateExporter {
     return data as Data
   }
 
-  private static func imageDestinationProperties(
+  nonisolated private static func imageDestinationProperties(
     for fileExtension: String,
     scaleFactor: CGFloat
   ) -> CFDictionary? {
@@ -345,9 +367,35 @@ final class AnnotateExporter {
     return image
   }
 
+  /// Main-actor render entry point (Save As / Copy / Share). Freezes state into a
+  /// snapshot first so every render path shares one implementation.
   static func renderFinalImage(state: AnnotateState) -> NSImage? {
+    guard let snapshot = state.makeRenderSnapshot() else { return nil }
+    if snapshot.editorMode == .mockup {
+      DiagnosticLogger.shared.log(.debug, .annotate, "Rendering mockup image")
+      guard let flatImage = renderMockupFlatImage(snapshot: snapshot) else { return nil }
+      return compositeMockupImage(flatImage: flatImage, snapshot: snapshot)
+    }
+    return renderFlatFinalImage(snapshot: snapshot)
+  }
+
+  /// Off-main render entry point for the save-and-close background path.
+  /// Mockup mode renders the flat image off-main, then composites 3D transforms on main
+  /// (SwiftUI `ImageRenderer` is a main-only API).
+  nonisolated static func renderFinalImage(snapshot: AnnotateRenderSnapshot) async -> NSImage? {
+    if snapshot.editorMode == .mockup {
+      DiagnosticLogger.shared.log(.debug, .annotate, "Rendering mockup image")
+      guard let flatImage = renderMockupFlatImage(snapshot: snapshot) else { return nil }
+      return await compositeMockupImage(flatImage: flatImage, snapshot: snapshot)
+    }
+    return renderFlatFinalImage(snapshot: snapshot)
+  }
+
+  /// Flat render pipeline (no mockup transforms). Pure CoreGraphics/AppKit drawing into a
+  /// private bitmap context — safe on any queue, reads only the frozen snapshot.
+  nonisolated static func renderFlatFinalImage(snapshot: AnnotateRenderSnapshot) -> NSImage? {
     let startedAt = CFAbsoluteTimeGetCurrent()
-    let embeddedLayerCount = state.annotations.reduce(into: 0) { count, annotation in
+    let embeddedLayerCount = snapshot.annotations.reduce(into: 0) { count, annotation in
       if case .embeddedImage = annotation.type {
         count += 1
       }
@@ -356,50 +404,44 @@ final class AnnotateExporter {
     defer {
       let durationMs = Int((CFAbsoluteTimeGetCurrent() - startedAt) * 1_000)
       DiagnosticLogger.shared.log(.debug, .annotate, "Render final image completed", context: [
-        "mode": state.editorMode.rawValue,
-        "annotations": "\(state.annotations.count)",
+        "mode": snapshot.editorMode.rawValue,
+        "annotations": "\(snapshot.annotations.count)",
         "embeddedLayers": "\(embeddedLayerCount)",
         "outputSize": outputSizeDescription,
         "durationMs": "\(durationMs)"
       ])
     }
 
-    guard let sourceImage = state.effectiveSourceImage else { return nil }
-
-    // If mockup mode is active, use mockup rendering path with 3D transforms
-    if state.editorMode == .mockup {
-      DiagnosticLogger.shared.log(.debug, .annotate, "Rendering mockup image")
-      return renderMockupImage(state: state)
-    }
+    let sourceImage = snapshot.sourceImage
 
     DiagnosticLogger.shared.log(.debug, .annotate, "Rendering final image", context: [
-      "annotations": "\(state.annotations.count)",
-      "hasCrop": "\(state.cropRect != nil)",
-      "background": "\(state.backgroundStyle)"
+      "annotations": "\(snapshot.annotations.count)",
+      "hasCrop": "\(snapshot.cropRect != nil)",
+      "background": "\(snapshot.backgroundStyle)"
     ])
 
     // Determine effective bounds (crop or full image)
     let effectiveBounds: CGRect
-    if state.isCombineMode {
-      effectiveBounds = state.effectiveContentBounds
-    } else if let cropRect = state.cropRect {
+    if snapshot.isCombineMode {
+      effectiveBounds = snapshot.effectiveContentBounds
+    } else if let cropRect = snapshot.cropRect {
       effectiveBounds = cropRect
     } else {
       effectiveBounds = CGRect(origin: .zero, size: sourceImage.size)
     }
 
-    let padding = state.isCombineMode ? state.padding : (state.backgroundStyle != .none ? state.padding : 0)
+    let padding = snapshot.isCombineMode ? snapshot.padding : (snapshot.backgroundStyle != .none ? snapshot.padding : 0)
 
     // Add alignment space for non-center alignments (matches preview)
-    let alignmentSpace: CGFloat = state.imageAlignment != .center ? 40 : 0
+    let alignmentSpace: CGFloat = snapshot.imageAlignment != .center ? 40 : 0
 
-    let totalSize: NSSize = state.isCombineMode
+    let totalSize: NSSize = snapshot.isCombineMode
       ? NSSize(width: effectiveBounds.width + padding * 2, height: effectiveBounds.height + padding * 2)
-      : state.aspectRatio.canvasSize(
+      : snapshot.aspectRatio.canvasSize(
         for: effectiveBounds.size,
         padding: padding,
         alignmentSpace: alignmentSpace,
-        orientation: state.aspectRatioOrientation
+        orientation: snapshot.aspectRatioOrientation
       )
     outputSizeDescription = "\(Int(totalSize.width))x\(Int(totalSize.height))"
 
@@ -429,7 +471,7 @@ final class AnnotateExporter {
     let context = graphicsContext.cgContext
 
     // Draw background
-    drawBackground(state: state, in: context, size: totalSize)
+    drawBackground(snapshot: snapshot, in: context, size: totalSize)
 
     // Calculate image position based on alignment
     let imageWidth = effectiveBounds.width
@@ -442,7 +484,7 @@ final class AnnotateExporter {
     let destX: CGFloat
     let destY: CGFloat
 
-    switch state.isCombineMode ? ImageAlignment.center : state.imageAlignment {
+    switch snapshot.isCombineMode ? ImageAlignment.center : snapshot.imageAlignment {
     case .center:
       destX = totalExtraWidth / 2
       destY = totalExtraHeight / 2
@@ -472,14 +514,14 @@ final class AnnotateExporter {
       destY = 0
     }
 
-    if state.cornerRadius > 0 {
+    if snapshot.cornerRadius > 0 {
       let clipRect = NSRect(
         x: destX,
         y: destY,
         width: effectiveBounds.width,
         height: effectiveBounds.height
       )
-      let path = NSBezierPath(roundedRect: clipRect, xRadius: state.cornerRadius, yRadius: state.cornerRadius)
+      let path = NSBezierPath(roundedRect: clipRect, xRadius: snapshot.cornerRadius, yRadius: snapshot.cornerRadius)
       path.addClip()
     }
 
@@ -490,13 +532,13 @@ final class AnnotateExporter {
       in: context
     )
 
-    if !state.isCombineMode {
+    if !snapshot.isCombineMode {
       context.resetClip()
     }
 
     // Unified Spotlight overlay pass (drawn below other annotations, above base image).
     // Opacity sourced from per-item properties so exported image matches the on-screen appearance.
-    let spotlightRegions: [SpotlightRegion] = state.annotations.compactMap { a in
+    let spotlightRegions: [SpotlightRegion] = snapshot.annotations.compactMap { a in
       guard case .spotlight = a.type else { return nil }
       let offset = offsetAnnotationForExport(
         a,
@@ -518,16 +560,16 @@ final class AnnotateExporter {
       context: context,
       sourceImage: sourceImage,
       embeddedImageProvider: { assetId in
-        state.embeddedImage(for: assetId)
+        snapshot.embeddedImages[assetId]
       },
       embeddedCGImageProvider: { assetId in
-        state.embeddedCGImage(for: assetId)
+        snapshot.embeddedCGImages[assetId]
       }
     )
-    for annotation in state.annotations {
+    for annotation in snapshot.annotations {
       if case .spotlight = annotation.type { continue }
       // Only include annotations that intersect with crop bounds
-      if let cropRect = state.cropRect {
+      if let cropRect = snapshot.cropRect {
         guard annotation.bounds.intersects(cropRect) else { continue }
       }
       let offsetAnnotation = offsetAnnotationForExport(
@@ -539,7 +581,7 @@ final class AnnotateExporter {
       renderer.draw(offsetAnnotation)
     }
 
-    if state.isCombineMode {
+    if snapshot.isCombineMode {
       context.resetClip()
     }
 
@@ -552,7 +594,7 @@ final class AnnotateExporter {
 
   /// Draw only the source-image portion that intersects the requested canvas bounds.
   /// Expanded crop areas outside the source image intentionally stay transparent/background-filled.
-  private static func drawSourceImage(
+  nonisolated private static func drawSourceImage(
     _ sourceImage: NSImage,
     effectiveBounds: CGRect,
     destinationOrigin: CGPoint,
@@ -601,7 +643,7 @@ final class AnnotateExporter {
     context.restoreGState()
   }
 
-  private static func sourcePixelCropRect(
+  nonisolated private static func sourcePixelCropRect(
     for bounds: CGRect,
     imageSize: CGSize,
     pixelSize: CGSize
@@ -631,7 +673,7 @@ final class AnnotateExporter {
   }
 
   /// Offset annotation for export, accounting for crop origin and alignment-based image position
-  private static func offsetAnnotationForExport(
+  nonisolated private static func offsetAnnotationForExport(
     _ annotation: AnnotationItem,
     cropOrigin: CGPoint,
     imageX: CGFloat,
@@ -675,7 +717,7 @@ final class AnnotateExporter {
   }
 
   /// Offset annotation for crop, accounting for crop origin and padding
-  private static func offsetAnnotationForCrop(
+  nonisolated private static func offsetAnnotationForCrop(
     _ annotation: AnnotationItem,
     cropOrigin: CGPoint,
     padding: CGFloat
@@ -718,7 +760,7 @@ final class AnnotateExporter {
   }
 
   /// Offset an annotation by padding, including internal points for lines/arrows
-  private static func offsetAnnotation(_ annotation: AnnotationItem, by padding: CGFloat) -> AnnotationItem {
+  nonisolated private static func offsetAnnotation(_ annotation: AnnotationItem, by padding: CGFloat) -> AnnotationItem {
     var result = annotation
     result.bounds = annotation.bounds.offsetBy(dx: padding, dy: padding)
 
@@ -742,10 +784,12 @@ final class AnnotateExporter {
     return result
   }
 
-  private static func drawBackground(state: AnnotateState, in context: CGContext, size: NSSize) {
+  /// Snapshot-based background draw. The wallpaper/blurred image arrives pre-resolved
+  /// (main-bound sandbox access + CI blur happen when the snapshot is built).
+  nonisolated private static func drawBackground(snapshot: AnnotateRenderSnapshot, in context: CGContext, size: NSSize) {
     let rect = CGRect(origin: .zero, size: size)
 
-    switch state.backgroundStyle {
+    switch snapshot.backgroundStyle {
     case .none:
       break
 
@@ -755,8 +799,8 @@ final class AnnotateExporter {
     case .solidColor(let color):
       context.setFillColor(NSColor(color).cgColor)
       context.fill(rect)
-      if state.isBlurredBackgroundEffectActive {
-        drawBlurredBackgroundTint(state: state, in: context, rect: rect)
+      if snapshot.isBlurredBackgroundEffectActive {
+        drawBlurredBackgroundTint(effect: snapshot.blurredBackgroundEffect, in: context, rect: rect)
       }
 
     case .wallpaper(let url):
@@ -766,18 +810,17 @@ final class AnnotateExporter {
         drawLinearGradient(colors: preset.colors, in: context, size: size)
         return
       }
-      let preferBlurred = state.isBlurredBackgroundEffectActive
-      if let wallpaper = resolveWallpaperImage(for: url, state: state, preferBlurred: preferBlurred) {
+      if let wallpaper = snapshot.resolvedBackgroundImage {
         wallpaper.draw(in: rect)
-        if preferBlurred {
-          drawBlurredBackgroundTint(state: state, in: context, rect: rect)
+        if snapshot.isBlurredBackgroundEffectActive {
+          drawBlurredBackgroundTint(effect: snapshot.blurredBackgroundEffect, in: context, rect: rect)
         }
       }
 
-    case .blurred(let url):
-      if let wallpaper = resolveWallpaperImage(for: url, state: state, preferBlurred: true) {
+    case .blurred:
+      if let wallpaper = snapshot.resolvedBackgroundImage {
         wallpaper.draw(in: rect)
-        drawBlurredBackgroundTint(state: state, in: context, rect: rect)
+        drawBlurredBackgroundTint(effect: snapshot.blurredBackgroundEffect, in: context, rect: rect)
       }
     }
   }
@@ -838,7 +881,7 @@ final class AnnotateExporter {
     return effects.isBlurredBackgroundEnabled
   }
 
-  private static func drawLinearGradient(colors: [Color], in context: CGContext, size: NSSize) {
+  nonisolated private static func drawLinearGradient(colors: [Color], in context: CGContext, size: NSSize) {
     let cgColors = colors.map { NSColor($0).cgColor }
     let gradient = CGGradient(
       colorsSpace: CGColorSpaceCreateDeviceRGB(),
@@ -857,22 +900,6 @@ final class AnnotateExporter {
 
   private static func resolveWallpaperImage(
     for url: URL,
-    state: AnnotateState,
-    preferBlurred: Bool
-  ) -> NSImage? {
-    if preferBlurred {
-      return state.blurredBackgroundImage(for: url)
-    }
-
-    if let image = state.backgroundImage(for: url) {
-      return image
-    }
-
-    return nil
-  }
-
-  private static func resolveWallpaperImage(
-    for url: URL,
     blurredEffect: BlurredBackgroundEffect,
     preferBlurred: Bool
   ) -> NSImage? {
@@ -883,21 +910,7 @@ final class AnnotateExporter {
     return makeBlurredBackgroundImage(from: image, effect: blurredEffect)
   }
 
-  private static func drawBlurredBackgroundTint(
-    state: AnnotateState,
-    in context: CGContext,
-    rect: CGRect
-  ) {
-    let effect = state.blurredBackgroundEffect
-    guard effect.tintOpacity > 0 else { return }
-
-    context.saveGState()
-    context.setFillColor(NSColor(effect.tintColor).withAlphaComponent(CGFloat(effect.tintOpacity)).cgColor)
-    context.fill(rect)
-    context.restoreGState()
-  }
-
-  private static func drawBlurredBackgroundTint(
+  nonisolated private static func drawBlurredBackgroundTint(
     effect: BlurredBackgroundEffect,
     in context: CGContext,
     rect: CGRect
@@ -910,7 +923,7 @@ final class AnnotateExporter {
     context.restoreGState()
   }
 
-  private static func makeBlurredBackgroundImage(
+  nonisolated private static func makeBlurredBackgroundImage(
     from image: NSImage?,
     effect: BlurredBackgroundEffect
   ) -> NSImage? {
@@ -938,7 +951,7 @@ final class AnnotateExporter {
     return blurred
   }
 
-  private static func destinationOrigin(
+  nonisolated private static func destinationOrigin(
     imageSize: CGSize,
     totalSize: CGSize,
     alignment: ImageAlignment
@@ -972,35 +985,14 @@ final class AnnotateExporter {
 
   // MARK: - Mockup Rendering
 
-  /// Render mockup image with 3D transforms using ImageRenderer
-  /// First flattens image + annotations, then applies 3D transforms
-  private static func renderMockupImage(state: AnnotateState) -> NSImage? {
-    guard state.effectiveSourceImage != nil else { return nil }
-
-    // Step 1: Render flat image with annotations (temporarily disable mockup mode)
-    let savedMode = state.editorMode
-    state.editorMode = .annotate
-    guard let flatImage = renderFlatImageWithAnnotations(state: state) else {
-      state.editorMode = savedMode
-      return nil
-    }
-    state.editorMode = savedMode
-
-    // Step 2: Apply mockup transforms to the flattened image
-    let mockupView = MockupExportViewForAnnotate(flatImage: flatImage, state: state)
-    let renderer = ImageRenderer(content: mockupView)
-    renderer.scale = 2.0
-
-    return renderer.nsImage
-  }
-
-  /// Render flat image with annotations (no mockup transforms)
-  private static func renderFlatImageWithAnnotations(state: AnnotateState) -> NSImage? {
-    guard let sourceImage = state.effectiveSourceImage else { return nil }
+  /// Render the flattened image + annotations that mockup transforms are applied to.
+  /// Pure bitmap drawing from the frozen snapshot — safe on any queue.
+  nonisolated static func renderMockupFlatImage(snapshot: AnnotateRenderSnapshot) -> NSImage? {
+    let sourceImage = snapshot.sourceImage
 
     // Determine effective bounds (crop or full image)
     let effectiveBounds: CGRect
-    if let cropRect = state.cropRect {
+    if let cropRect = snapshot.cropRect {
       effectiveBounds = cropRect
     } else {
       effectiveBounds = CGRect(origin: .zero, size: sourceImage.size)
@@ -1038,14 +1030,14 @@ final class AnnotateExporter {
       context: context,
       sourceImage: sourceImage,
       embeddedImageProvider: { assetId in
-        state.embeddedImage(for: assetId)
+        snapshot.embeddedImages[assetId]
       },
       embeddedCGImageProvider: { assetId in
-        state.embeddedCGImage(for: assetId)
+        snapshot.embeddedCGImages[assetId]
       }
     )
-    for annotation in state.annotations {
-      if let cropRect = state.cropRect {
+    for annotation in snapshot.annotations {
+      if let cropRect = snapshot.cropRect {
         guard annotation.bounds.intersects(cropRect) else { continue }
       }
       let offsetAnnotation = offsetAnnotationForCrop(
@@ -1062,6 +1054,16 @@ final class AnnotateExporter {
     image.addRepresentation(bitmapRep)
     return image
   }
+
+  /// Apply mockup 3D transforms to the flattened image via SwiftUI ImageRenderer.
+  /// ImageRenderer is main-only — this is the sole main-actor step of mockup export.
+  @MainActor static func compositeMockupImage(flatImage: NSImage, snapshot: AnnotateRenderSnapshot) -> NSImage? {
+    let mockupView = MockupExportViewForAnnotate(flatImage: flatImage, snapshot: snapshot)
+    let renderer = ImageRenderer(content: mockupView)
+    renderer.scale = 2.0
+
+    return renderer.nsImage
+  }
 }
 
 // MARK: - Mockup Export View for Annotate
@@ -1069,7 +1071,7 @@ final class AnnotateExporter {
 /// SwiftUI view for exporting mockup with 3D transforms
 struct MockupExportViewForAnnotate: View {
   let flatImage: NSImage  // Pre-rendered image with annotations
-  let state: AnnotateState
+  let snapshot: AnnotateRenderSnapshot
 
   var body: some View {
     ZStack {
@@ -1080,31 +1082,31 @@ struct MockupExportViewForAnnotate: View {
         .resizable()
         .aspectRatio(contentMode: .fit)
         .frame(maxWidth: imageSize.width, maxHeight: imageSize.height)
-        .clipShape(RoundedRectangle(cornerRadius: state.cornerRadius, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: snapshot.cornerRadius, style: .continuous))
         .rotation3DEffect(
-          .degrees(state.mockupRotationY),
+          .degrees(snapshot.mockupRotationY),
           axis: (x: 0, y: 1, z: 0),
           anchor: .center,
           anchorZ: 0,
-          perspective: state.mockupPerspective
+          perspective: snapshot.mockupPerspective
         )
         .rotation3DEffect(
-          .degrees(state.mockupRotationX),
+          .degrees(snapshot.mockupRotationX),
           axis: (x: 1, y: 0, z: 0),
           anchor: .center,
           anchorZ: 0,
-          perspective: state.mockupPerspective
+          perspective: snapshot.mockupPerspective
         )
         .rotation3DEffect(
-          .degrees(state.mockupRotationZ),
+          .degrees(snapshot.mockupRotationZ),
           axis: (x: 0, y: 0, z: 1),
           anchor: .center
         )
         .shadow(
-          color: .black.opacity(state.shadowIntensity),
-          radius: state.mockupShadowRadius,
-          x: state.mockupShadowOffsetX,
-          y: state.mockupShadowOffsetY
+          color: .black.opacity(snapshot.shadowIntensity),
+          radius: snapshot.mockupShadowRadius,
+          x: snapshot.mockupShadowOffsetX,
+          y: snapshot.mockupShadowOffsetY
         )
     }
   }
@@ -1116,7 +1118,7 @@ struct MockupExportViewForAnnotate: View {
   }
 
   private var canvasSize: CGSize {
-    let padding = state.backgroundStyle != .none ? state.padding : 0
+    let padding = snapshot.backgroundStyle != .none ? snapshot.padding : 0
     let extraSpace = padding * 2 + 100 // Extra for shadow and rotation
     return CGSize(
       width: imageSize.width + extraSpace,
@@ -1128,7 +1130,7 @@ struct MockupExportViewForAnnotate: View {
 
   @ViewBuilder
   private var backgroundLayer: some View {
-    switch state.backgroundStyle {
+    switch snapshot.backgroundStyle {
     case .none:
       Color.clear
     case .gradient(let preset):
@@ -1139,51 +1141,37 @@ struct MockupExportViewForAnnotate: View {
       )
     case .solidColor(let color):
       color
-        .brightness(state.isBlurredBackgroundEffectActive ? state.blurredBackgroundEffect.brightness : 0)
+        .brightness(snapshot.isBlurredBackgroundEffectActive ? snapshot.blurredBackgroundEffect.brightness : 0)
         .overlay(
-          (state.isBlurredBackgroundEffectActive ? state.blurredBackgroundEffect.tintColor : .clear)
-            .opacity(state.isBlurredBackgroundEffectActive ? state.blurredBackgroundEffect.tintOpacity : 0)
+          (snapshot.isBlurredBackgroundEffectActive ? snapshot.blurredBackgroundEffect.tintColor : .clear)
+            .opacity(snapshot.isBlurredBackgroundEffectActive ? snapshot.blurredBackgroundEffect.tintOpacity : 0)
         )
     case .wallpaper(let url):
       // Check if this is a preset wallpaper
       if url.scheme == "preset", let presetName = url.host,
          let preset = WallpaperPreset(rawValue: presetName) {
         preset.gradient
-      } else if state.isBlurredBackgroundEffectActive,
-                let image = state.blurredBackgroundImage(for: url) {
+      } else if let image = snapshot.resolvedBackgroundImage {
         Image(nsImage: image)
           .resizable()
           .aspectRatio(contentMode: .fill)
-          .overlay(state.blurredBackgroundEffect.tintColor.opacity(state.blurredBackgroundEffect.tintOpacity))
-      } else if let image = resolvedWallpaperImage(for: url) {
-        Image(nsImage: image)
-          .resizable()
-          .aspectRatio(contentMode: .fill)
+          .overlay(
+            snapshot.isBlurredBackgroundEffectActive
+              ? snapshot.blurredBackgroundEffect.tintColor.opacity(snapshot.blurredBackgroundEffect.tintOpacity)
+              : .clear
+          )
       } else {
         Color.gray.opacity(0.3)
       }
-    case .blurred(let url):
-      let effect = state.blurredBackgroundEffect
-      if let image = state.blurredBackgroundImage(for: url) {
+    case .blurred:
+      if let image = snapshot.resolvedBackgroundImage {
         Image(nsImage: image)
           .resizable()
           .aspectRatio(contentMode: .fill)
-          .overlay(effect.tintColor.opacity(effect.tintOpacity))
-      } else if let image = resolvedWallpaperImage(for: url) {
-        Image(nsImage: image)
-          .resizable()
-          .aspectRatio(contentMode: .fill)
-          .blur(radius: effect.blurRadius)
-          .saturation(effect.saturation)
-          .brightness(effect.brightness)
-          .overlay(effect.tintColor.opacity(effect.tintOpacity))
+          .overlay(snapshot.blurredBackgroundEffect.tintColor.opacity(snapshot.blurredBackgroundEffect.tintOpacity))
       } else {
         Color.gray.opacity(0.3)
       }
     }
-  }
-
-  private func resolvedWallpaperImage(for url: URL) -> NSImage? {
-    state.backgroundImage(for: url)
   }
 }

--- a/Snapzy/Features/Annotate/Services/AnnotateSpotlightCompositor.swift
+++ b/Snapzy/Features/Annotate/Services/AnnotateSpotlightCompositor.swift
@@ -14,7 +14,7 @@ struct SpotlightRegion {
   let opacity: CGFloat  // darkness strength, clamped 0.1...0.9
 }
 
-enum SpotlightCompositor {
+nonisolated enum SpotlightCompositor {
   /// Darken canvasRect except the union of spotlight regions. Opacity is sourced from regions themselves,
   /// so per-item slider changes reflect immediately without a global state sync cycle.
   static func drawOverlay(

--- a/Snapzy/Features/Annotate/Services/AnnotationSessionStore.swift
+++ b/Snapzy/Features/Annotate/Services/AnnotationSessionStore.swift
@@ -13,7 +13,7 @@ final class AnnotationSessionStore {
   static let shared = AnnotationSessionStore()
 
   private let fileManager: FileManager
-  private let rootDirectory: URL
+  private nonisolated let rootDirectory: URL
 
   init(
     rootDirectory: URL = AnnotationSessionStore.defaultRootDirectory(),
@@ -64,22 +64,54 @@ final class AnnotationSessionStore {
 
   @discardableResult
   func persist(_ sessionData: AnnotationSessionData, for sourceURL: URL) -> Bool {
+    let scopedAccess = SandboxFileAccessManager.shared.beginAccessingURL(sourceURL)
+    defer { scopedAccess.stop() }
+    guard let signature = readFileSignature(for: sourceURL) else { return false }
+    let manifest = buildManifest(sessionData, for: sourceURL, signature: signature)
+    return persistWrite(manifest: manifest, sessionData: sessionData, for: sourceURL)
+  }
+
+  /// Off-main persist for the save-and-close background path: the multi-MB package
+  /// write runs on the calling queue instead of the main thread.
+  nonisolated func persistOffMain(_ sessionData: AnnotationSessionData, for sourceURL: URL) async -> Bool {
+    let scopedAccess = await MainActor.run { SandboxFileAccessManager.shared.beginAccessingURL(sourceURL) }
+    defer { scopedAccess.stop() }
+    guard let signature = readFileSignature(for: sourceURL) else { return false }
+    let manifest = await buildManifest(sessionData, for: sourceURL, signature: signature)
+    return persistWrite(manifest: manifest, sessionData: sessionData, for: sourceURL)
+  }
+
+  /// Manifest construction is cheap and kept on main (the conversion init is @MainActor).
+  @MainActor
+  private func buildManifest(
+    _ sessionData: AnnotationSessionData,
+    for sourceURL: URL,
+    signature: PersistedFileSignature
+  ) -> PersistedAnnotationSession {
     let normalizedPath = Self.normalizedPath(for: sourceURL)
     let pathHash = Self.pathHash(for: normalizedPath)
-    guard let signature = fileSignature(for: sourceURL) else { return false }
-
     let directory = sessionDirectory(pathHash: pathHash)
     let previousCreatedAt = readManifest(
       at: directory.appendingPathComponent("manifest.json")
     )?.createdAt ?? Date()
-    let manifest = PersistedAnnotationSession(
+    return PersistedAnnotationSession(
       sessionData: sessionData,
       sourceFilePath: normalizedPath,
       sourceFilePathHash: pathHash,
       sourceSignature: signature,
       createdAt: previousCreatedAt
     )
+  }
 
+  /// The heavy multi-MB package write. Runs on the caller's queue (main for the
+  /// interactive path, a background queue for the save-and-close path).
+  private nonisolated func persistWrite(
+    manifest: PersistedAnnotationSession,
+    sessionData: AnnotationSessionData,
+    for sourceURL: URL
+  ) -> Bool {
+    let pathHash = Self.pathHash(for: Self.normalizedPath(for: sourceURL))
+    let directory = sessionDirectory(pathHash: pathHash)
     do {
       try writePackage(
         manifest: manifest,
@@ -203,19 +235,22 @@ final class AnnotationSessionStore {
       .appendingPathComponent("AnnotationSessions", isDirectory: true)
   }
 
-  private func sessionDirectory(pathHash: String) -> URL {
+  private nonisolated func sessionDirectory(pathHash: String) -> URL {
     rootDirectory.appendingPathComponent(pathHash, isDirectory: true)
   }
 
-  private func ensureRootDirectory() throws {
-    try fileManager.createDirectory(at: rootDirectory, withIntermediateDirectories: true)
+  private nonisolated func ensureRootDirectory() throws {
+    try FileManager.default.createDirectory(at: rootDirectory, withIntermediateDirectories: true)
   }
 
   private func fileSignature(for sourceURL: URL) -> PersistedFileSignature? {
     let scopedAccess = SandboxFileAccessManager.shared.beginAccessingURL(sourceURL)
     defer { scopedAccess.stop() }
+    return readFileSignature(for: sourceURL)
+  }
 
-    guard let attributes = try? fileManager.attributesOfItem(atPath: sourceURL.path) else {
+  private nonisolated func readFileSignature(for sourceURL: URL) -> PersistedFileSignature? {
+    guard let attributes = try? FileManager.default.attributesOfItem(atPath: sourceURL.path) else {
       return nil
     }
     let modifiedAt = (attributes[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
@@ -228,14 +263,14 @@ final class AnnotationSessionStore {
     )
   }
 
-  private func readManifest(at url: URL) -> PersistedAnnotationSession? {
+  private nonisolated func readManifest(at url: URL) -> PersistedAnnotationSession? {
     guard let data = try? Data(contentsOf: url) else { return nil }
     let decoder = JSONDecoder()
     decoder.dateDecodingStrategy = .iso8601
     return try? decoder.decode(PersistedAnnotationSession.self, from: data)
   }
 
-  private func writePackage(
+  private nonisolated func writePackage(
     manifest: PersistedAnnotationSession,
     sessionData: AnnotationSessionData,
     to directory: URL
@@ -243,7 +278,7 @@ final class AnnotationSessionStore {
     try ensureRootDirectory()
     let tempDirectory = rootDirectory.appendingPathComponent(".\(directory.lastPathComponent).\(UUID().uuidString)", isDirectory: true)
     let assetsDirectory = tempDirectory.appendingPathComponent("assets", isDirectory: true)
-    try fileManager.createDirectory(at: assetsDirectory, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: assetsDirectory, withIntermediateDirectories: true)
     do {
       try sessionData.originalImageData.write(to: tempDirectory.appendingPathComponent(manifest.originalFileName), options: .atomic)
       if let cutoutFileName = manifest.cutoutFileName, let cutoutImageData = sessionData.cutoutImageData {
@@ -255,17 +290,17 @@ final class AnnotationSessionStore {
         try data.write(to: assetsDirectory.appendingPathComponent(fileName), options: .atomic)
       }
       try writeManifest(manifest, to: tempDirectory.appendingPathComponent("manifest.json"))
-      if fileManager.fileExists(atPath: directory.path) {
-        try fileManager.removeItem(at: directory)
+      if FileManager.default.fileExists(atPath: directory.path) {
+        try FileManager.default.removeItem(at: directory)
       }
-      try fileManager.moveItem(at: tempDirectory, to: directory)
+      try FileManager.default.moveItem(at: tempDirectory, to: directory)
     } catch {
-      try? fileManager.removeItem(at: tempDirectory)
+      try? FileManager.default.removeItem(at: tempDirectory)
       throw error
     }
   }
 
-  private func writeManifest(_ manifest: PersistedAnnotationSession, to url: URL) throws {
+  private nonisolated func writeManifest(_ manifest: PersistedAnnotationSession, to url: URL) throws {
     let encoder = JSONEncoder()
     encoder.dateEncodingStrategy = .iso8601
     encoder.outputFormatting = [.sortedKeys]

--- a/Snapzy/Features/Preferences/Models/PreferencesKeys.swift
+++ b/Snapzy/Features/Preferences/Models/PreferencesKeys.swift
@@ -132,7 +132,7 @@ enum PreferencesKeys {
   static let annotationShortcutHoldDuration = "recording.annotation.shortcutHoldDuration"
 
   // Diagnostics
-  static let diagnosticsEnabled = "diagnostics.enabled"
+  nonisolated static let diagnosticsEnabled = "diagnostics.enabled"
   static let diagnosticsRetentionDays = "diagnostics.retentionDays"
   static let diagnosticsSessionActive = "diagnostics.sessionActive"
 

--- a/Snapzy/Features/QuickAccess/Components/QuickAccessCardView.swift
+++ b/Snapzy/Features/QuickAccess/Components/QuickAccessCardView.swift
@@ -687,7 +687,7 @@ struct QuickAccessCardView: View {
             do {
               try await CloudManager.shared.deleteByKey(key: oldKey)
             } catch {
-              await DiagnosticLogger.shared.logError(.cloud, error, "Quick access old cloud object cleanup failed")
+              DiagnosticLogger.shared.logError(.cloud, error, "Quick access old cloud object cleanup failed")
             }
           }
         }

--- a/Snapzy/Features/QuickAccess/Managers/QuickAccessPanelController.swift
+++ b/Snapzy/Features/QuickAccess/Managers/QuickAccessPanelController.swift
@@ -157,6 +157,12 @@ final class QuickAccessPanelController {
     panel?.resumeMouseMonitors()
   }
 
+  /// Self-heal the panel's hover monitors after editor windows close (a stalled
+  /// runloop can get the global event tap silently disabled by the system).
+  func reinstallMouseMonitors() {
+    panel?.reinstallMouseMonitors()
+  }
+
   /// Check if panel is currently visible
   var isVisible: Bool {
     panel != nil

--- a/Snapzy/Features/QuickAccess/QuickAccessManager.swift
+++ b/Snapzy/Features/QuickAccess/QuickAccessManager.swift
@@ -136,6 +136,9 @@ final class QuickAccessManager: ObservableObject {
   private let fileAccessManager = SandboxFileAccessManager.shared
   private let tempCaptureManager = TempCaptureManager.shared
   private var dismissTimers: [UUID: QuickAccessCountdownTimer] = [:]
+  /// Monotonic per-item save tokens; guards the async save-and-close thumbnail push
+  /// against out-of-order arrival when the same item is saved twice quickly.
+  private var thumbnailSaveGenerations: [UUID: UInt64] = [:]
   /// Tracks which item IDs are currently being edited (paused by editor)
   private var editingItemIds: Set<UUID> = []
   /// Tracks items doing async work, such as GIF conversion or cloud upload.
@@ -640,8 +643,15 @@ final class QuickAccessManager: ObservableObject {
   func setWindowOpen(id: UUID, isOpen: Bool) {
     if let index = items.firstIndex(where: { $0.id == id }) {
       PerfSignpost.event("setWindowOpenCommit")
-      withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
-        items[index].isWindowOpen = isOpen
+      // No inline withAnimation here: QuickAccessStackView's
+      // `.animation(value: visibleItems.count)` is the single driver for the
+      // hide/reappear spring. Wrapping this mutation too would compound two springs.
+      items[index].isWindowOpen = isOpen
+
+      if !isOpen {
+        // An editor window just closed and the card reappeared: self-heal the
+        // hover monitors in case the runloop stall got the global event tap killed.
+        panelController.reinstallMouseMonitors()
       }
     }
   }
@@ -794,9 +804,16 @@ final class QuickAccessManager: ObservableObject {
     logger.info("Thumbnail updated directly for item \(id)")
   }
 
-  /// Update thumbnail directly with an already-scaled thumbnail and full-resolution image.
+  /// Update thumbnail directly with an already-scaled thumbnail and an optional full-resolution image.
   /// Skips lockFocus scaling on the main thread.
-  func updateItemThumbnail(id: UUID, thumbnail: NSImage, fullResImage: NSImage) {
+  /// - `fullResImage`: when non-nil, also pushed to the pin window as `imageOverride`
+  ///   (pin sizing derives from it, so never pass a downscaled thumb here).
+  /// - `generation`: stale-write guard from `nextThumbnailGeneration(for:)`; a late
+  ///   off-main render with an older generation is dropped so last-save-wins holds.
+  func updateItemThumbnail(id: UUID, thumbnail: NSImage, fullResImage: NSImage?, generation: UInt64? = nil) {
+    if let generation {
+      guard generation >= thumbnailSaveGenerations[id, default: 0] else { return }
+    }
     guard let index = items.firstIndex(where: { $0.id == id }) else { return }
     let existing = items[index]
     items[index] = QuickAccessItem(
@@ -811,12 +828,23 @@ final class QuickAccessManager: ObservableObject {
       isCloudStale: existing.isCloudStale,
       isPinned: existing.isPinned
     )
-    pinWindowManager.update(item: items[index], imageOverride: fullResImage)
+    if let fullResImage {
+      pinWindowManager.update(item: items[index], imageOverride: fullResImage)
+    }
     logger.info("Thumbnail updated directly with pre-scaled image for item \(id)")
   }
 
+  /// Monotonic per-item token for the save-and-close async thumbnail push.
+  /// Call on main when the save starts; pass the token to the async `updateItemThumbnail`
+  /// so a slower earlier render can never overwrite a newer one.
+  func nextThumbnailGeneration(for id: UUID) -> UInt64 {
+    let next = thumbnailSaveGenerations[id, default: 0] + 1
+    thumbnailSaveGenerations[id] = next
+    return next
+  }
+
   /// Scale image to thumbnail size using CGContext (thread-safe, runs on any queue)
-  func cgScaleThumbnail(_ image: NSImage, maxSize: CGFloat) -> NSImage {
+  nonisolated static func cgScaleThumbnail(_ image: NSImage, maxSize: CGFloat) -> NSImage {
     let originalSize = image.size
     guard originalSize.width > 0, originalSize.height > 0 else { return image }
 

--- a/Snapzy/Features/QuickAccess/QuickAccessManager.swift
+++ b/Snapzy/Features/QuickAccess/QuickAccessManager.swift
@@ -639,6 +639,7 @@ final class QuickAccessManager: ObservableObject {
 
   func setWindowOpen(id: UUID, isOpen: Bool) {
     if let index = items.firstIndex(where: { $0.id == id }) {
+      PerfSignpost.event("setWindowOpenCommit")
       withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
         items[index].isWindowOpen = isOpen
       }
@@ -793,34 +794,93 @@ final class QuickAccessManager: ObservableObject {
     logger.info("Thumbnail updated directly for item \(id)")
   }
 
-  /// Scale image to thumbnail size (synchronous, no file I/O)
-  private func scaleThumbnail(_ image: NSImage, maxSize: CGFloat) -> NSImage {
+  /// Update thumbnail directly with an already-scaled thumbnail and full-resolution image.
+  /// Skips lockFocus scaling on the main thread.
+  func updateItemThumbnail(id: UUID, thumbnail: NSImage, fullResImage: NSImage) {
+    guard let index = items.firstIndex(where: { $0.id == id }) else { return }
+    let existing = items[index]
+    items[index] = QuickAccessItem(
+      id: existing.id,
+      url: existing.url,
+      thumbnail: thumbnail,
+      capturedAt: existing.capturedAt,
+      itemType: existing.itemType,
+      duration: existing.duration,
+      cloudURL: existing.cloudURL,
+      cloudKey: existing.cloudKey,
+      isCloudStale: existing.isCloudStale,
+      isPinned: existing.isPinned
+    )
+    pinWindowManager.update(item: items[index], imageOverride: fullResImage)
+    logger.info("Thumbnail updated directly with pre-scaled image for item \(id)")
+  }
+
+  /// Scale image to thumbnail size using CGContext (thread-safe, runs on any queue)
+  func cgScaleThumbnail(_ image: NSImage, maxSize: CGFloat) -> NSImage {
     let originalSize = image.size
     guard originalSize.width > 0, originalSize.height > 0 else { return image }
 
-    let scale: CGFloat
-    if originalSize.width > originalSize.height {
-      scale = min(maxSize / originalSize.width, 1.0)
-    } else {
-      scale = min(maxSize / originalSize.height, 1.0)
-    }
+    let scale = min(maxSize / max(originalSize.width, originalSize.height), 1.0)
     if scale >= 1.0 { return image }
 
     let newSize = CGSize(
       width: originalSize.width * scale,
       height: originalSize.height * scale
     )
-    let thumbnail = NSImage(size: newSize)
-    thumbnail.lockFocus()
-    NSGraphicsContext.current?.imageInterpolation = .high
-    image.draw(
-      in: NSRect(origin: .zero, size: newSize),
-      from: NSRect(origin: .zero, size: originalSize),
-      operation: .copy,
-      fraction: 1.0
-    )
-    thumbnail.unlockFocus()
-    return thumbnail
+
+    var rect = CGRect(origin: .zero, size: originalSize)
+    guard let cgImage = image.cgImage(forProposedRect: &rect, context: nil, hints: nil) else { return image }
+    let width = Int(newSize.width)
+    let height = Int(newSize.height)
+
+    guard let colorSpace = CGColorSpace(name: CGColorSpace.sRGB),
+          let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+          ) else { return image }
+
+    context.interpolationQuality = .high
+    context.draw(cgImage, in: CGRect(origin: .zero, size: newSize))
+
+    guard let scaledCgImage = context.makeImage() else { return image }
+    return NSImage(cgImage: scaledCgImage, size: newSize)
+  }
+
+  /// Scale image to thumbnail size (synchronous, no file I/O)
+  private func scaleThumbnail(_ image: NSImage, maxSize: CGFloat) -> NSImage {
+    return PerfSignpost.measure("scaleThumbnailInner") {
+      let originalSize = image.size
+      guard originalSize.width > 0, originalSize.height > 0 else { return image }
+
+      let scale: CGFloat
+      if originalSize.width > originalSize.height {
+        scale = min(maxSize / originalSize.width, 1.0)
+      } else {
+        scale = min(maxSize / originalSize.height, 1.0)
+      }
+      if scale >= 1.0 { return image }
+
+      let newSize = CGSize(
+        width: originalSize.width * scale,
+        height: originalSize.height * scale
+      )
+      let thumbnail = NSImage(size: newSize)
+      thumbnail.lockFocus()
+      NSGraphicsContext.current?.imageInterpolation = .high
+      image.draw(
+        in: NSRect(origin: .zero, size: newSize),
+        from: NSRect(origin: .zero, size: originalSize),
+        operation: .copy,
+        fraction: 1.0
+      )
+      thumbnail.unlockFocus()
+      return thumbnail
+    }
   }
 
   /// Refresh thumbnail for an item after its image was updated on disk (e.g. annotation saved)

--- a/Snapzy/Features/QuickAccess/QuickAccessPanel.swift
+++ b/Snapzy/Features/QuickAccess/QuickAccessPanel.swift
@@ -50,6 +50,16 @@ final class QuickAccessPanel: NSPanel {
     installMouseMonitors()
   }
 
+  /// Reinstall monitors after a runloop stall. macOS can silently disable the global
+  /// event tap when delivery stalls (no re-enable notification reaches the app),
+  /// which leaves hover dead until the monitors are recreated. No-op while suspended
+  /// (e.g. during an active capture session).
+  func reinstallMouseMonitors() {
+    guard !isMonitorsSuspended else { return }
+    removeMouseMonitors()
+    installMouseMonitors()
+  }
+
   func updatePassthroughRegion(itemCount: Int, scale: CGFloat) {
     visibleItemCount = max(0, itemCount)
     overlayScale = max(0.1, scale)

--- a/Snapzy/Features/VideoEditor/VideoEditorManager.swift
+++ b/Snapzy/Features/VideoEditor/VideoEditorManager.swift
@@ -39,9 +39,12 @@ final class VideoEditorManager {
 
   /// Switch back to accessory mode (menu bar only) if no windows open
   private func becomeAccessoryAppIfNeeded() {
-    guard !hasOpenWindows else { return }
-    guard !AnnotateManager.shared.hasOpenWindows else { return }
-    NSApp.revertActivationPolicyToAccessoryIfNeeded()
+    DispatchQueue.main.async { [weak self] in
+      guard let self = self else { return }
+      guard !self.hasOpenWindows else { return }
+      guard !AnnotateManager.shared.hasOpenWindows else { return }
+      NSApp.revertActivationPolicyToAccessoryIfNeeded()
+    }
   }
 
   /// Open video editor for a quick access item

--- a/Snapzy/Services/Capture/PostCaptureActionHandler.swift
+++ b/Snapzy/Services/Capture/PostCaptureActionHandler.swift
@@ -254,6 +254,9 @@ final class PostCaptureActionHandler {
   }
 
   /// Re-run clipboard automation after an in-place edit save succeeds.
+  /// Screenshots: decode/encode run off-main (serialized so rapid successive
+  /// saves keep last-save-wins clipboard order); only the pasteboard write
+  /// hops back to main. Videos stay on the cheap file-URL path.
   func copyEditedCaptureToClipboardIfEnabled(for captureType: CaptureType, url: URL) {
     guard preferences.isActionEnabled(.copyFile, for: captureType) else {
       DiagnosticLogger.shared.log(
@@ -265,7 +268,15 @@ final class PostCaptureActionHandler {
       return
     }
 
-    copyToClipboard(url: url, isVideo: captureType == .recording)
+    if captureType == .recording {
+      copyToClipboard(url: url, isVideo: true)
+    } else {
+      let previous = editedClipboardTask
+      editedClipboardTask = Task.detached(priority: .userInitiated) {
+        await previous?.value
+        await ClipboardHelper.copyImageOffMain(from: url)
+      }
+    }
 
     let label = captureType == .screenshot ? "screenshot" : "recording"
     logger.debug("Clipboard re-copy executed for edited \(url.lastPathComponent)")
@@ -276,6 +287,9 @@ final class PostCaptureActionHandler {
       context: ["captureType": label, "fileName": url.lastPathComponent]
     )
   }
+
+  /// Chained task serializing off-main edited-capture clipboard writes.
+  private var editedClipboardTask: Task<Void, Never>?
 
   // MARK: - Private
 

--- a/Snapzy/Services/Clipboard/ClipboardHelper.swift
+++ b/Snapzy/Services/Clipboard/ClipboardHelper.swift
@@ -12,7 +12,7 @@ import Foundation
 import UniformTypeIdentifiers
 import os.log
 
-private let logger = Logger(subsystem: "Snapzy", category: "ClipboardHelper")
+nonisolated private let logger = Logger(subsystem: "Snapzy", category: "ClipboardHelper")
 
 /// Centralized helper for copying images to clipboard while respecting the configured format.
 ///
@@ -114,6 +114,7 @@ enum ClipboardHelper {
       to: pasteboard,
       fileURL: url,
       image: image,
+      tiffData: image?.tiffRepresentation,
       encodedData: encodedData,
       encodedType: encodedType
     )
@@ -123,6 +124,51 @@ enum ClipboardHelper {
       // The pasteboard item still exposes the file URL and original encoded data.
       logger.warning("ClipboardHelper: could not decode image, file/data-only clipboard for \(url.lastPathComponent)")
       DiagnosticLogger.shared.log(.warning, .clipboard, "Image decode failed, file/data-only", context: ["file": url.lastPathComponent])
+    }
+
+    logger.info("Clipboard: copied file \(url.lastPathComponent)")
+  }
+
+  /// Off-main variant of `copyImage(from:)` for the post-save re-copy path.
+  /// File read, image decode and TIFF encode (the expensive parts, 50-150ms+ for
+  /// Retina captures) run on the calling background queue; only the pasteboard
+  /// write hops to main. Capture files live inside the app container, so no
+  /// security scope is needed for the read — the scoped-access token is acquired
+  /// on main for parity with the main-thread variant.
+  nonisolated static func copyImageOffMain(from url: URL) async {
+    DiagnosticLogger.shared.log(.info, .clipboard, "Copy image from file (off-main)", context: ["file": url.lastPathComponent])
+
+    guard FileManager.default.fileExists(atPath: url.path) else {
+      logger.error("ClipboardHelper: file not found \(url.lastPathComponent)")
+      DiagnosticLogger.shared.log(.error, .clipboard, "File not found", context: ["file": url.lastPathComponent])
+      return
+    }
+
+    // Heavy work off-main
+    let image = NSImage(contentsOf: url)
+    let tiffData = image?.tiffRepresentation
+    let encodedData = try? Data(contentsOf: url)
+    let encodedType = pasteboardImageType(for: url.pathExtension)
+
+    await MainActor.run {
+      let fileAccess = SandboxFileAccessManager.shared.beginAccessingURL(url)
+      defer { fileAccess.stop() }
+
+      let pasteboard = NSPasteboard.general
+      pasteboard.clearContents()
+      writeSingleImageItem(
+        to: pasteboard,
+        fileURL: url,
+        image: image,
+        tiffData: tiffData,
+        encodedData: encodedData,
+        encodedType: encodedType
+      )
+
+      if image == nil {
+        logger.warning("ClipboardHelper: could not decode image, file/data-only clipboard for \(url.lastPathComponent)")
+        DiagnosticLogger.shared.log(.warning, .clipboard, "Image decode failed, file/data-only", context: ["file": url.lastPathComponent])
+      }
     }
 
     logger.info("Clipboard: copied file \(url.lastPathComponent)")
@@ -173,6 +219,7 @@ enum ClipboardHelper {
       to: pasteboard,
       fileURL: tempURL,
       image: image,
+      tiffData: image.tiffRepresentation,
       encodedData: data,
       encodedType: pasteboardImageType(for: ext)
     )
@@ -186,6 +233,7 @@ enum ClipboardHelper {
     to pasteboard: NSPasteboard,
     fileURL: URL,
     image: NSImage?,
+    tiffData: Data?,
     encodedData: Data?,
     encodedType: NSPasteboard.PasteboardType?
   ) {
@@ -212,7 +260,7 @@ enum ClipboardHelper {
       if let encodedData, let encodedType {
         pasteboard.setData(encodedData, forType: encodedType)
       }
-      if let tiffData = image?.tiffRepresentation {
+      if let tiffData {
         pasteboard.setData(tiffData, forType: .tiff)
       }
     }
@@ -227,7 +275,7 @@ enum ClipboardHelper {
     pasteboard.setString(fileURL.path, forType: .string)
   }
 
-  private static func pasteboardImageType(for fileExtension: String) -> NSPasteboard.PasteboardType? {
+  nonisolated private static func pasteboardImageType(for fileExtension: String) -> NSPasteboard.PasteboardType? {
     let ext = fileExtension.lowercased()
     switch ext {
     case "png":

--- a/Snapzy/Services/Diagnostics/DiagnosticLogEntry.swift
+++ b/Snapzy/Services/Diagnostics/DiagnosticLogEntry.swift
@@ -40,7 +40,7 @@ enum DiagnosticLogCategory: String {
 
 // MARK: - Log Entry
 
-struct DiagnosticLogEntry {
+nonisolated struct DiagnosticLogEntry {
   let timestamp: Date
   let level: DiagnosticLogLevel
   let category: DiagnosticLogCategory

--- a/Snapzy/Services/Diagnostics/DiagnosticLogger.swift
+++ b/Snapzy/Services/Diagnostics/DiagnosticLogger.swift
@@ -10,7 +10,7 @@ import Foundation
 import IOKit
 
 final class DiagnosticLogger {
-  static let shared = DiagnosticLogger()
+  nonisolated static let shared = DiagnosticLogger()
 
   // MARK: - Configuration
 
@@ -29,7 +29,7 @@ final class DiagnosticLogger {
 
   // MARK: - Public API
 
-  var isEnabled: Bool {
+  nonisolated var isEnabled: Bool {
     UserDefaults.standard.object(forKey: PreferencesKeys.diagnosticsEnabled) as? Bool ?? true
   }
 
@@ -43,7 +43,8 @@ final class DiagnosticLogger {
 
   /// Log a diagnostic entry with source location and optional context.
   /// Backward-compatible: existing calls like `log(.info, .capture, "msg")` still compile.
-  func log(
+  /// Thread-safe: all file state is confined to a private serial queue.
+  nonisolated func log(
     _ level: DiagnosticLogLevel,
     _ category: DiagnosticLogCategory,
     _ message: String,
@@ -68,7 +69,7 @@ final class DiagnosticLogger {
   }
 
   /// Convenience for logging errors — auto-extracts localizedDescription, NSError domain/code, and underlying error.
-  func logError(
+  nonisolated func logError(
     _ category: DiagnosticLogCategory,
     _ error: Error,
     _ message: String = "",

--- a/Snapzy/Services/Diagnostics/PerformanceSignpost.swift
+++ b/Snapzy/Services/Diagnostics/PerformanceSignpost.swift
@@ -9,7 +9,7 @@ import Foundation
 import os
 
 @available(macOS 12.0, *)
-private let poster = OSSignposter(subsystem: "com.snapzy.perf", category: "annotate-return")
+nonisolated private let poster = OSSignposter(subsystem: "com.snapzy.perf", category: "annotate-return")
 
 enum PerfSignpost {
   #if DEBUG
@@ -20,7 +20,7 @@ enum PerfSignpost {
   }
   #endif
 
-  static func beginInterval(_ name: StaticString) -> Any? {
+  nonisolated static func beginInterval(_ name: StaticString) -> Any? {
     #if DEBUG
     if #available(macOS 12.0, *) {
       if UserDefaults.standard.bool(forKey: "perf.signposts") {
@@ -32,7 +32,7 @@ enum PerfSignpost {
     return nil
   }
 
-  static func endInterval(_ interval: Any?) {
+  nonisolated static func endInterval(_ interval: Any?) {
     #if DEBUG
     if #available(macOS 12.0, *) {
       if let iv = interval as? Interval {
@@ -42,7 +42,7 @@ enum PerfSignpost {
     #endif
   }
 
-  static func event(_ name: StaticString) {
+  nonisolated static func event(_ name: StaticString) {
     #if DEBUG
     if #available(macOS 12.0, *) {
       if UserDefaults.standard.bool(forKey: "perf.signposts") {
@@ -53,7 +53,7 @@ enum PerfSignpost {
   }
 
   @discardableResult
-  static func measure<T>(_ name: StaticString, _ body: () -> T) -> T {
+  nonisolated static func measure<T>(_ name: StaticString, _ body: () -> T) -> T {
     #if DEBUG
     if #available(macOS 12.0, *) {
       if UserDefaults.standard.bool(forKey: "perf.signposts") {

--- a/Snapzy/Services/Diagnostics/PerformanceSignpost.swift
+++ b/Snapzy/Services/Diagnostics/PerformanceSignpost.swift
@@ -1,0 +1,73 @@
+//
+//  PerformanceSignpost.swift
+//  Snapzy
+//
+//  Helper for performance measurements using OSSignposter.
+//
+
+import Foundation
+import os
+
+@available(macOS 12.0, *)
+private let poster = OSSignposter(subsystem: "com.snapzy.perf", category: "annotate-return")
+
+enum PerfSignpost {
+  #if DEBUG
+  @available(macOS 12.0, *)
+  struct Interval {
+    let name: StaticString
+    let state: OSSignpostIntervalState
+  }
+  #endif
+
+  static func beginInterval(_ name: StaticString) -> Any? {
+    #if DEBUG
+    if #available(macOS 12.0, *) {
+      if UserDefaults.standard.bool(forKey: "perf.signposts") {
+        let state = poster.beginInterval(name)
+        return Interval(name: name, state: state)
+      }
+    }
+    #endif
+    return nil
+  }
+
+  static func endInterval(_ interval: Any?) {
+    #if DEBUG
+    if #available(macOS 12.0, *) {
+      if let iv = interval as? Interval {
+        poster.endInterval(iv.name, iv.state)
+      }
+    }
+    #endif
+  }
+
+  static func event(_ name: StaticString) {
+    #if DEBUG
+    if #available(macOS 12.0, *) {
+      if UserDefaults.standard.bool(forKey: "perf.signposts") {
+        poster.emitEvent(name)
+      }
+    }
+    #endif
+  }
+
+  @discardableResult
+  static func measure<T>(_ name: StaticString, _ body: () -> T) -> T {
+    #if DEBUG
+    if #available(macOS 12.0, *) {
+      if UserDefaults.standard.bool(forKey: "perf.signposts") {
+        let start = CFAbsoluteTimeGetCurrent()
+        let state = poster.beginInterval(name)
+        defer {
+          poster.endInterval(name, state)
+          let elapsed = (CFAbsoluteTimeGetCurrent() - start) * 1000
+          DiagnosticLogger.shared.log(.debug, .ui, "Performance [\(name)]: \(String(format: "%.2f", elapsed))ms")
+        }
+        return body()
+      }
+    }
+    #endif
+    return body()
+  }
+}

--- a/Snapzy/Services/WebPEncoder.swift
+++ b/Snapzy/Services/WebPEncoder.swift
@@ -15,7 +15,7 @@ import WebP
 /// - `method = 1` (fast, ~5x vs default method=4)
 /// - `threadLevel = 1` (multi-threaded VP8 encoding)
 /// - `preset = .photo` (optimised for screenshots / photographic content)
-enum WebPEncoderService {
+nonisolated enum WebPEncoderService {
 
   /// Whether WebP encoding is available (always true when Swift-WebP is linked)
   static var isAvailable: Bool { true }

--- a/Snapzy/Shared/Extensions/NSApplication+Activation.swift
+++ b/Snapzy/Shared/Extensions/NSApplication+Activation.swift
@@ -19,7 +19,9 @@ extension NSApplication {
     }
 
     if visibleWindows.isEmpty && activationPolicy() != .accessory {
-      setActivationPolicy(.accessory)
+      PerfSignpost.measure("policyRevert") {
+        _ = setActivationPolicy(.accessory)
+      }
       DiagnosticLogger.shared.log(.debug, .ui, "Activation policy restored to accessory coordinates")
     }
   }

--- a/Snapzy/Shared/Extensions/NSView+Descendants.swift
+++ b/Snapzy/Shared/Extensions/NSView+Descendants.swift
@@ -1,0 +1,23 @@
+//
+//  NSView+Descendants.swift
+//  Snapzy
+//
+//  View-hierarchy lookup helpers.
+//
+
+import AppKit
+
+extension NSView {
+  /// Depth-first search for the first descendant (excluding self) of the given type.
+  func firstDescendant<T: NSView>(ofType type: T.Type) -> T? {
+    for subview in subviews {
+      if let match = subview as? T {
+        return match
+      }
+      if let match = subview.firstDescendant(ofType: type) {
+        return match
+      }
+    }
+    return nil
+  }
+}

--- a/Snapzy/Shared/Localization/L10n.swift
+++ b/Snapzy/Shared/Localization/L10n.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum L10n {
+nonisolated enum L10n {
   private nonisolated static let tableMappings: [(prefix: String, tableName: String)] = [
     ("action.", "Common"),
     ("combine.", "Combine"),

--- a/SnapzyTests/Features/Annotate/AnnotateRenderSnapshotTests.swift
+++ b/SnapzyTests/Features/Annotate/AnnotateRenderSnapshotTests.swift
@@ -1,0 +1,193 @@
+//
+//  AnnotateRenderSnapshotTests.swift
+//  SnapzyTests
+//
+//  Tests for the snapshot-based off-main render path (save-and-close flow).
+//
+
+import AppKit
+import SwiftUI
+import XCTest
+@testable import Snapzy
+
+@MainActor
+final class AnnotateRenderSnapshotTests: XCTestCase {
+
+  // Keep AnnotateState alive for the test process; XCTest scope cleanup can
+  // crash while deinitializing this MainActor app-level ObservableObject.
+  @MainActor private static var retainedStates: [AnnotateState] = []
+
+  @MainActor
+  private func makeState() -> AnnotateState {
+    let state = AnnotateState()
+    Self.retainedStates.append(state)
+    return state
+  }
+
+  private func makeSourceImage(width: Int = 120, height: Int = 80) throws -> NSImage {
+    let cgImage = try XCTUnwrap(TestImageFactory.solidColor(width: width, height: height))
+    return NSImage(cgImage: cgImage, size: NSSize(width: width, height: height))
+  }
+
+  // MARK: - Snapshot equivalence
+
+  /// The off-main snapshot render must produce byte-identical output to the
+  /// legacy main-actor state render (file output must not change).
+  func testSnapshotRender_matchesStateRender() async throws {
+    let state = makeState()
+    state.sourceImage = try makeSourceImage()
+    state.annotations = [
+      AnnotationItem(
+        type: .rectangle,
+        bounds: CGRect(x: 10, y: 10, width: 40, height: 30),
+        properties: AnnotationProperties(strokeColor: .red, strokeWidth: 3)
+      ),
+      AnnotationItem(
+        type: .text("Hi"),
+        bounds: CGRect(x: 20, y: 40, width: 60, height: 20),
+        properties: AnnotationProperties(fontSize: 14)
+      ),
+    ]
+
+    let reference = try XCTUnwrap(AnnotateExporter.renderFinalImage(state: state))
+    let snapshot = try XCTUnwrap(state.makeRenderSnapshot())
+    let renderedImage = await AnnotateExporter.renderFinalImage(snapshot: snapshot)
+    let rendered = try XCTUnwrap(renderedImage)
+
+    XCTAssertEqual(rendered.size, reference.size)
+    XCTAssertEqual(rendered.tiffRepresentation, reference.tiffRepresentation)
+  }
+
+  /// Canvas effects (gradient background + padding) must flow through the snapshot.
+  func testSnapshotRender_withCanvasEffects_matchesStateRender() async throws {
+    let state = makeState()
+    state.sourceImage = try makeSourceImage()
+    state.backgroundStyle = .gradient(.pinkOrange)
+    state.padding = 24
+    state.cornerRadius = 8
+
+    let reference = try XCTUnwrap(AnnotateExporter.renderFinalImage(state: state))
+    let snapshot = try XCTUnwrap(state.makeRenderSnapshot())
+    let renderedImage = await AnnotateExporter.renderFinalImage(snapshot: snapshot)
+    let rendered = try XCTUnwrap(renderedImage)
+
+    XCTAssertEqual(rendered.size, reference.size)
+    XCTAssertEqual(rendered.tiffRepresentation, reference.tiffRepresentation)
+  }
+
+  /// Crop bounds must be honored identically by both paths.
+  func testSnapshotRender_withCrop_matchesStateRender() async throws {
+    let state = makeState()
+    state.sourceImage = try makeSourceImage()
+    state.cropRect = CGRect(x: 10, y: 10, width: 50, height: 40)
+
+    let reference = try XCTUnwrap(AnnotateExporter.renderFinalImage(state: state))
+    let snapshot = try XCTUnwrap(state.makeRenderSnapshot())
+    let renderedImage = await AnnotateExporter.renderFinalImage(snapshot: snapshot)
+    let rendered = try XCTUnwrap(renderedImage)
+
+    XCTAssertEqual(rendered.size, reference.size)
+    XCTAssertEqual(rendered.tiffRepresentation, reference.tiffRepresentation)
+  }
+
+  // MARK: - Snapshot freezing
+
+  /// The snapshot must pre-warm the lazy embedded CGImage cache so the off-main
+  /// render never mutates state.
+  func testMakeRenderSnapshot_warmsEmbeddedCGImageCache() throws {
+    let state = makeState()
+    state.sourceImage = try makeSourceImage()
+    let assetId = UUID()
+    let embedded = try makeSourceImage(width: 20, height: 20)
+    state.restoreEmbeddedImageAssets(from: [assetId: embedded.tiffRepresentation!])
+    state.annotations = [
+      AnnotationItem(
+        type: .embeddedImage(assetId),
+        bounds: CGRect(x: 5, y: 5, width: 20, height: 20),
+        properties: AnnotationProperties(strokeColor: .clear, fillColor: .clear, strokeWidth: 1)
+      ),
+    ]
+
+    let snapshot = try XCTUnwrap(state.makeRenderSnapshot())
+    XCTAssertNotNil(snapshot.embeddedImages[assetId])
+    XCTAssertNotNil(snapshot.embeddedCGImages[assetId])
+  }
+
+  /// Mutating state after the snapshot is taken must not change the render output
+  /// (proves the snapshot is a frozen copy, not a live reference).
+  func testSnapshot_isFrozenAgainstLaterStateMutation() async throws {
+    let state = makeState()
+    state.sourceImage = try makeSourceImage()
+    state.annotations = [
+      AnnotationItem(
+        type: .rectangle,
+        bounds: CGRect(x: 10, y: 10, width: 40, height: 30),
+        properties: AnnotationProperties(strokeColor: .red, strokeWidth: 3)
+      ),
+    ]
+
+    let reference = try XCTUnwrap(AnnotateExporter.renderFinalImage(state: state))
+    let snapshot = try XCTUnwrap(state.makeRenderSnapshot())
+
+    // Mutate live state after snapshotting
+    state.annotations = []
+    state.cropRect = CGRect(x: 0, y: 0, width: 20, height: 20)
+
+    let renderedImage = await AnnotateExporter.renderFinalImage(snapshot: snapshot)
+    let rendered = try XCTUnwrap(renderedImage)
+    XCTAssertEqual(rendered.size, reference.size)
+    XCTAssertEqual(rendered.tiffRepresentation, reference.tiffRepresentation)
+  }
+
+  // MARK: - cgScaleThumbnail
+
+  func testCgScaleThumbnail_downscalesKeepingAspect() throws {
+    let image = try makeSourceImage(width: 400, height: 200)
+    let thumb = QuickAccessManager.cgScaleThumbnail(image, maxSize: 200)
+    XCTAssertEqual(thumb.size.width, 200, accuracy: 1)
+    XCTAssertEqual(thumb.size.height, 100, accuracy: 1)
+  }
+
+  func testCgScaleThumbnail_doesNotUpscale() throws {
+    let image = try makeSourceImage(width: 100, height: 50)
+    let thumb = QuickAccessManager.cgScaleThumbnail(image, maxSize: 200)
+    XCTAssertEqual(thumb.size, image.size)
+  }
+
+  // MARK: - Save generation guard
+
+  /// A stale (older-generation) async thumbnail push must be dropped so the
+  /// last save always wins, even if its render finishes first.
+  func testUpdateItemThumbnail_dropsStaleGeneration() async throws {
+    let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let fileURL = tempDir.appendingPathComponent("capture.png")
+    let image = try makeSourceImage()
+    try XCTUnwrap(image.tiffRepresentation).write(to: fileURL)
+
+    await QuickAccessManager.shared.addScreenshot(url: fileURL)
+    guard let item = QuickAccessManager.shared.items.first(where: { $0.url == fileURL }) else {
+      return XCTFail("Item was not added")
+    }
+    defer { QuickAccessManager.shared.removeItem(id: item.id) }
+
+    let manager = QuickAccessManager.shared
+    let gen1 = manager.nextThumbnailGeneration(for: item.id)
+    let gen2 = manager.nextThumbnailGeneration(for: item.id)
+    XCTAssertLessThan(gen1, gen2)
+
+    let versionBefore = try XCTUnwrap(manager.items.first { $0.id == item.id }).thumbnailVersion
+
+    // Stale push (older generation) must be dropped
+    manager.updateItemThumbnail(id: item.id, thumbnail: image, fullResImage: nil, generation: gen1)
+    let versionAfterStale = try XCTUnwrap(manager.items.first { $0.id == item.id }).thumbnailVersion
+    XCTAssertEqual(versionAfterStale, versionBefore)
+
+    // Current-generation push must be applied
+    manager.updateItemThumbnail(id: item.id, thumbnail: image, fullResImage: nil, generation: gen2)
+    let versionAfterFresh = try XCTUnwrap(manager.items.first { $0.id == item.id }).thumbnailVersion
+    XCTAssertNotEqual(versionAfterFresh, versionBefore)
+  }
+}

--- a/docs/ANNOTATE.md
+++ b/docs/ANNOTATE.md
@@ -9,7 +9,7 @@ Snapzy's annotation subsystem: the full Annotate editor window (hybrid AppKit sh
 - `Snapzy/Features/Annotate/Managers/AnnotateWindow.swift` — `NSWindow` subclass; intercepts ⌘+scroll zoom, trackpad magnify, Space key (pan mode via `annotateSpaceDown/Up` notifications), drag events; level floats while key (`activeEditorLevel`) and restores `restingLevel` on resign; pin sets resting level `.floating`.
 - `Snapzy/Features/Annotate/AnnotateState.swift` — central `ObservableObject` (~4.8k lines): annotations, tools, undo/redo, zoom/pan, canvas effects, crop, cutout, mockup, combine, cloud state.
 - Layout (`AnnotateMainView`): `AnnotateToolbarView` → `AnnotateQuickPropertiesBar` → `HStack(AnnotateSidebarView 240pt | AnnotateCanvasView)` → `AnnotateBottomBarView`.
-- Rendering: `DrawingCanvasNSView` (AppKit, CoreGraphics draw pass in `AnnotateCanvasDrawingView`) + `AnnotateAnnotationRenderer`; deterministic export via `AnnotateExporter.renderFinalImage` / `renderMockupImage`.
+- Rendering: `DrawingCanvasNSView` (AppKit, CoreGraphics draw pass in `AnnotateCanvasDrawingView`) + `AnnotateAnnotationRenderer`; deterministic export via `AnnotateExporter.renderFinalImage` (mockup: `renderMockupFlatImage` off-main + `compositeMockupImage` on main — `ImageRenderer` is main-only).
 - `AnnotateState.EditorMode`: `.annotate` (flat editing), `.mockup` (3D transforms), `.preview` (hides editing UI).
 
 ```mermaid
@@ -27,6 +27,17 @@ flowchart TD
     I -->|Save / copy&close / drag success / cloud upload| J["AnnotateExporter.renderFinalImage -> write file + persist sidecar"]
     I -->|Close w/o commit| K["Unsaved-change prompt; no sidecar write"]
 ```
+
+### Save-and-close ordering (perf)
+
+⌘S/close-with-save is ordered so the Quick Access card reappears with an unblocked main thread:
+
+1. `markAsSaved` + session cache + `state.makeRenderSnapshot()` — freezes every render input into a value-type `AnnotateRenderSnapshot` (warms lazy embedded-CGImage caches, pre-resolves main-bound wallpaper/blur images).
+2. Instant anti-flash thumbnail: `cacheDisplay` of the canvas region (`DrawingCanvasNSView`, no toolbar/sidebar chrome) downscaled to 200px — set on the card immediately; the pin window is NOT updated with it.
+3. `forceClose()` — window hidden + closed, card reappear commits.
+4. `Task.detached`: off-main `renderFinalImage(snapshot:)` → off-main 200px downscale → main push of the authoritative thumbnail + pin full-res update + `markCloudStale` (guarded by a per-item save generation, last-save-wins) → `saveToFileOffMain` (encode off-main; scoped write + history on main) → sidecar persist off-main (`AnnotationSessionStore.persistOffMain`) → clipboard re-copy off-main (`ClipboardHelper.copyImageOffMain`, serialized).
+
+The `.accessory` activation-policy revert is deferred to a later runloop turn (shared by Annotate/VideoEditor) so it never stalls the reappear. Signposts (`perf.signposts` default + Instruments `com.snapzy.perf`): `AnnotateReturn`, `instantThumbCapture`, `windowClose`, `render`, `thumbnailScale`. Perf evidence: `plans/260718-1956-quick-access-annotate-return-perf/reports/`.
 
 ## Tools & Shortcuts
 

--- a/docs/QUICK_ACCESS.md
+++ b/docs/QUICK_ACCESS.md
@@ -6,8 +6,9 @@ Floating post-capture card stack: appears after every screenshot/video/GIF when 
 
 - `QuickAccessPanel` — borderless `.nonactivatingPanel` NSPanel at `.floating` level; mouse-passthrough outside the card region (`updatePassthroughRegion`, `ignoresMouseEvents` toggled by hit-test).
 - `QuickAccessManager` — singleton stack state; `maxVisibleItems = 5`, newest at top; oldest evicted when full.
-- Mouse monitors suspended during area capture (`suspendForCapture()` → panel + pin windows).
+- Mouse monitors suspended during area capture (`suspendForCapture()` → panel + pin windows). Self-heal: `setWindowOpen(isOpen: false)` (editor window closed) reinstalls the panel's monitors — macOS can silently disable the global event tap after a runloop stall, which otherwise leaves hover dead.
 - Slide-in animation: spring 0.4s (`QuickAccessAnimations.panelEnter`, damping 0.75); falls back to fade under reduceMotion. Appear sound via `QuickAccessSound`.
+- Card hide/reappear (editor open/close) is driven by a SINGLE animation source: `QuickAccessStackView.animation(value: visibleItems.count)` — `QuickAccessManager.setWindowOpen` deliberately does NOT wrap its mutation in `withAnimation` (two compounding springs caused reappear jank).
 - Position: 4-corner model `QuickAccessPosition`; prefs UI exposes left/right (bottom corners). Overlay scale 0.75–1.5 step 0.25 (`overlayScale`, scales `QuickAccessLayout` 180×112 base). Animation style slide/scale (`quickAccess.animationStyle`).
 
 ## Card Anatomy
@@ -75,8 +76,8 @@ flowchart TD
 ```
 
 - See [POST_CAPTURE.md](POST_CAPTURE.md) for the routing matrix, [RECORDING.md](RECORDING.md) for the GIF swap, [HISTORY.md](HISTORY.md) for restore.
-- Clipboard copy runs before Quick Access work so pasteboard updates stay immediate.
-- Save/copy/drag of a pinned screenshot pushes the new render into the open pin window immediately.
+- Clipboard copy runs before Quick Access work so pasteboard updates stay immediate. Exception: the re-copy after an EDITED save runs off-main (decode/encode in background, serialized) and lands ~100-300ms after the window closes — keeps the card reappear stall-free.
+- Save/copy/drag of a pinned screenshot pushes the new render into the open pin window as soon as the background render completes (~50-100ms after save-and-close). The instant 200px anti-flash thumbnail is card-only and is never sent to the pin window (pin sizing derives from the full-res image).
 
 ## Preferences Surface
 


### PR DESCRIPTION
## Problem

Returning from Annotate (⌘S / close-with-save) to the Quick Access card was laggy: dropped frames on the card reappear, occasionally dead hover (healed only by a new capture), and a CPU spike at save.

Root causes (all main-thread work colliding with the reappear animation):
1. Sync full-res render + lockFocus thumbnail downscale + `setActivationPolicy(.accessory)` revert — all in the same runloop turn as the reappear commit.
2. The staged fix moved render off-main but violated MainActor isolation (live `AnnotateState` reads + mockup `ImageRenderer` off-main).
3. Remaining post-commit stalls: clipboard re-copy (default ON: full-res decode + TIFF encode + pasteboard write on main), multi-MB session sidecar write on main.
4. Stuck hover: macOS silently disables the panel's global mouse-monitor event tap after runloop stalls; no reinstall logic existed.

## Changes

**Off-main, actor-safe render**
- `AnnotateRenderSnapshot`: value-type freeze of all render inputs (warms lazy embedded-CGImage cache, pre-resolves main-bound wallpaper/blur images)
- `AnnotateExporter.renderFinalImage(snapshot:) async` — nonisolated flat pipeline; mockup renders flat off-main and only the `ImageRenderer` composite hops to main
- `cgScaleThumbnail` → `nonisolated static`; render-path types audited and marked `nonisolated`
- PNG/JPEG/WebP encode + sidecar package write off-main (`saveToFileOffMain`, `AnnotationSessionStore.persistOffMain`); only scoped write + history on main

**UX correctness**
- Instant anti-flash thumbnail now captures the canvas region only (`DrawingCanvasNSView`), not the whole window chrome; measured via `instantThumbCapture` signpost
- Pin window no longer receives the 200px thumb as `fullResImage` (pin sizing derives from it) — authoritative full-res pushed when the background render lands
- Single animation source drives the reappear (`QuickAccessStackView.animation(value:)`); duplicate `withAnimation` removed from `setWindowOpen`
- Per-item save generation guard: stale async thumbnail pushes dropped (last-save-wins)
- Hover self-heal: panel mouse monitors reinstalled when an editor window closes

**Docs**
- ANNOTATE.md / QUICK_ACCESS.md updated for the new ordering

## Verification

- Build: **BUILD SUCCEEDED** (Debug), no new warnings in touched files
- Tests: **1176 passed, 0 failed** — incl. 8 new tests proving snapshot render is **byte-identical** to the legacy render (plain / canvas-effects / crop), snapshot frozen against mutation, stale-generation drop, thumbnail scaling
- Interactive signpost protocol documented in `plans/260718-1956-quick-access-annotate-return-perf/reports/06-post-review-fixes.md`

Note: Debug builds run `-Onone`; remaining constant-factor slowness is expected vs Release.

## Trade-offs
- Clipboard content after an edited save lands ~100-300ms post-close (was synchronous, blocking)
- One residual warning kept deliberately: `blurCacheManager.getCachedBlur` stays main-isolated (mutable cache, never invoked on the export path)