### PR TITLE
feat: Add dim non-selected area preference for recording

### DIFF
--- a/Snapzy/Features/Preferences/Components/PreferencesCaptureSettingsView.swift
+++ b/Snapzy/Features/Preferences/Components/PreferencesCaptureSettingsView.swift
@@ -60,6 +60,7 @@ struct CaptureSettingsView: View {
   @AppStorage(PreferencesKeys.recordingRememberLastArea) private var rememberLastArea = true
   @AppStorage(PreferencesKeys.recordingIncludeOwnApp) private var includeOwnAppInRecordings = false
   @AppStorage(PreferencesKeys.recordingShowCursor) private var recordingShowCursor = true
+  @AppStorage(PreferencesKeys.recordingDimNonSelectedArea) private var recordingDimNonSelectedArea = true
   @AppStorage(PreferencesKeys.recordingHoverBarVisible) private var recordingHoverBarVisible = true
   @AppStorage(PreferencesKeys.recordingShowTimeOnMenuBar) private var recordingShowTimeOnMenuBar = true
 
@@ -420,6 +421,15 @@ struct CaptureSettingsView: View {
               description: L10n.PreferencesCapture.recordingShowCursorDescription
             ) {
               Toggle("", isOn: $recordingShowCursor)
+                .labelsHidden()
+            }
+
+            SettingRow(
+              icon: "rectangle.center.inset.filled",
+              title: L10n.PreferencesCapture.recordingDimNonSelectedAreaTitle,
+              description: L10n.PreferencesCapture.recordingDimNonSelectedAreaDescription
+            ) {
+              Toggle("", isOn: $recordingDimNonSelectedArea)
                 .labelsHidden()
             }
 

--- a/Snapzy/Features/Preferences/Models/PreferencesKeys.swift
+++ b/Snapzy/Features/Preferences/Models/PreferencesKeys.swift
@@ -108,6 +108,7 @@ enum PreferencesKeys {
   static let recordingOutputMode = "recording.outputMode"
   static let recordingIncludeOwnApp = "recording.includeOwnApp"
   static let recordingShowCursor = "recording.showCursor"
+  static let recordingDimNonSelectedArea = "recording.dimNonSelectedArea"
   static let recordingHighlightClicks = "recording.highlightClicks"
   static let recordingShowKeystrokes = "recording.showKeystrokes"
   static let recordingHoverBarVisible = "recording.hoverBarVisible"

--- a/Snapzy/Features/Recording/Components/RecordingToolbarOptionsMenu.swift
+++ b/Snapzy/Features/Recording/Components/RecordingToolbarOptionsMenu.swift
@@ -126,6 +126,17 @@ private struct ToolbarOptionsPopoverContent: View {
             }
           )
         )
+
+        RightAlignedToggleRow(
+          title: L10n.RecordingToolbar.dimNonSelectedArea,
+          isOn: Binding(
+            get: { state.dimNonSelectedArea },
+            set: { newValue in
+              state.dimNonSelectedArea = newValue
+              UserDefaults.standard.set(newValue, forKey: PreferencesKeys.recordingDimNonSelectedArea)
+            }
+          )
+        )
       }
     }
     .padding(12)

--- a/Snapzy/Features/Recording/Managers/RecordingRegionOverlayWindow.swift
+++ b/Snapzy/Features/Recording/Managers/RecordingRegionOverlayWindow.swift
@@ -138,6 +138,16 @@ final class RecordingRegionOverlayWindow: NSPanel {
     overlayView.needsDisplay = true
   }
 
