### PR TITLE
fix: Handle first mouse in inline annotation canvas

### DIFF
--- a/Snapzy/Features/Annotate/Components/AnnotateCanvasDrawingView.swift
+++ b/Snapzy/Features/Annotate/Components/AnnotateCanvasDrawingView.swift
@@ -14,9 +14,10 @@ struct CanvasDrawingView: NSViewRepresentable {
   let state: AnnotateState
   var displayScale: CGFloat = 1.0
   var canvasBounds: CGRect
+  var acceptsFirstMouse = false
 
   func makeNSView(context _: Context) -> DrawingCanvasNSView {
-    let view = DrawingCanvasNSView(state: state)
+    let view = DrawingCanvasNSView(state: state, acceptsFirstMouse: acceptsFirstMouse)
     view.displayScale = displayScale
     view.canvasBounds = canvasBounds
     return view
@@ -34,6 +35,7 @@ struct CanvasDrawingView: NSViewRepresentable {
       nsView.canvasBounds = canvasBounds
       nsView.invalidateDrawing()
     }
+    nsView.acceptsInactiveWindowMouse = acceptsFirstMouse
   }
 }
 
@@ -90,6 +92,7 @@ final class DrawingCanvasNSView: NSView {
 
   var displayScale: CGFloat = 1.0
   var canvasBounds: CGRect = .zero
+  var acceptsInactiveWindowMouse: Bool
   private let shortcutManager = AnnotateShortcutManager.shared
   private var currentPath: [CGPoint] = []
   private var isDrawing = false
@@ -155,8 +158,9 @@ final class DrawingCanvasNSView: NSView {
 
   private var stateObservers = Set<AnyCancellable>()
 
-  init(state: AnnotateState) {
+  init(state: AnnotateState, acceptsFirstMouse: Bool = false) {
     self.state = state
+    self.acceptsInactiveWindowMouse = acceptsFirstMouse
     super.init(frame: .zero)
     setupView()
     observeStateChanges()
@@ -308,6 +312,10 @@ final class DrawingCanvasNSView: NSView {
 
   override var acceptsFirstResponder: Bool {
     true
+  }
+
+  override func acceptsFirstMouse(for _: NSEvent?) -> Bool {
+    acceptsInactiveWindowMouse
   }
 
   override func keyDown(with event: NSEvent) {

--- a/Snapzy/Features/Annotate/InlineAreaAnnotateWindow.swift
+++ b/Snapzy/Features/Annotate/InlineAreaAnnotateWindow.swift
@@ -352,7 +352,8 @@ private struct InlineAreaAnnotateRootView: View {
       CanvasDrawingView(
         state: session.state,
         displayScale: displayScale,
-        canvasBounds: CGRect(origin: .zero, size: imageSize)
+        canvasBounds: CGRect(origin: .zero, size: imageSize),
+        acceptsFirstMouse: true
       )
       .frame(width: rect.width, height: rect.height)
 

--- a/SnapzyTests/Features/Annotate/AnnotateCoreTests.swift
+++ b/SnapzyTests/Features/Annotate/AnnotateCoreTests.swift
@@ -893,6 +893,16 @@ final class AnnotateCoreTests: XCTestCase {
   }
 
   @MainActor
+  func testCanvasFirstMouseHandlingIsOptIn() {
+    let state = makeAnnotateState()
+    let editorCanvas = DrawingCanvasNSView(state: state)
+    let inlineCanvas = DrawingCanvasNSView(state: state, acceptsFirstMouse: true)
+
+    XCTAssertFalse(editorCanvas.acceptsFirstMouse(for: nil))
+    XCTAssertTrue(inlineCanvas.acceptsFirstMouse(for: nil))
+  }
+
+  @MainActor
   func testCanvasBlankClickWithActiveShapeToolDeselectsItemButKeepsTool() {
     let state = makeAnnotateState()
     let annotation = AnnotationItem(

--- a/SnapzyTests/Services/Capture/AreaSelectionMultiMonitorReconciliationTests.swift
+++ b/SnapzyTests/Services/Capture/AreaSelectionMultiMonitorReconciliationTests.swift
@@ -51,10 +51,9 @@ final class AreaSelectionMultiMonitorReconciliationTests: AreaSelectionOverlayTe
     // GIVEN: a selection session starts with EMPTY backdrops (backdrop-less / lazy-backdrop mode,
     // e.g. recording-area selection), so every display's `selectionEnabled(for:)` starts out `true`
     // via the `selectionBackdrops.isEmpty` branch.
-    let startExpectation = XCTestExpectation(description: "Session started and pool populated")
     controller.startSelection(mode: .recording) { _, _ in }
-    DispatchQueue.main.async { startExpectation.fulfill() }
-    wait(for: [startExpectation], timeout: 2.0)
+    // Window-pool setup is synchronous. Do not yield here: the live-session luma task may
+    // apply a backdrop on the next main-actor turn and invalidate this initial-state precondition.
 
     let mirror = Mirror(reflecting: controller)
     guard let windowPool = mirror.children.first(where: { $0.label == "windowPool" })?.value


### PR DESCRIPTION
## Problem

After #429 added default and remembered startup tools, an inline screenshot session can display the restored tool as selected while ignoring the first canvas interaction. The user must click once to activate the canvas before drawing works.

This affects the shared inline canvas event path, so it can happen with any restored tool rather than Rectangle alone. Drag-based tools such as Rectangle and Arrow make the failure most visible.

## Reproduction context

The issue was observed with two displays:

- drawing can work immediately on one display but require an activation click on the other
- occurrence can appear intermittent because it depends on which overlay panel is the key window when annotation begins
- the failure is more likely when the selected screenshot region is on a display whose overlay is not currently key

## Root cause

Inline area annotation creates one non-activating `NSPanel` per display and shares one annotation session across them. The coordinator makes only the primary-display panel, or a fallback panel, the key window.

The outer `InlineAreaHostingView` already accepts the first mouse event, which allows region selection on a non-key display. Once annotation begins, however, the actual hit-tested view is `DrawingCanvasNSView`, which previously inherited AppKit's default first-mouse behavior. Its first interaction could therefore be consumed by window activation instead of reaching the selected tool.

Before #429, users normally clicked a toolbar tool before drawing. That click activated the overlay and masked this event-routing gap. Starting directly with a configured or remembered tool exposed it.

## What changed

- added an opt-in `acceptsFirstMouse` configuration to `CanvasDrawingView`
- forwarded the setting to `DrawingCanvasNSView` for both initial creation and SwiftUI updates
- enabled first-mouse delivery only for the inline screenshot annotation canvas
- left the standalone annotation editor on the default, activation-only behavior
- added a regression test that verifies first-mouse handling is opt-in
- removed an unnecessary main-queue yield from an existing multi-display test so its initial-state assertion runs before the asynchronous live-session backdrop task

The product fix does not add delays, retry focus changes, or force every display panel to become key. It corrects event delivery at the view that actually handles drawing. The multi-display test adjustment changes test scheduling only; no `AreaSelectionController` production behavior was changed.

## Behavior change and trade-off

| Scope | Before | After |
| --- | --- | --- |
| Inactive inline canvas | First interaction may only activate its panel | First interaction is delivered to the current tool |
| Active inline canvas | Tool handles the first interaction | Unchanged |
| Standalone annotation editor | First click follows normal inactive-window behavior | Unchanged |
| Toolbar and action controls | Existing first-click behavior | Unchanged |

The intentional trade-off is that clicking an inactive inline canvas now performs the selected tool action immediately instead of serving only as an activation click. This matches the modal screenshot workflow, where the visible canvas is already the active task, and avoids applying the behavior to normal document-style editor windows.

## User impact

- default and remembered tools can be used immediately on every display
- Rectangle, Filled Rectangle, Oval, Arrow, Line, Pencil, Highlighter, Text, Counter, Blur, Spotlight, and Watermark use the corrected canvas path
- users no longer need a preliminary activation click
- selection, toolbar activation, shortcuts, capture, rendering, export, and preference persistence remain unchanged

## Risk assessment

- **Scope:** limited to the inline screenshot canvas through an explicit opt-in flag; the other `CanvasDrawingView` call site keeps the default `false` value
- **Multi-display behavior:** every display creates the same opted-in inline canvas, so non-key secondary-display panels receive the same first interaction as the key panel
- **Focus and keyboard behavior:** no key-window selection, first-responder, keyboard monitor, or text-editing logic is changed
- **Performance:** AppKit reads one Boolean only when deciding whether to deliver an initial mouse event; no work is added to pointer-move, drag, drawing, rendering, capture, or export loops
- **Memory:** one Boolean is stored per canvas view; no new observers, tasks, closures, or retained window references are added
- **Data and compatibility:** no configuration, UserDefaults, annotation data, file format, localization, permission, network, or security behavior changes

## Residual risk and manual verification

The unit test covers the opt-in contract and protects the standalone editor's default behavior. XCTest does not fully reproduce AppKit key-window arbitration across multiple physical displays, so repeated dual-display verification is still required before this PR is marked ready.

Manual verification should cover:

- primary and secondary displays
- alternating the selected region between displays
- both configured-default and remembered-tool startup paths
- a drag tool such as Rectangle or Arrow
- a click-placement tool such as Text or Counter
- repeated captures while Snapzy is active and after another application was frontmost

## Testing

Passed locally on the latest `upstream/master`:

- `AnnotateCoreTests`
- `InlineAreaAnnotateSessionTests`
- `AreaSelectionMultiMonitorReconciliationTests`, excluding the same two physical-window interaction tests skipped by CI
- 126 targeted tests, 0 failures
- `testApplyBackdrop_reconcilesSelectionEnabledForOtherPooledDisplays`: 20/20 passes after test isolation
- `git diff --check`
- local SwiftFormat build phase
- GitHub `swiftformat` check on `f704bd1`
- GitHub `build` check on `f704bd1`

CI skips these two existing hardware/window-server-sensitive tests, and the local targeted run used the same exclusions:

- `testMouseExited_hidesCoordinateIndicatorAndMagnifier`
- `testIsMouseOver_evaluatesFrameAndVisibility`

## CI failure analysis

The first CI build on `d912f9f` compiled successfully, then failed in the existing test:

`AreaSelectionMultiMonitorReconciliationTests.testApplyBackdrop_reconcilesSelectionEnabledForOtherPooledDisplays()`

The failure occurred at the test's initial precondition, `Cached selectionEnabled must start true when selectionBackdrops is empty`, before the test explicitly called `applyBackdrop` and before any first-mouse code changed by this PR was exercised.

The test called `startSelection`, then yielded the main queue with `DispatchQueue.main.async` plus an XCTest expectation. Window-pool setup is synchronous, but that yield also allowed the live-session luma task to apply a backdrop before the test inspected the empty-backdrop initial state. Depending on scheduling, the assertion therefore observed either the intended initial state or a later asynchronous state.

Evidence and fix:

- before isolation: 3 passes and 2 failures across 5 repeated local runs, always at the same initial precondition
- fix: remove only the unnecessary main-queue yield and inspect the synchronously populated window pool immediately
- after isolation: 20 passes across 20 repeated runs
- focused regression run: 126 tests passed with 0 failures
- production code touched by the test: unchanged

The fresh [CI Build Check](https://github.com/duongductrong/Snapzy/actions/runs/30510864509) on `f704bd1` passed, including the full CI XCTest scope.

## Rollback

The product change is isolated and can be reverted by removing the inline `acceptsFirstMouse: true` argument and the opt-in plumbing. The test-only commit can be reverted independently. No stored data or configuration migration would need to be reversed.

This is a follow-up fix for #429.