### PR TITLE
ci: auto-update docs version stamps on release

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -616,18 +616,25 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           sed -i '' "s|/Snapzy/v[0-9][0-9.]*\/install.sh|/Snapzy/v${VERSION}/install.sh|g" README.md
 
+      - name: Update docs version stamps
+        run: |
+          chmod +x scripts/update-docs-version-stamps.sh
+          ./scripts/update-docs-version-stamps.sh \
+            "${{ steps.version.outputs.version }}" \
+            "${{ steps.build.outputs.number }}"
+
       - name: Commit appcast and cask update
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add appcast.xml Casks/snapzy.rb README.md
+          git add appcast.xml Casks/snapzy.rb README.md docs/*.md
           if git diff --cached --quiet; then
-            echo "No appcast/cask/readme changes to commit"
+            echo "No appcast/cask/readme/docs changes to commit"
             exit 0
           fi
           if [ "${{ steps.version.outputs.is_beta }}" = "true" ]; then
-            git commit -m "chore: update appcast for v${{ steps.version.outputs.version }}"
+            git commit -m "chore: update appcast and docs for v${{ steps.version.outputs.version }}"
           else
-            git commit -m "chore: update appcast, cask, and readme for v${{ steps.version.outputs.version }}"
+            git commit -m "chore: update appcast, cask, readme, and docs for v${{ steps.version.outputs.version }}"
           fi
           git push origin master

--- a/docs/APP_LIFECYCLE.md
+++ b/docs/APP_LIFECYCLE.md
@@ -2,7 +2,7 @@
 
 How Snapzy launches, runs onboarding, lives in the menu bar, and shuts down. Covers `Snapzy/App/`, splash/onboarding, app identity, theme, data migrations, and the entitlements/Info.plist contract.
 
-Current as of HEAD (`v1.30.0-beta.4`, build 140, macOS 13.0+ deployment target).
+Current as of HEAD (`v1.30.0-beta.14`, build 150, macOS 13.0+ deployment target).
 
 ## Platform shape
 

--- a/docs/CLOUD.md
+++ b/docs/CLOUD.md
@@ -2,7 +2,7 @@
 
 Bring-your-own-storage cloud uploads for captures: AWS S3, Cloudflare R2, Google Drive. No Snapzy servers, no telemetry — files go straight from the Mac to the user's bucket/drive.
 
-Verified against `Snapzy/Services/Cloud/`, `Snapzy/Features/Preferences/Components/PreferencesCloud*.swift`, and upload call sites at HEAD (`v1.30.0-beta.4`).
+Verified against `Snapzy/Services/Cloud/`, `Snapzy/Features/Preferences/Components/PreferencesCloud*.swift`, and upload call sites at HEAD (`v1.30.0-beta.14`).
 
 ## Current state (as of `dd4ccd5`)
 

--- a/docs/PREFERENCES.md
+++ b/docs/PREFERENCES.md
@@ -1,6 +1,6 @@
 # Preferences
 
-Reference for the Settings window: tab structure, every section, and how preferences are stored. Verified against `Snapzy/Features/Preferences/` at HEAD (`v1.30.0-beta.4`).
+Reference for the Settings window: tab structure, every section, and how preferences are stored. Verified against `Snapzy/Features/Preferences/` at HEAD (`v1.30.0-beta.14`).
 
 ## Root
 

--- a/docs/SHORTCUTS.md
+++ b/docs/SHORTCUTS.md
@@ -2,7 +2,7 @@
 
 Global keyboard shortcuts, in-overlay capture shortcuts, Annotate editor shortcuts, conflict detection, the cheat-sheet overlay, and the `snapzy://` deep-link route table.
 
-Verified against `Snapzy/Services/Shortcuts/`, `Snapzy/Features/Shortcuts/`, `Snapzy/Features/Annotate/Services/AnnotateShortcutManager.swift`, `Snapzy/App/SnapzyDeepLinkHandler.swift`, `Snapzy/Services/Capture/CaptureOverlayShortcutSettings.swift` at HEAD (`v1.30.0-beta.4`).
+Verified against `Snapzy/Services/Shortcuts/`, `Snapzy/Features/Shortcuts/`, `Snapzy/Features/Annotate/Services/AnnotateShortcutManager.swift`, `Snapzy/App/SnapzyDeepLinkHandler.swift`, `Snapzy/Services/Capture/CaptureOverlayShortcutSettings.swift` at HEAD (`v1.30.0-beta.14`).
 
 ## Global shortcut mechanism
 

--- a/docs/UPDATES.md
+++ b/docs/UPDATES.md
@@ -2,7 +2,7 @@
 
 Sparkle-based app updates, local diagnostic logging, crash detection, and the manual problem-report bundle. No telemetry anywhere — logs stay on the user's Mac.
 
-Verified against `Snapzy/Services/Updates/UpdaterManager.swift`, `Snapzy/Features/Updates/`, `Snapzy/Services/Diagnostics/`, `Snapzy/Features/CrashReport/`, `Snapzy/Resources/Info.plist`, and `appcast.xml` at HEAD (`v1.30.0-beta.4`).
+Verified against `Snapzy/Services/Updates/UpdaterManager.swift`, `Snapzy/Features/Updates/`, `Snapzy/Services/Diagnostics/`, `Snapzy/Features/CrashReport/`, `Snapzy/Resources/Info.plist`, and `appcast.xml` at HEAD (`v1.30.0-beta.14`).
 
 ## Sparkle updates
 

--- a/scripts/update-docs-version-stamps.sh
+++ b/scripts/update-docs-version-stamps.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# update-docs-version-stamps.sh - Align docs HEAD version stamps with a release
+# Usage: ./scripts/update-docs-version-stamps.sh <version> <build_number> [docs_dir]
+#
+# Example:
+#   ./scripts/update-docs-version-stamps.sh "1.2.3" "999"
+
+set -euo pipefail
+
+VERSION_RAW="${1:?Usage: update-docs-version-stamps.sh <version> <build_number> [docs_dir]}"
+BUILD_NUMBER="${2:?Usage: update-docs-version-stamps.sh <version> <build_number> [docs_dir]}"
+DOCS_DIR="${3:-docs}"
+
+VERSION="${VERSION_RAW#v}"
+
+if [ ! -d "$DOCS_DIR" ]; then
+  echo "::error::Docs directory not found: $DOCS_DIR"
+  exit 1
+fi
+
+if ! [[ "$BUILD_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "::error::Build number must be an integer: $BUILD_NUMBER"
+  exit 1
+fi
+
+DEPLOYMENT_TARGET="13.0"
+PROJ_FILE="Snapzy.xcodeproj/project.pbxproj"
+if [ -f "$PROJ_FILE" ]; then
+  DETECTED=$(grep -m1 'MACOSX_DEPLOYMENT_TARGET' "$PROJ_FILE" | sed 's/.*= //' | sed 's/;.*//' | tr -d ' ' || true)
+  if [[ "$DETECTED" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
+    DEPLOYMENT_TARGET="$DETECTED"
+  fi
+fi
+
+updated=0
+shopt -s nullglob
+for file in "$DOCS_DIR"/*.md; do
+  before=$(cksum <"$file")
+
+  # Simple stamp: at HEAD (`v…`)
+  sed -i '' -E \
+    "s/at HEAD \(\`v[^\`]+\`\)/at HEAD (\`v${VERSION}\`)/g" \
+    "$file"
+
+  # Detailed stamp: Current as of HEAD (`v…`, build N, macOS X.Y+ deployment target)
+  sed -i '' -E \
+    "s/Current as of HEAD \(\`v[^\`]+\`, build [0-9]+, macOS [0-9]+(\.[0-9]+)*\+ deployment target\)/Current as of HEAD (\`v${VERSION}\`, build ${BUILD_NUMBER}, macOS ${DEPLOYMENT_TARGET}+ deployment target)/g" \
+    "$file"
+
+  after=$(cksum <"$file")
+  if [ "$before" != "$after" ]; then
+    echo "Updated stamps in $file"
+    updated=$((updated + 1))
+  fi
+done
+
+echo "Docs version stamps: v${VERSION}, build ${BUILD_NUMBER}, macOS ${DEPLOYMENT_TARGET}+ (${updated} file(s) changed)"


### PR DESCRIPTION
## Summary
- Add `scripts/update-docs-version-stamps.sh` to align `docs/*.md` HEAD version stamps with the release version/build.
- Call the script from `release-publish.yml` after appcast updates, and include `docs/*.md` in the same bot commit.
- Refresh the currently stale stamps to `v1.30.0-beta.14` (build 150).

## Why
Several docs still said `at HEAD (v1.30.0-beta.4)` while the project was already at `v1.30.0-beta.14`. Appcast is already maintained by the publish workflow; docs stamps were not, so they drifted after every release.

## Validation
```bash
# Fake version — 5 files update
./scripts/update-docs-version-stamps.sh "9.9.9-beta.99" "999"
# Restore current release stamps
./scripts/update-docs-version-stamps.sh "1.30.0-beta.14" "150"
# Idempotent — expect 0 file(s) changed
./scripts/update-docs-version-stamps.sh "1.30.0-beta.14" "150"

bash -n scripts/update-docs-version-stamps.sh
```