+  /// Enable or disable the dim fill outside the recording region.
+  /// Called at record-start (and on live preference changes) so non-selected
+  /// windows stay fully visible and usable during recording.
+  func setDimEnabled(_ enabled: Bool) {
+    guard overlayView.showDim != enabled else { return }
+    overlayView.showDim = enabled
+    // Full-view invalidate (not dirty-rect) so any previously drawn dim is fully cleared.
+    overlayView.needsDisplay = true
+  }
+
   /// Enable or disable mouse interaction (disabled during recording)
   func setInteractionEnabled(_ enabled: Bool) {
     ignoresMouseEvents = !enabled
@@ -175,6 +185,7 @@ final class RecordingRegionOverlayView: NSView {
 
   var highlightRect: CGRect
   var showBorder: Bool = true
+  var showDim: Bool = true
   var isInteractionEnabled: Bool = false
   var guidance: RecordingRegionOverlayGuidance? {
     didSet {
@@ -730,9 +741,11 @@ final class RecordingRegionOverlayView: NSView {
   override func draw(_ dirtyRect: NSRect) {
     super.draw(dirtyRect)
 
-    // Draw dim overlay — only the dirty region
-    dimColor.setFill()
-    dirtyRect.fill()
+    // Draw dim overlay — only the dirty region (skipped when dimming is disabled)
+    if showDim {
+      dimColor.setFill()
+      dirtyRect.fill()
+    }
 
     // If actively making new selection, draw that instead
     if isNewSelecting {
@@ -756,11 +769,13 @@ final class RecordingRegionOverlayView: NSView {
     // Clamp to bounds
     let clampedRect = localRect.intersection(bounds)
 
-    // Clear the highlight area (only the portion within dirtyRect)
-    let clearRect = clampedRect.intersection(dirtyRect)
-    if !clearRect.isNull {
-      NSColor.clear.setFill()
-      clearRect.fill(using: .copy)
+    // Clear the highlight area (only meaningful when a dim fill was drawn)
+    if showDim {
+      let clearRect = clampedRect.intersection(dirtyRect)
+      if !clearRect.isNull {
+        NSColor.clear.setFill()
+        clearRect.fill(using: .copy)
+      }
     }
 
     // Draw border around highlight (only in pre-record phase)

--- a/Snapzy/Features/Recording/RecordingCoordinator.swift
+++ b/Snapzy/Features/Recording/RecordingCoordinator.swift
@@ -49,9 +49,19 @@ final class RecordingCoordinator: ObservableObject {
     let showCursor: Bool
     let highlightClicks: Bool
     let showKeystrokes: Bool
+    let dimNonSelectedArea: Bool
   }
 
-  private init() {}
+  private init() {
+    // Live-apply the dim preference while recording so toggling it in Settings (or the
+    // toolbar options) takes effect immediately, mirroring the hover-bar live toggle.
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(dimPreferenceDidChange),
+      name: UserDefaults.didChangeNotification,
+      object: nil
+    )
+  }
 
   private let tempCaptureManager = TempCaptureManager.shared
 
@@ -345,7 +355,8 @@ final class RecordingCoordinator: ObservableObject {
       outputMode: toolbarWindow.outputMode,
       showCursor: toolbarWindow.state.showCursor,
       highlightClicks: toolbarWindow.state.highlightClicks,
-      showKeystrokes: toolbarWindow.state.showKeystrokes
+      showKeystrokes: toolbarWindow.state.showKeystrokes,
+      dimNonSelectedArea: toolbarWindow.state.dimNonSelectedArea
     )
   }
 
@@ -363,6 +374,7 @@ final class RecordingCoordinator: ObservableObject {
       toolbar.state.showCursor = configuration.showCursor
       toolbar.state.highlightClicks = configuration.highlightClicks
       toolbar.state.showKeystrokes = configuration.showKeystrokes
+      toolbar.state.dimNonSelectedArea = configuration.dimNonSelectedArea
       return
     }
 
@@ -632,6 +644,17 @@ final class RecordingCoordinator: ObservableObject {
     }
   }
 
+  /// Re-applies the dim preference to the live region overlays when it changes.
+  /// Only acts while actively recording — the pre-record selection always keeps
+  /// its dim for selection feedback, regardless of the preference.
+  @objc private func dimPreferenceDidChange() {
+    guard recorder.state.isPauseResumeEligible, !regionOverlayWindows.isEmpty else { return }
+    let dimNonSelectedArea = RecordingToolbarPreferences.dimNonSelectedArea()
+    for overlay in regionOverlayWindows {
+      overlay.setDimEnabled(dimNonSelectedArea)
+    }
+  }
+
   private func startRecording() {
     guard let rect = selectedRect, let window = toolbarWindow else {
       DiagnosticLogger.shared.log(.warning, .recording, "Start recording ignored: missing selection or toolbar")
@@ -712,11 +735,13 @@ final class RecordingCoordinator: ObservableObject {
         try await recorder.startRecording()
         removeEscapeMonitors()
 
-        // Hide border on overlay (would appear in video)
-        // Disable interaction during recording
+        // Hide border on overlay (would appear in video), disable interaction, and
+        // apply the dim preference — off keeps non-selected windows fully visible.
+        let dimNonSelectedArea = RecordingToolbarPreferences.dimNonSelectedArea()
         for overlay in regionOverlayWindows {
           overlay.hideBorder()
           overlay.setInteractionEnabled(false)
+          overlay.setDimEnabled(dimNonSelectedArea)
         }
 
         // Setup annotation overlay (must be after recording starts so window exists)
@@ -841,9 +866,11 @@ final class RecordingCoordinator: ObservableObject {
         try await recorder.startRecording()
         removeEscapeMonitors()
 
+        let dimNonSelectedArea = RecordingToolbarPreferences.dimNonSelectedArea()
         for overlay in regionOverlayWindows {
           overlay.hideBorder()
           overlay.setInteractionEnabled(false)
+          overlay.setDimEnabled(dimNonSelectedArea)
         }
         window.showRecordingStatusBar(recorder: recorder, visible: isHoverBarVisiblePreference)
         finishRecordingStartAttempt()

--- a/Snapzy/Features/Recording/RecordingToolbarWindow.swift
+++ b/Snapzy/Features/Recording/RecordingToolbarWindow.swift
@@ -87,6 +87,12 @@ enum RecordingToolbarPreferences {
     defaults.object(forKey: PreferencesKeys.recordingShowCursor) as? Bool ?? true
   }
 
+  /// Whether the area outside the recording region is dimmed during recording.
+  /// Defaults to `true` (dimmed) to preserve prior behavior when unset.
+  static func dimNonSelectedArea(defaults: UserDefaults = .standard) -> Bool {
+    defaults.object(forKey: PreferencesKeys.recordingDimNonSelectedArea) as? Bool ?? true
+  }
+
   /// Whether the floating recording controls bar is shown during recording.
   /// Defaults to `true` (visible) to preserve prior behavior when unset.
   static func hoverBarVisible(defaults: UserDefaults = .standard) -> Bool {
@@ -140,6 +146,7 @@ final class RecordingToolbarState: ObservableObject {
   @Published var showCursor: Bool
   @Published var highlightClicks: Bool
   @Published var showKeystrokes: Bool
+  @Published var dimNonSelectedArea: Bool
   @Published var isPreparingToRecord: Bool = false
 
   var onCaptureModeChanged: ((RecordingCaptureMode) -> Void)?
@@ -155,6 +162,7 @@ final class RecordingToolbarState: ObservableObject {
     self.showCursor = RecordingToolbarPreferences.showCursor()
     self.highlightClicks = RecordingToolbarPreferences.highlightClicks()
     self.showKeystrokes = RecordingToolbarPreferences.showKeystrokes()
+    self.dimNonSelectedArea = RecordingToolbarPreferences.dimNonSelectedArea()
   }
 }
 

--- a/Snapzy/Resources/Localization/Features/Capture.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Capture.xcstrings
@@ -66,7 +66,6 @@
         }
       }
     },
-
     "after-capture.copy-file-action": {
       "extractionState": "stale",
       "localizations": {
@@ -522,7 +521,6 @@
         }
       }
     },
-
     "capture-kind.recording": {
       "extractionState": "stale",
       "localizations": {
@@ -16968,6 +16966,134 @@
           "stringUnit": {
             "state": "translated",
             "value": "在狀態圖示旁顯示已錄製時長。"
+          }
+        }
+      }
+    },
+    "preferences-capture.recording-dim-non-selected-area-title": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht ausgewählten Bereich abdunkeln"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dim Non-Selected Area"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atenuar el área no seleccionada"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assombrir la zone non sélectionnée"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択範囲外を暗くする"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택하지 않은 영역 어둡게 표시"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Затемнять невыбранную область"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Làm mờ vùng không được chọn"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "调暗未选定区域"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "調暗未選取的區域"
+          }
+        }
+      }
+    },
+    "preferences-capture.recording-dim-non-selected-area-description": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dunkelt während der Aufnahme alles außerhalb des Aufnahmebereichs ab, damit der erfasste Bereich hervorsticht. Deaktivieren, damit andere Fenster während der Aufnahme vollständig sichtbar und nutzbar bleiben."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Darken everything outside the recording region while recording so the captured area stands out. Turn off to keep other windows fully visible and usable during recording."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oscurece todo lo que está fuera de la región de grabación mientras grabas para que el área capturada destaque. Desactívalo para mantener otras ventanas completamente visibles y utilizables durante la grabación."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assombrit tout ce qui se trouve en dehors de la zone d'enregistrement pendant l'enregistrement afin de faire ressortir la zone capturée. Désactivez cette option pour garder les autres fenêtres entièrement visibles et utilisables pendant l'enregistrement."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録画中に録画範囲の外側をすべて暗くして、キャプチャ領域を目立たせます。オフにすると、録画中も他のウインドウを完全に表示したまま操作できます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹화하는 동안 녹화 영역 바깥을 어둡게 하여 캡처 영역이 돋보이도록 합니다. 끄면 녹화 중에도 다른 창을 완전히 보고 사용할 수 있습니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Затемняет всё за пределами области записи во время записи, чтобы выделить захватываемую область. Отключите, чтобы другие окна оставались полностью видимыми и доступными во время записи."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Làm tối mọi thứ bên ngoài vùng ghi khi đang ghi để làm nổi bật vùng được ghi. Tắt để giữ cho các cửa sổ khác luôn hiển thị đầy đủ và có thể sử dụng trong khi ghi."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录制时将录制区域以外的所有内容调暗，使捕获区域更加突出。关闭后，录制期间其他窗口仍可完全可见和使用。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "錄製時將錄製區域以外的所有內容調暗，使擷取區域更加突出。關閉後，錄製期間其他視窗仍可完全顯示與使用。"
           }
         }
       }

