### PR TITLE
ci: bump actions off nodejs 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload test diagnostics
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-test-diagnostics
           path: |

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -42,7 +42,7 @@ jobs:
           echo "Release version: v${VERSION}"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: master
@@ -424,13 +424,13 @@ jobs:
           } >> build/changelog.md
 
       - name: Upload DMG artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Snapzy-v${{ steps.version.outputs.version }}
           path: ${{ env.dmg_path }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.version.outputs.version }}
           name: v${{ steps.version.outputs.version }}

--- a/.github/workflows/swiftformat.yml
+++ b/.github/workflows/swiftformat.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install SwiftFormat
         run: brew install swiftformat


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` and `actions/upload-artifact` from `@v4` to `@v7`.
- Bump `softprops/action-gh-release` from `@v2` to `@v3`.

## Why
GitHub is deprecating the Node.js 20 runtime used by older Action versions. These bumps move the workflows onto maintained Action majors that no longer depend on Node.js 20.
![img](https://github.com/user-attachments/assets/916cd766-313b-448e-ae60-414b6969d438)
