### PR TITLE
feat: Reduced freeze-screen area capture latency

### DIFF
--- a/Snapzy/Features/Capture/CaptureViewModel.swift
+++ b/Snapzy/Features/Capture/CaptureViewModel.swift
@@ -600,6 +600,36 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
     // Give WindowServer enough time to fully remove hidden app windows before
     // the frozen backdrop is prepared.
     let snapshotDelay = hiddenWindowSession.didHideWindows ? frozenSnapshotWindowHideSettleDelay : 0
+
+    // Resolve NSScreen data on main thread (AppKit requirement), then pass as
+    // value types across the thread boundary for off-main CGDisplayCreateImage.
+    // Eligibility mirrors captureFastDisplaySnapshot guards for these call-site args;
+    // the own-application guard always passes because own windows were hidden above.
+    // Both call sites are on the main thread, so NSScreen access stays safe.
+    let makeFastSnapshotTask: () -> Task<FrozenDisplaySnapshot?, Never>? = {
+      guard !showCursor && !excludeDesktopIcons && !excludeDesktopWidgets,
+            let screen = NSScreen.screens.first(where: { $0.displayID == targetDisplayID })
+      else { return nil }
+      let screenFrame = screen.frame
+      let backingScaleFactor = screen.backingScaleFactor
+      let colorSpaceName = self.captureManager.preferredCaptureColorSpaceName(for: screen)
+      let captureManager = self.captureManager
+      // Task.detached ensures CGDisplayCreateImage runs on the cooperative thread
+      // pool, freeing the main thread.
+      return Task.detached {
+        captureManager.captureFastDisplaySnapshotOffMain(
+          displayID: targetDisplayID,
+          screenFrame: screenFrame,
+          backingScaleFactor: backingScaleFactor,
+          colorSpaceName: colorSpaceName
+        )
+      }
+    }
+    // Only pre-start the task when no windows were hidden: when they were, the
+    // off-main snapshot must wait out the settle delay or it can pick up
+    // Snapzy's own just-hidden windows.
+    let fastSnapshotTask = hiddenWindowSession.didHideWindows ? nil : makeFastSnapshotTask()
+
     DispatchQueue.main.asyncAfter(deadline: .now() + snapshotDelay) { [weak self] in
       guard let self else {
         DiagnosticLogger.shared.log(.warning, .capture, "captureArea: self deallocated")
@@ -614,16 +644,11 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
           self.isCapturing = true
           let snapshotStartedAt = Date()
           let captureMode: String
-          if let fastSnapshot = self.captureManager.captureFastDisplaySnapshot(
-            displayID: targetDisplayID,
-            showCursor: showCursor,
-            excludeDesktopIcons: excludeDesktopIcons,
-            excludeDesktopWidgets: excludeDesktopWidgets,
-            excludeOwnApplication: excludeOwnApplication,
-            allowFastPathWhenOwnApplicationHidden: excludeOwnApplication
-          ) {
+          if let fastSnapshotTask = fastSnapshotTask ?? makeFastSnapshotTask(),
+             let fastSnapshot = await fastSnapshotTask.value
+          {
             frozenSession = FrozenAreaCaptureSession.fromSnapshot(fastSnapshot)
-            captureMode = "coregraphics"
+            captureMode = "coregraphics-offmain"
           } else {
             let shareableContentTask = prefetchedContentTask ?? self.captureManager.prefetchShareableContent(
               includeDesktopWindows: excludeDesktopIcons || excludeDesktopWidgets
@@ -836,16 +861,36 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
       && !excludeDesktopIcons
       && !excludeDesktopWidgets
     if canUseFastPath {
-      let snapshots = NSScreen.screens.compactMap { screen -> FrozenDisplaySnapshot? in
-        guard let displayID = screen.displayID else { return nil }
-        return captureManager.captureFastDisplaySnapshot(
-          displayID: displayID,
-          showCursor: false,
-          excludeDesktopIcons: false,
-          excludeDesktopWidgets: false,
-          excludeOwnApplication: excludeOwnApplication,
-          allowFastPathWhenOwnApplicationHidden: excludeOwnApplication
-        )
+      // Resolve NSScreen data on main thread (AppKit requirement), then run
+      // CGDisplayCreateImage concurrently off-main for all displays.
+      let captureManager = captureManager
+      let screens = NSScreen.screens
+      let screenInputs: [(displayID: CGDirectDisplayID, screenFrame: CGRect, backingScaleFactor: CGFloat, colorSpaceName: CFString?)] =
+        screens.compactMap { screen in
+          guard let displayID = screen.displayID else { return nil }
+          return (
+            displayID,
+            screen.frame,
+            screen.backingScaleFactor,
+            captureManager.preferredCaptureColorSpaceName(for: screen)
+          )
+        }
+      let snapshots = await withTaskGroup(of: FrozenDisplaySnapshot?.self) { group in
+        for input in screenInputs {
+          group.addTask {
+            captureManager.captureFastDisplaySnapshotOffMain(
+              displayID: input.displayID,
+              screenFrame: input.screenFrame,
+              backingScaleFactor: input.backingScaleFactor,
+              colorSpaceName: input.colorSpaceName
+            )
+          }
+        }
+        var results: [FrozenDisplaySnapshot] = []
+        for await snapshot in group {
+          if let snapshot { results.append(snapshot) }
+        }
+        return results
       }
       if !snapshots.isEmpty, snapshots.count == NSScreen.screens.count {
         return (FrozenAreaCaptureSession.fromSnapshots(snapshots), "coregraphics-all")
@@ -976,19 +1021,38 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
                   excludeOwnApplication: excludeOwnApplication
                 )
               }
-              let cropResult: FrozenAreaCropResult
+              let snapshotsByID = frozenSession.allSnapshots()
               let outputScaleFactor = self.preferredScreenshotOutputScaleFactor
+              let cropStartedAt = Date()
+              let cropResult: FrozenAreaCropResult
               if selection.spansMultipleDisplays {
-                cropResult = try frozenSession.cropCompositeImage(
-                  for: selection,
-                  minimumOutputScaleFactor: outputScaleFactor
-                )
+                cropResult = try await Task.detached {
+                  try FrozenAreaCaptureSession.cropCompositeImage(
+                    snapshots: snapshotsByID,
+                    for: selection,
+                    minimumOutputScaleFactor: outputScaleFactor
+                  )
+                }.value
               } else {
-                cropResult = try frozenSession.cropImage(
-                  for: selection,
-                  minimumOutputScaleFactor: outputScaleFactor
-                )
+                cropResult = try await Task.detached {
+                  try FrozenAreaCaptureSession.cropImage(
+                    snapshots: snapshotsByID,
+                    for: selection,
+                    minimumOutputScaleFactor: outputScaleFactor
+                  )
+                }.value
               }
+              DiagnosticLogger.shared.log(
+                .debug,
+                .capture,
+                "Frozen area crop completed",
+                context: [
+                  "duration_ms": "\(Int(Date().timeIntervalSince(cropStartedAt) * 1000))",
+                  "mode": selection.spansMultipleDisplays ? "composite" : "single",
+                  "width": "\(cropResult.image.width)",
+                  "height": "\(cropResult.image.height)",
+                ]
+              )
               let result = await self.captureManager.saveProcessedImage(
                 cropResult.image,
                 to: actualSaveDirectory,
@@ -1325,19 +1389,37 @@ final class ScreenCaptureViewModel: ObservableObject, KeyboardShortcutDelegate {
     let frozenSession = FrozenAreaCaptureSession.fromSnapshots(snapshots)
 
     do {
+      let snapshotsByID = frozenSession.allSnapshots()
       let outputScaleFactor = preferredScreenshotOutputScaleFactor
+      let cropStartedAt = Date()
       let cropResult: FrozenAreaCropResult
       if selection.spansMultipleDisplays {
-        cropResult = try frozenSession.cropCompositeImage(
-          for: selection,
-          minimumOutputScaleFactor: outputScaleFactor
-        )
+        cropResult = try await Task.detached {
+          try FrozenAreaCaptureSession.cropCompositeImage(
+            snapshots: snapshotsByID,
+            for: selection,
+            minimumOutputScaleFactor: outputScaleFactor
+          )
+        }.value
       } else {
-        cropResult = try frozenSession.cropImage(
-          for: selection,
-          minimumOutputScaleFactor: outputScaleFactor
-        )
+        cropResult = try await Task.detached {
+          try FrozenAreaCaptureSession.cropImage(
+            snapshots: snapshotsByID,
+            for: selection,
+            minimumOutputScaleFactor: outputScaleFactor
+          )
+        }.value
       }
+      DiagnosticLogger.shared.log(
+        .debug, .capture,
+        "Frozen area crop completed",
+        context: [
+          "duration_ms": "\(Int(Date().timeIntervalSince(cropStartedAt) * 1000))",
+          "mode": selection.spansMultipleDisplays ? "composite" : "single",
+          "width": "\(cropResult.image.width)",
+          "height": "\(cropResult.image.height)"
+        ]
+      )
       let result = await captureManager.saveProcessedImage(
         cropResult.image,
         to: saveDirectory,

--- a/Snapzy/Services/Capture/AreaSelectionMagnifier.swift
+++ b/Snapzy/Services/Capture/AreaSelectionMagnifier.swift
@@ -131,14 +131,12 @@ final class AreaSelectionMagnifier {
     return zoom != oldZoom
   }
 
+  private var pixelReadContext: CGContext?
+
   func update(
     at point: CGPoint,
     bounds: CGRect,
     backdropImage: CGImage?,
-    pixelData: [UInt8]?,
-    backdropWidth: Int,
-    backdropHeight: Int,
-    backdropScale: CGFloat,
     contentsScale: CGFloat,
     in rootLayer: CALayer
   ) {
@@ -195,23 +193,8 @@ final class AreaSelectionMagnifier {
     let pixelRect = CGRect(x: px, y: py, width: zoom, height: zoom)
     centerIndicator.path = CGPath(rect: pixelRect, transform: nil)
 
-    // Read pixel color under cursor from backdropPixelDataArray
-    var hexText = ""
-    if let pixelData = pixelData, backdropWidth > 0, backdropHeight > 0 {
-      let scaleX = bounds.width > 0 ? CGFloat(backdropWidth) / bounds.width : backdropScale
-      let scaleY = bounds.height > 0 ? CGFloat(backdropHeight) / bounds.height : backdropScale
-      let pixelX = point.x * scaleX
-      let pixelY = point.y * scaleY
-      let x = max(0, min(backdropWidth - 1, Int(pixelX)))
-      let y = max(0, min(backdropHeight - 1, backdropHeight - 1 - Int(pixelY)))
-      let pixelOffset = (y * backdropWidth + x) * 4
-      if pixelOffset + 2 < pixelData.count {
-        let r = pixelData[pixelOffset]
-        let g = pixelData[pixelOffset + 1]
-        let b = pixelData[pixelOffset + 2]
-        hexText = String(format: "#%02X%02X%02X", r, g, b)
-      }
-    }
+    // Read pixel color under cursor directly from the backdrop image (1×1 crop + draw, exact)
+    let hexText = hexColor(at: point, bounds: bounds, image: backdropImage) ?? ""
 
     let zoomString = String(format: "%.0fx", zoom)
     let infoString = hexText.isEmpty ? zoomString : "\(zoomString) • \(hexText)"
@@ -236,5 +219,49 @@ final class AreaSelectionMagnifier {
     infoText.isHidden = false
 
     CATransaction.commit()
+  }
+
+  /// Reads the exact pixel color under `point` by cropping a single pixel out of `image`
+  /// and drawing it into a reusable 1×1 context. Returns nil on any failure.
+  private func hexColor(at point: CGPoint, bounds: CGRect, image: CGImage) -> String? {
+    guard bounds.width > 0, bounds.height > 0, image.width > 0, image.height > 0 else {
+      return nil
+    }
+
+    let scaleX = CGFloat(image.width) / bounds.width
+    let scaleY = CGFloat(image.height) / bounds.height
+    let x = max(0, min(image.width - 1, Int(point.x * scaleX)))
+    // Invert y because Cocoa origin is bottom-left, while CGImage origin is top-left
+    let y = max(0, min(image.height - 1, image.height - 1 - Int(point.y * scaleY)))
+
+    let colorSpace = CGColorSpaceCreateDeviceRGB()
+    let context: CGContext
+    if let cached = pixelReadContext {
+      context = cached
+    } else {
+      guard let created = CGContext(
+        data: nil,
+        width: 1,
+        height: 1,
+        bitsPerComponent: 8,
+        bytesPerRow: 0,
+        space: colorSpace,
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
+      ) else {
+        return nil
+      }
+      pixelReadContext = created
+      context = created
+    }
+
+    guard let pixel = image.cropping(to: CGRect(x: x, y: y, width: 1, height: 1)) else {
+      return nil
+    }
+    context.clear(CGRect(x: 0, y: 0, width: 1, height: 1))
+    context.draw(pixel, in: CGRect(x: 0, y: 0, width: 1, height: 1))
+
+    guard let data = context.data else { return nil }
+    let bytes = data.assumingMemoryBound(to: UInt8.self)
+    return String(format: "#%02X%02X%02X", bytes[0], bytes[1], bytes[2])
   }
 }

--- a/Snapzy/Services/Capture/AreaSelectionWindow.swift
+++ b/Snapzy/Services/Capture/AreaSelectionWindow.swift
@@ -288,14 +288,14 @@ final class AreaSelectionController: NSObject {
     } else {
       window.overlayView.clearBackdrop()
     }
+    window.selectionDelegate = self
+    window.orderFrontRegardless()
     window.overlayView.setAllowsApplicationWindowSelection(allowsApplicationWindowSelection)
     window.overlayView.setWindowSelectionSnapshot(windowSelectionSnapshot)
     window.overlayView.setInteractionMode(interactionMode, resetSelection: false)
     window.overlayView.setSelectionEnabled(selectionEnabled(for: displayID))
     window.overlayView.resetSelection()
     window.setReceivesKeyboardInput(displayID == keyboardOwnerDisplayID)
-    window.selectionDelegate = self
-    window.orderFrontRegardless()
     window.activateKeyboardInputIfNeeded()
     window.overlayView.refreshCursor()
   }
@@ -2118,9 +2118,26 @@ final class AreaSelectionOverlayView: NSView {
     delegate?.overlayView(self, manualSelectionChangedTo: currentMousePosition)
   }
 
+  /// Max long-edge of the cached backdrop bitmap. The cache only feeds the 5×5 average-luminance
+  /// sample grid, so a tiny image is plenty; this avoids a ~59 MB main-thread raster + copy on
+  /// 5K Retina displays.
+  private static let backdropPixelCacheMaxLongEdge: CGFloat = 512
+
   private func cacheBackdropPixels(from cgImage: CGImage, scale: CGFloat) {
-    let width = cgImage.width
-    let height = cgImage.height
+    let startedAt = Date()
+    let sourceWidth = cgImage.width
+    let sourceHeight = cgImage.height
+    guard sourceWidth > 0, sourceHeight > 0 else {
+      self.backdropWidth = 0
+      self.backdropHeight = 0
+      self.backdropScale = scale
+      self.backdropPixelDataArray = nil
+      return
+    }
+
+    let downscale = min(1, Self.backdropPixelCacheMaxLongEdge / CGFloat(max(sourceWidth, sourceHeight)))
+    let width = max(1, Int((CGFloat(sourceWidth) * downscale).rounded()))
+    let height = max(1, Int((CGFloat(sourceHeight) * downscale).rounded()))
     self.backdropWidth = width
     self.backdropHeight = height
     self.backdropScale = scale
@@ -2145,8 +2162,9 @@ final class AreaSelectionOverlayView: NSView {
       return
     }
 
+    context.interpolationQuality = .medium
     context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
-    
+
     if let dataPtr = context.data {
       let totalBytes = width * height * 4
       let bufferPointer = UnsafeBufferPointer(start: dataPtr.assumingMemoryBound(to: UInt8.self), count: totalBytes)
@@ -2162,8 +2180,11 @@ final class AreaSelectionOverlayView: NSView {
       context: [
         "width": "\(width)",
         "height": "\(height)",
+        "sourceWidth": "\(sourceWidth)",
+        "sourceHeight": "\(sourceHeight)",
         "scale": "\(scale)",
-        "cachedBytes": "\(self.backdropPixelDataArray?.count ?? 0)"
+        "cachedBytes": "\(self.backdropPixelDataArray?.count ?? 0)",
+        "duration_ms": "\(Date().timeIntervalSince(startedAt) * 1000)"
       ]
     )
   }
@@ -2340,10 +2361,6 @@ final class AreaSelectionOverlayView: NSView {
       at: point,
       bounds: bounds,
       backdropImage: currentBackdropImage,
-      pixelData: backdropPixelDataArray,
-      backdropWidth: backdropWidth,
-      backdropHeight: backdropHeight,
-      backdropScale: backdropScale,
       contentsScale: screenScaleFactor,
       in: layer ?? CALayer()
     )

--- a/Snapzy/Services/Capture/FrozenAreaCaptureSession.swift
+++ b/Snapzy/Services/Capture/FrozenAreaCaptureSession.swift
@@ -98,6 +98,13 @@ nonisolated final class FrozenAreaCaptureSession {
     snapshots[displayID] != nil
   }
 
+  /// Value copy of the current snapshots, safe to hand to a detached task for
+  /// off-main cropping (dictionaries are value types; later mutations of the
+  /// session copy-on-write and never affect the returned value).
+  func allSnapshots() -> [CGDirectDisplayID: FrozenDisplaySnapshot] {
+    snapshots
+  }
+
   func addSnapshot(_ snapshot: FrozenDisplaySnapshot) {
     snapshots[snapshot.displayID] = snapshot
   }
@@ -116,6 +123,20 @@ nonisolated final class FrozenAreaCaptureSession {
   }
 
   func cropImage(
+    for selection: AreaSelectionResult,
+    minimumOutputScaleFactor: CGFloat = 1
+  ) throws -> FrozenAreaCropResult {
+    try Self.cropImage(
+      snapshots: snapshots,
+      for: selection,
+      minimumOutputScaleFactor: minimumOutputScaleFactor
+    )
+  }
+
+  /// Heavy crop/scale-promote/sharpen pipeline, decoupled from session state so
+  /// callers can run it off the main actor with a snapshots value copy.
+  static func cropImage(
+    snapshots: [CGDirectDisplayID: FrozenDisplaySnapshot],
     for selection: AreaSelectionResult,
     minimumOutputScaleFactor: CGFloat = 1
   ) throws -> FrozenAreaCropResult {
@@ -192,6 +213,20 @@ nonisolated final class FrozenAreaCaptureSession {
   }
 
   func cropCompositeImage(
+    for selection: AreaSelectionResult,
+    minimumOutputScaleFactor: CGFloat = 1
+  ) throws -> FrozenAreaCropResult {
+    try Self.cropCompositeImage(
+      snapshots: snapshots,
+      for: selection,
+      minimumOutputScaleFactor: minimumOutputScaleFactor
+    )
+  }
+
+  /// Heavy multi-display composite pipeline, decoupled from session state so
+  /// callers can run it off the main actor with a snapshots value copy.
+  static func cropCompositeImage(
+    snapshots: [CGDirectDisplayID: FrozenDisplaySnapshot],
     for selection: AreaSelectionResult,
     minimumOutputScaleFactor: CGFloat = 1
   ) throws -> FrozenAreaCropResult {

--- a/Snapzy/Services/Capture/SingleFrameStreamCaptureSession.swift
+++ b/Snapzy/Services/Capture/SingleFrameStreamCaptureSession.swift
@@ -24,6 +24,10 @@ final class SingleFrameStreamCaptureSession: NSObject, @unchecked Sendable {
   /// frame in well under a second.
   nonisolated static let defaultTimeout: TimeInterval = 5
 
+  /// Shared CIContext: immutable and documented thread-safe for concurrent rendering;
+  /// avoids per-frame allocation on delivered frames.
+  private static let sharedCIContext = CIContext()
+
   private let lock = NSLock()
   private nonisolated(unsafe) var continuation: CheckedContinuation<CGImage, Error>?
   private nonisolated(unsafe) var stream: SCStream?
@@ -169,14 +173,13 @@ extension SingleFrameStreamCaptureSession: SCStreamOutput {
 
     // Convert CVPixelBuffer to CGImage
     let ciImage = CIImage(cvPixelBuffer: imageBuffer)
-    let context = CIContext()
     let rect = CGRect(
       x: 0, y: 0,
       width: CVPixelBufferGetWidth(imageBuffer),
       height: CVPixelBufferGetHeight(imageBuffer)
     )
 
-    guard let cgImage = context.createCGImage(ciImage, from: rect) else {
+    guard let cgImage = Self.sharedCIContext.createCGImage(ciImage, from: rect) else {
       finish(.failure(CaptureError.captureFailed(L10n.ScreenCapture.failedToCreateImageFromFrame)))
       return
     }


### PR DESCRIPTION
## What changed

- **Downsampled backdrop luma cache** (`AreaSelectionWindow.swift`)
  - Cached bitmap capped at ≤512 px on the long edge instead of full 5K resolution.
  - Removes the ~59 MB main-thread raster + Swift `[UInt8]` copy that previously ran before the overlay could appear.
- **On-demand magnifier hex read** (`AreaSelectionMagnifier.swift`)
  - Hex color label now reads the exact pixel via a 1×1 crop + reused 1×1 `CGContext` from the source `CGImage`, instead of the full-resolution cache.
- **Off-main frozen snapshot** (`CaptureViewModel.swift`)
  - Uses the existing `captureFastDisplaySnapshotOffMain` inside `Task.detached`, overlapping the work when safe.
  - Gated so it never races the `frozenSnapshotWindowHideSettleDelay` when own windows were hidden.
- **Off-main crop / scale-promotion / sharpen** (`CaptureViewModel.swift` + `FrozenAreaCaptureSession.swift`)
  - `cropImage` / `cropCompositeImage` refactored into static helpers; instances delegate unchanged.
  - Heavy vImage scale + 3×3 convolution now run in `Task.detached`.
- **Shared CIContext** (`SingleFrameStreamCaptureSession.swift`)
  - Reuses one static context in the macOS 13 fallback instead of allocating per frame.
- **Earlier `orderFrontRegardless`** (`AreaSelectionWindow.swift`)
  - Overlay window ordered front right after backdrop apply, shortening time-to-first-paint.

## Estimated impact

All numbers are **calculated/estimated from the changed code paths**, not yet measured on a production build. Real-world values depend on CPU, display resolution, and system load.

| Metric | Before (typical 5K Retina) | After (typical 5K Retina) |
|---|---|---|
| **Shortcut → frozen overlay visible** | ~300–700 ms; up to ~950 ms on cold SCK path | ~80–200 ms |
| **Main-thread block at overlay show** | ~150–400 ms (`cacheBackdropPixels`) + ~50–200 ms (`CGDisplayCreateImage`) | ~10–25 ms (downsampled cache) |
| **Mouse-up → capture saved (1× display, promotion path)** | ~50–130 ms main-thread stall | main-thread free; work moved to background |
| **Transient RAM per frozen display** | ~177 MB peak (source 59 MB + full cache 59 MB + array 59 MB) | ~60 MB (source 59 MB + downsampled cache ~0.6 MB) |
| **Selection-drag FPS** | Periodic 0 FPS spikes during new-display lazy freeze / completion | Stays ~60 FPS; spikes reduced to <1 frame |
| **CPU on freeze** | ~150–400 ms of full-display decode+draw on one core | ~10–25 ms of downsampled decode+draw |

## Verification

- `xcodebuild build` succeeds with no new warnings.
- Targeted suites pass (~165 cases): `FrozenAreaCaptureSessionTests`, `AreaSelectionMultiMonitorReconciliationTests`, `LiveAreaMouseUpSnapshotTests`, `AreaSelectionOverlayTests`, `AreaSelectionOverlayLumaSamplingTests`, `AreaSelectionOverlayDimmingTests`, `AreaSelectionOverlayMagnifierTests`, `SingleFrameStreamCaptureSessionTests`, `ScreenCaptureAreaCropTests`.
- Full test suite: 1210 tests; failures are a pre-existing flaky AppKit window-animation teardown crash (`_NSWindowTransformAnimation dealloc`) with zero Snapzy symbols, confirmed in DiagnosticReports from before this changeset.

## Notes

- The luma cache downsample preserves the existing light/dark overlay heuristic; the magnifier hex read keeps exact per-pixel behavior.
- `DiagnosticLogger` now emits `duration_ms` for snapshot preparation, backdrop pixel caching, and crop completion so real-world gains can be validated from user logs.