--- a/Snapzy/Resources/Localization/Features/Recording.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Recording.xcstrings
@@ -6110,6 +6110,70 @@
           }
         }
       }
+    },
+    "recording-toolbar.dim-non-selected-area": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht ausgewählten Bereich abdunkeln"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dim Non-Selected Area"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atenuar el área no seleccionada"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assombrir la zone non sélectionnée"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択範囲外を暗くする"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택하지 않은 영역 어둡게 표시"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Затемнять невыбранную область"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Làm mờ vùng không được chọn"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "调暗未选定区域"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "調暗未選取的區域"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Snapzy/Services/Configuration/SnapzyConfigurationExporter.swift
+++ b/Snapzy/Services/Configuration/SnapzyConfigurationExporter.swift
@@ -95,6 +95,7 @@ enum SnapzyConfigurationExporter {
     writer.value("remember_last_area", defaults.boolValue(PreferencesKeys.recordingRememberLastArea, default: true))
     writer.value("include_snapzy", defaults.boolValue(PreferencesKeys.recordingIncludeOwnApp, default: false))
     writer.value("show_cursor", RecordingToolbarPreferences.showCursor(defaults: defaults))
+    writer.value("dim_non_selected_area", RecordingToolbarPreferences.dimNonSelectedArea(defaults: defaults))
     writer.value("highlight_clicks", RecordingToolbarPreferences.highlightClicks(defaults: defaults))
     writer.value("show_keystrokes", RecordingToolbarPreferences.showKeystrokes(defaults: defaults))
     writer.value("video_editor_zoom_transition_duration", defaults.doubleValue(PreferencesKeys.videoEditorZoomTransitionDuration, default: 0.4))

--- a/Snapzy/Services/Configuration/SnapzyConfigurationImporter.swift
+++ b/Snapzy/Services/Configuration/SnapzyConfigurationImporter.swift
@@ -214,6 +214,9 @@ enum SnapzyConfigurationImporter {
     collectBool(&reader, "recording", "show_cursor", mutations: &mutations) {
       defaults.set($0, forKey: PreferencesKeys.recordingShowCursor)
     }
+    collectBool(&reader, "recording", "dim_non_selected_area", mutations: &mutations) {
+      defaults.set($0, forKey: PreferencesKeys.recordingDimNonSelectedArea)
+    }
     collectBool(&reader, "recording", "highlight_clicks", mutations: &mutations) {
       defaults.set($0, forKey: PreferencesKeys.recordingHighlightClicks)
     }

--- a/Snapzy/Shared/Localization/L10n.swift
+++ b/Snapzy/Shared/Localization/L10n.swift
@@ -2588,6 +2588,16 @@ nonisolated enum L10n {
       defaultValue: "Include mouse pointer in recorded videos and GIFs",
       comment: "Recording preferences setting description"
     )
+    static let recordingDimNonSelectedAreaTitle = string(
+      "preferences-capture.recording-dim-non-selected-area-title",
+      defaultValue: "Dim Non-Selected Area",
+      comment: "Recording preferences setting title"
+    )
+    static let recordingDimNonSelectedAreaDescription = string(
+      "preferences-capture.recording-dim-non-selected-area-description",
+      defaultValue: "Darken everything outside the recording region while recording so the captured area stands out. Turn off to keep other windows fully visible and usable during recording.",
+      comment: "Recording preferences setting description"
+    )
     static let imageFormatTitle = string(
       "preferences-capture.image-format-title",
       defaultValue: "Image Format",
@@ -6396,6 +6406,11 @@ nonisolated enum L10n {
     static let showCursor = string(
       "recording-toolbar.show-cursor",
       defaultValue: "Show Cursor",
+      comment: "Recording toolbar setting label"
+    )
+    static let dimNonSelectedArea = string(
+      "recording-toolbar.dim-non-selected-area",
+      defaultValue: "Dim Non-Selected Area",
       comment: "Recording toolbar setting label"
     )
     static let outputModeAccessibilityPrefix = string(

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -142,6 +142,7 @@ fps = 30
 capture_system_audio = false
 capture_microphone = false
 show_cursor = true
+dim_non_selected_area = true
 highlight_clicks = false
 show_keystrokes = false
 video_editor_zoom_transition_duration = 0.4

--- a/docs/PREFERENCES.md
+++ b/docs/PREFERENCES.md
@@ -43,7 +43,7 @@ Segmented into three panes (`CaptureSettingsPane`): General / Screenshot / Recor
 - **Recording pane**:
   - Format: MOV / MP4 (`recording.format`).
   - Quality: Frame Rate 30/60 (`recording.fps`), Quality (`recording.quality`, `VideoQuality`).
-  - Behavior: Show Cursor (`recording.showCursor`), Remember Last Area (`recording.rememberLastArea`).
+  - Behavior: Show Cursor (`recording.showCursor`), Dim Non-Selected Area (`recording.dimNonSelectedArea`, default on — darkens everything outside the recording region during recording; turn off to keep other windows fully visible/usable while recording), Remember Last Area (`recording.rememberLastArea`).
   - Controls: Hover Bar Visible (`recording.hoverBarVisible`), Show Time on Menu Bar (`recording.showTimeOnMenuBar`).
   - Mouse Highlight: size 30–100, animation 0.3–2.0 s, ripple count 1–5, color (archived `NSColor` in `recording.mouseHighlight.color`), opacity 0.2–1.0; reset-to-default.
   - Keystroke Overlay: font size 12–32, position (`KeystrokeOverlayPosition`), display duration 0.5–5.0 s; reset-to-default.

--- a/docs/RECORDING.md
+++ b/docs/RECORDING.md
@@ -82,6 +82,8 @@ Snapzy windows are normally excluded from the stream; effect overlays are re-inc
 
 Overlay setup happens after `startRecording()` succeeds; region overlay borders are hidden and interaction disabled at the same moment.
 
+- **Region dimming toggle** (pref `PreferencesKeys.recordingDimNonSelectedArea`, default on): `RecordingRegionOverlayView` fills the area outside the recording rect with `black@0.4` (window `sharingType = .none`, so it never enters the video). The dim is always shown during pre-record selection for visual feedback. At record-start each per-screen overlay gets `setDimEnabled(dimNonSelectedArea)` in the same loop that calls `hideBorder()`, so when the pref is off the dim disappears the instant recording begins and non-selected windows stay fully usable. Surfaced in Settings (Capture → Recording → Behavior) and the pre-record toolbar Options popover; `RecordingCoordinator` observes `UserDefaults.didChangeNotification` and re-applies to live overlays while `RecordingState.isPauseResumeEligible` (mid-recording Settings toggles apply live). Pre-record selection dim is never affected by the toggle.
+
 ## GIF Output
 
 - `RecordingOutputMode { .video, .gif }` toggle in the toolbar's Record-button dropdown, persisted `PreferencesKeys.recordingOutputMode`.


### PR DESCRIPTION
## Summary
Adds a new **"Dim Non-Selected Area"** preference setting and toolbar option for screen recording. This allows users to toggle whether areas outside the designated recording region are dimmed during active screen recording, matching the customizable visual experience of area screenshot capture.

Closes #270

---

## Key Changes

### 1. User Interface & Preferences
- **Preferences Panel**: Added *Dim Non-Selected Area* toggle under **Settings -> Capture -> Recording -> Behavior** with localized title and description.
- **Recording Toolbar Options**: Integrated a quick-toggle setting inside the pre-record options popover menu.
- **Localization**: Added localized strings across all 10 supported languages (EN, ES, FR, JA, KO, RU, VI, zh-Hans, zh-Hant).

### 2. Core Behavior & Live Updates
- **Default State**: Enabled by default (`true`), filling the area outside the recording box with a `black@0.4` overlay (`sharingType = .none`, ensuring it is excluded from recorded video streams).
- **Toggle Off Behavior**: When disabled, the dimming overlay automatically hides the moment recording starts, keeping surrounding windows fully visible and interactive. Pre-recording region selection retains dimming for optimal feedback.
- **Live Reactivity**: `RecordingCoordinator` observes `UserDefaults.didChangeNotification` to update active region overlays live when the preference changes during recording.

### 3. Configuration & Documentation
- **TOML Config Sync**: Supported in `SnapzyConfigurationExporter` and `SnapzyConfigurationImporter` via `recording.dim_non_selected_area`.
- **Docs**: Updated `docs/CONFIGURATION.md`, `docs/PREFERENCES.md`, and `docs/RECORDING.md`.

---

## Verification Plan

### Automated / Build Verification
- Verified app builds cleanly with no compiler warnings or type errors.

### Manual Verification
1. **Pre-record Selection**: Verified dimming is visible during region selection regardless of toggle state.
2. **Active Recording (Default ON)**: Verified area outside recording region remains dimmed during recording.
3. **Active Recording (OFF)**: Toggled setting OFF and verified surrounding screen becomes fully clear and interactive upon recording start.
4. **Live Settings Update**: Changed setting in Preferences while recording and verified live overlay reaction.
5. **TOML Import/Export**: Exported configuration and verified `dim_non_selected_area` key is properly serialized and imported.