### PR TITLE
feat: add customizable menu bar menu and menu bar icon

### DIFF
--- a/Snapzy/App/AppStatusBarController.swift
+++ b/Snapzy/App/AppStatusBarController.swift
@@ -20,7 +20,11 @@ final class AppStatusBarController: ObservableObject {
   private var statusItem: NSStatusItem?
   private var cancellables = Set<AnyCancellable>()
   private let recorder = ScreenRecordingManager.shared
-  private lazy var idleStatusImage = makeIdleStatusImage()
+  private let menuBarCustomizationStore = MenuBarCustomizationStore.shared
+  private let menuBarIconRenderer = MenuBarIconRenderer.shared
+  private var cachedIdleStatusImage: NSImage?
+  private var cachedIdleStatusStyle: MenuBarIconStyle?
+  private var cachedCustomIconDate: Date?
   private lazy var recordingStopImage = makeRecordingStopImage()
   private var menu: NSMenu?
   private var didDetectCrash = false
@@ -328,36 +332,23 @@ final class AppStatusBarController: ObservableObject {
     }
   }
 
-  private func makeIdleStatusImage() -> NSImage? {
-    guard let appIcon = NSImage(named: "MenubarIcon") else { return nil }
+  /// Idle menu bar icon for the configured style. Cached per style + custom
+  /// icon file date; recomputed when the user changes icon preferences.
+  private var idleStatusImage: NSImage? {
+    let style = menuBarCustomizationStore.iconStyle
+    let customDate = style == .custom ? menuBarIconRenderer.customIconModificationDate : nil
 
-    let canvasSize = NSSize(width: 18, height: 18)
-    let targetVisibleOccupancy: CGFloat = 0.89
-    // Current MenubarIcon PNG alpha bounds occupy 75.28% of its transparent canvas.
-    let sourceVisibleOccupancy: CGFloat = 0.7528
-    let drawSize = NSSize(
-      width: canvasSize.width * targetVisibleOccupancy / sourceVisibleOccupancy,
-      height: canvasSize.height * targetVisibleOccupancy / sourceVisibleOccupancy
-    )
-    let drawRect = NSRect(
-      x: (canvasSize.width - drawSize.width) / 2,
-      y: (canvasSize.height - drawSize.height) / 2,
-      width: drawSize.width,
-      height: drawSize.height
-    )
+    if let cachedIdleStatusImage,
+       cachedIdleStatusStyle == style,
+       cachedCustomIconDate == customDate {
+      return cachedIdleStatusImage
+    }
 
-    let resizedIcon = NSImage(size: canvasSize)
-    resizedIcon.lockFocus()
-    appIcon.draw(
-      in: drawRect,
-      from: NSRect(origin: .zero, size: appIcon.size),
-      operation: .copy,
-      fraction: 1.0
-    )
-    resizedIcon.unlockFocus()
-    // Template images let AppKit adapt the glyph color to the current menu bar material.
-    resizedIcon.isTemplate = true
-    return resizedIcon
+    let image = menuBarIconRenderer.statusImage(for: style)
+    cachedIdleStatusImage = image
+    cachedIdleStatusStyle = style
+    cachedCustomIconDate = customDate
+    return image
   }
 
   /// Distinct "stop" glyph shown on the menu bar item while recording with the hover bar hidden.
@@ -413,222 +404,16 @@ final class AppStatusBarController: ObservableObject {
       menu?.addItem(NSMenuItem.separator())
     }
 
-    // Capture Actions
-    let captureAreaItem = NSMenuItem(
-      title: L10n.Actions.captureArea,
-      action: #selector(captureAreaAction),
-      keyEquivalent: ""
-    )
-    applyConfiguredShortcut(captureAreaItem, for: .area, using: shortcutManager)
-    captureAreaItem.target = self
-    captureAreaItem.image = NSImage(systemSymbolName: "crop", accessibilityDescription: nil)
-    captureAreaItem.isEnabled = viewModel.hasPermission
-    menu?.addItem(captureAreaItem)
-
-    let captureAreaAnnotateItem = NSMenuItem(
-      title: L10n.Actions.captureAreaAnnotate,
-      action: #selector(captureAreaAnnotateAction),
-      keyEquivalent: ""
-    )
-    applyConfiguredShortcut(captureAreaAnnotateItem, for: .areaAnnotate, using: shortcutManager)
-    captureAreaAnnotateItem.target = self
-    captureAreaAnnotateItem.image = NSImage(systemSymbolName: "pencil.and.scribble", accessibilityDescription: nil)
-    captureAreaAnnotateItem.isEnabled = viewModel.hasPermission
-    menu?.addItem(captureAreaAnnotateItem)
-
-    let applicationCaptureShortcut = CaptureOverlayShortcutSettings.applicationCaptureShortcut
-    let applicationCaptureItem = NSMenuItem(
-      title: L10n.PreferencesShortcuts.applicationCaptureTitle,
-      action: #selector(captureApplicationAction),
-      keyEquivalent: ""
-    )
-    configureOverlayMenuItem(
-      applicationCaptureItem,
-      base: L10n.PreferencesShortcuts.applicationCaptureTitle,
-      shortcut: applicationCaptureShortcut,
-      parentKind: .area,
-      using: shortcutManager
-    )
-    applicationCaptureItem.target = self
-    applicationCaptureItem.image = NSImage(systemSymbolName: "macwindow", accessibilityDescription: nil)
-    applicationCaptureItem.isEnabled = viewModel.hasPermission
-    menu?.addItem(applicationCaptureItem)
-
-    let captureFullscreenItem = NSMenuItem(
-      title: L10n.Actions.captureFullscreen,
-      action: #selector(captureFullscreenAction),
-      keyEquivalent: ""
-    )
-    applyConfiguredShortcut(captureFullscreenItem, for: .fullscreen, using: shortcutManager)
-    captureFullscreenItem.target = self
-    captureFullscreenItem.image = NSImage(
-      systemSymbolName: "rectangle.dashed", accessibilityDescription: nil)
-    captureFullscreenItem.isEnabled = viewModel.hasPermission
-    menu?.addItem(captureFullscreenItem)
-
-    let captureActiveWindowItem = NSMenuItem(
-      title: L10n.Actions.captureActiveWindow,
-      action: #selector(captureActiveWindowAction),
-      keyEquivalent: ""
-    )
-    applyConfiguredShortcut(captureActiveWindowItem, for: .activeWindow, using: shortcutManager)
-    captureActiveWindowItem.target = self
-    captureActiveWindowItem.image = NSImage(
-      systemSymbolName: "macwindow.on.rectangle", accessibilityDescription: nil)
-    captureActiveWindowItem.isEnabled = viewModel.hasPermission
-    menu?.addItem(captureActiveWindowItem)
-
-    let scrollingCaptureItem = NSMenuItem(
-      title: L10n.Actions.scrollingCapture,
-      action: #selector(captureScrollingAction),
-      keyEquivalent: ""
-    )
-    applyConfiguredShortcut(scrollingCaptureItem, for: .scrollingCapture, using: shortcutManager)
-    scrollingCaptureItem.target = self
-    scrollingCaptureItem.image = NSImage(systemSymbolName: "arrow.up.and.down", accessibilityDescription: nil)
-    scrollingCaptureItem.isEnabled = viewModel.hasPermission && !ScrollingCaptureCoordinator.shared.isActive
-    menu?.addItem(scrollingCaptureItem)
-
-    let captureOCRItem = NSMenuItem(
-      title: L10n.Actions.captureTextOCR,
-      action: #selector(captureOCRAction),
-      keyEquivalent: ""
-    )
-    applyConfiguredShortcut(captureOCRItem, for: .ocr, using: shortcutManager)
-    captureOCRItem.target = self
-    captureOCRItem.image = NSImage(systemSymbolName: "text.viewfinder", accessibilityDescription: nil)
-    captureOCRItem.isEnabled = viewModel.hasPermission
-    menu?.addItem(captureOCRItem)
-
-    let captureSmartElementItem = NSMenuItem(
-      title: L10n.Actions.captureSmartElement,
-      action: #selector(captureSmartElementAction),
-      keyEquivalent: ""
-    )
-    applyConfiguredShortcut(captureSmartElementItem, for: .smartElement, using: shortcutManager)
-    captureSmartElementItem.target = self
-    captureSmartElementItem.image = NSImage(systemSymbolName: "dot.viewfinder", accessibilityDescription: nil)
-    captureSmartElementItem.isEnabled = viewModel.hasPermission
-    menu?.addItem(captureSmartElementItem)
-
-    let captureObjectCutoutItem = NSMenuItem(
-      title: GlobalShortcutKind.objectCutout.displayName,
-      action: #selector(captureObjectCutoutAction),
-      keyEquivalent: ""
-    )
-    applyConfiguredShortcut(captureObjectCutoutItem, for: .objectCutout, using: shortcutManager)
-    captureObjectCutoutItem.target = self
-    captureObjectCutoutItem.image = NSImage(systemSymbolName: "person.crop.rectangle", accessibilityDescription: nil)
-    if #available(macOS 14.0, *) {
-      captureObjectCutoutItem.isEnabled = viewModel.hasPermission
-    } else {
-      captureObjectCutoutItem.isEnabled = false
+    // Customizable groups (Capture → Recording → Tools): user-ordered, hidden
+    // items filtered out, separators only between non-empty groups.
+    for group in MenuBarItemGroup.allCases {
+      let groupItems = menuBarCustomizationStore.orderedVisibleItems(for: group).map {
+        makeMenuItem(for: $0, viewModel: viewModel, shortcutManager: shortcutManager)
+      }
+      guard !groupItems.isEmpty else { continue }
+      groupItems.forEach { menu?.addItem($0) }
+      menu?.addItem(NSMenuItem.separator())
     }
-    menu?.addItem(captureObjectCutoutItem)
-
-    menu?.addItem(NSMenuItem.separator())
-
-    // Recording
-    let recordItem = NSMenuItem(
-      title: L10n.Menu.recordScreen,
-      action: #selector(recordScreenAction),
-      keyEquivalent: ""
-    )
-    applyConfiguredShortcut(recordItem, for: .recording, using: shortcutManager)
-    recordItem.target = self
-    recordItem.image = NSImage(systemSymbolName: "record.circle", accessibilityDescription: nil)
-    recordItem.isEnabled = viewModel.hasPermission && !recorder.isActive
-    menu?.addItem(recordItem)
-
-    let applicationRecordingShortcut = CaptureOverlayShortcutSettings.recordingApplicationCaptureShortcut
-    let applicationRecordingItem = NSMenuItem(
-      title: L10n.PreferencesShortcuts.applicationRecordingTitle,
-      action: #selector(recordApplicationAction),
-      keyEquivalent: ""
-    )
-    configureOverlayMenuItem(
-      applicationRecordingItem,
-      base: L10n.PreferencesShortcuts.applicationRecordingTitle,
-      shortcut: applicationRecordingShortcut,
-      parentKind: .recording,
-      using: shortcutManager
-    )
-    applicationRecordingItem.target = self
-    applicationRecordingItem.image = NSImage(systemSymbolName: "square.on.square", accessibilityDescription: nil)
-    applicationRecordingItem.isEnabled = viewModel.hasPermission && !recorder.isActive
-    menu?.addItem(applicationRecordingItem)
-
-    menu?.addItem(NSMenuItem.separator())
-
-    // Tools
-    let annotateItem = NSMenuItem(
-      title: L10n.Actions.openAnnotate,
-      action: #selector(openAnnotateAction),
-      keyEquivalent: ""
-    )
-    applyConfiguredShortcut(annotateItem, for: .annotate, using: shortcutManager)
-    annotateItem.target = self
-    annotateItem.image = NSImage(
-      systemSymbolName: "pencil.and.outline", accessibilityDescription: nil)
-    annotateItem.isEnabled = true
-    menu?.addItem(annotateItem)
-
-    let combineImagesItem = NSMenuItem(
-      title: L10n.Combine.open,
-      action: #selector(openCombineImagesAction),
-      keyEquivalent: ""
-    )
-    combineImagesItem.target = self
-    combineImagesItem.image = NSImage(
-      systemSymbolName: "rectangle.3.group", accessibilityDescription: nil)
-    combineImagesItem.isEnabled = true
-    menu?.addItem(combineImagesItem)
-
-    let editVideoItem = NSMenuItem(
-      title: L10n.Menu.editVideo,
-      action: #selector(editVideoAction),
-      keyEquivalent: ""
-    )
-    applyConfiguredShortcut(editVideoItem, for: .videoEditor, using: shortcutManager)
-    editVideoItem.target = self
-    editVideoItem.image = NSImage(systemSymbolName: "film", accessibilityDescription: nil)
-    editVideoItem.isEnabled = true
-    menu?.addItem(editVideoItem)
-
-    let cloudUploadsItem = NSMenuItem(
-      title: L10n.Actions.cloudUploads,
-      action: #selector(openCloudUploadsAction),
-      keyEquivalent: ""
-    )
-    applyConfiguredShortcut(cloudUploadsItem, for: .cloudUploads, using: shortcutManager)
-    cloudUploadsItem.target = self
-    cloudUploadsItem.image = NSImage(systemSymbolName: "icloud.and.arrow.up", accessibilityDescription: nil)
-    cloudUploadsItem.isEnabled = CloudManager.shared.isConfigured
-    menu?.addItem(cloudUploadsItem)
-
-    let historyItem = NSMenuItem(
-      title: L10n.Actions.openHistory,
-      action: #selector(openHistoryAction),
-      keyEquivalent: ""
-    )
-    applyConfiguredShortcut(historyItem, for: .history, using: shortcutManager)
-    historyItem.target = self
-    historyItem.image = NSImage(systemSymbolName: "clock.arrow.circlepath", accessibilityDescription: nil)
-    historyItem.isEnabled = true
-    menu?.addItem(historyItem)
-
-    let shortcutListItem = NSMenuItem(
-      title: L10n.Menu.keyboardShortcuts,
-      action: #selector(showShortcutListAction),
-      keyEquivalent: ""
-    )
-    applyConfiguredShortcut(shortcutListItem, for: .shortcutList, using: shortcutManager)
-    shortcutListItem.target = self
-    shortcutListItem.image = NSImage(systemSymbolName: "list.bullet.rectangle", accessibilityDescription: nil)
-    shortcutListItem.isEnabled = true
-    menu?.addItem(shortcutListItem)
-
-    menu?.addItem(NSMenuItem.separator())
 
     // Permission (if not granted)
     if !viewModel.hasPermission {
@@ -658,17 +443,10 @@ final class AppStatusBarController: ObservableObject {
       menu?.addItem(whatsNewItem)
     }
 
-    // Check for Updates
-    let updateItem = NSMenuItem(
-      title: L10n.Menu.checkForUpdates,
-      action: #selector(checkForUpdatesAction),
-      keyEquivalent: ""
-    )
-    updateItem.target = self
-    updateItem.image = NSImage(
-      systemSymbolName: "arrow.triangle.2.circlepath", accessibilityDescription: nil)
-    updateItem.isEnabled = true
-    menu?.addItem(updateItem)
+    // Check for Updates (hideable, fixed position)
+    if !menuBarCustomizationStore.isHidden(.checkForUpdates) {
+      menu?.addItem(makeMenuItem(for: .checkForUpdates, viewModel: viewModel, shortcutManager: shortcutManager))
+    }
 
     // Preferences
     let prefsItem = NSMenuItem(
@@ -695,6 +473,254 @@ final class AppStatusBarController: ObservableObject {
     quitItem.image = NSImage(systemSymbolName: "power", accessibilityDescription: nil)
     quitItem.isEnabled = true
     menu?.addItem(quitItem)
+  }
+
+  // MARK: - Menu Item Factory
+
+  /// Builds a configured menu entry for a customizable item. Titles, icons,
+  /// actions, shortcuts, and enabled states are identical to the original
+  /// fixed menu regardless of user ordering or visibility.
+  private func makeMenuItem(
+    for kind: MenuBarItemKind,
+    viewModel: ScreenCaptureViewModel,
+    shortcutManager: KeyboardShortcutManager
+  ) -> NSMenuItem {
+    switch kind {
+    case .captureArea:
+      let item = NSMenuItem(
+        title: L10n.Actions.captureArea,
+        action: #selector(captureAreaAction),
+        keyEquivalent: ""
+      )
+      applyConfiguredShortcut(item, for: .area, using: shortcutManager)
+      item.target = self
+      item.image = NSImage(systemSymbolName: "crop", accessibilityDescription: nil)
+      item.isEnabled = viewModel.hasPermission
+      return item
+
+    case .captureAreaAnnotate:
+      let item = NSMenuItem(
+        title: L10n.Actions.captureAreaAnnotate,
+        action: #selector(captureAreaAnnotateAction),
+        keyEquivalent: ""
+      )
+      applyConfiguredShortcut(item, for: .areaAnnotate, using: shortcutManager)
+      item.target = self
+      item.image = NSImage(systemSymbolName: "pencil.and.scribble", accessibilityDescription: nil)
+      item.isEnabled = viewModel.hasPermission
+      return item
+
+    case .captureApplication:
+      let item = NSMenuItem(
+        title: L10n.PreferencesShortcuts.applicationCaptureTitle,
+        action: #selector(captureApplicationAction),
+        keyEquivalent: ""
+      )
+      configureOverlayMenuItem(
+        item,
+        base: L10n.PreferencesShortcuts.applicationCaptureTitle,
+        shortcut: CaptureOverlayShortcutSettings.applicationCaptureShortcut,
+        parentKind: .area,
+        using: shortcutManager
+      )
+      item.target = self
+      item.image = NSImage(systemSymbolName: "macwindow", accessibilityDescription: nil)
+      item.isEnabled = viewModel.hasPermission
+      return item
+
+    case .captureFullscreen:
+      let item = NSMenuItem(
+        title: L10n.Actions.captureFullscreen,
+        action: #selector(captureFullscreenAction),
+        keyEquivalent: ""
+      )
+      applyConfiguredShortcut(item, for: .fullscreen, using: shortcutManager)
+      item.target = self
+      item.image = NSImage(
+        systemSymbolName: "rectangle.dashed", accessibilityDescription: nil)
+      item.isEnabled = viewModel.hasPermission
+      return item
+
+    case .captureActiveWindow:
+      let item = NSMenuItem(
+        title: L10n.Actions.captureActiveWindow,
+        action: #selector(captureActiveWindowAction),
+        keyEquivalent: ""
+      )
+      applyConfiguredShortcut(item, for: .activeWindow, using: shortcutManager)
+      item.target = self
+      item.image = NSImage(
+        systemSymbolName: "macwindow.on.rectangle", accessibilityDescription: nil)
+      item.isEnabled = viewModel.hasPermission
+      return item
+
+    case .scrollingCapture:
+      let item = NSMenuItem(
+        title: L10n.Actions.scrollingCapture,
+        action: #selector(captureScrollingAction),
+        keyEquivalent: ""
+      )
+      applyConfiguredShortcut(item, for: .scrollingCapture, using: shortcutManager)
+      item.target = self
+      item.image = NSImage(systemSymbolName: "arrow.up.and.down", accessibilityDescription: nil)
+      item.isEnabled = viewModel.hasPermission && !ScrollingCaptureCoordinator.shared.isActive
+      return item
+
+    case .captureOCR:
+      let item = NSMenuItem(
+        title: L10n.Actions.captureTextOCR,
+        action: #selector(captureOCRAction),
+        keyEquivalent: ""
+      )
+      applyConfiguredShortcut(item, for: .ocr, using: shortcutManager)
+      item.target = self
+      item.image = NSImage(systemSymbolName: "text.viewfinder", accessibilityDescription: nil)
+      item.isEnabled = viewModel.hasPermission
+      return item
+
+    case .captureSmartElement:
+      let item = NSMenuItem(
+        title: L10n.Actions.captureSmartElement,
+        action: #selector(captureSmartElementAction),
+        keyEquivalent: ""
+      )
+      applyConfiguredShortcut(item, for: .smartElement, using: shortcutManager)
+      item.target = self
+      item.image = NSImage(systemSymbolName: "dot.viewfinder", accessibilityDescription: nil)
+      item.isEnabled = viewModel.hasPermission
+      return item
+
+    case .captureObjectCutout:
+      let item = NSMenuItem(
+        title: GlobalShortcutKind.objectCutout.displayName,
+        action: #selector(captureObjectCutoutAction),
+        keyEquivalent: ""
+      )
+      applyConfiguredShortcut(item, for: .objectCutout, using: shortcutManager)
+      item.target = self
+      item.image = NSImage(systemSymbolName: "person.crop.rectangle", accessibilityDescription: nil)
+      if #available(macOS 14.0, *) {
+        item.isEnabled = viewModel.hasPermission
+      } else {
+        item.isEnabled = false
+      }
+      return item
+
+    case .recordScreen:
+      let item = NSMenuItem(
+        title: L10n.Menu.recordScreen,
+        action: #selector(recordScreenAction),
+        keyEquivalent: ""
+      )
+      applyConfiguredShortcut(item, for: .recording, using: shortcutManager)
+      item.target = self
+      item.image = NSImage(systemSymbolName: "record.circle", accessibilityDescription: nil)
+      item.isEnabled = viewModel.hasPermission && !recorder.isActive
+      return item
+
+    case .recordApplication:
+      let item = NSMenuItem(
+        title: L10n.PreferencesShortcuts.applicationRecordingTitle,
+        action: #selector(recordApplicationAction),
+        keyEquivalent: ""
+      )
+      configureOverlayMenuItem(
+        item,
+        base: L10n.PreferencesShortcuts.applicationRecordingTitle,
+        shortcut: CaptureOverlayShortcutSettings.recordingApplicationCaptureShortcut,
+        parentKind: .recording,
+        using: shortcutManager
+      )
+      item.target = self
+      item.image = NSImage(systemSymbolName: "square.on.square", accessibilityDescription: nil)
+      item.isEnabled = viewModel.hasPermission && !recorder.isActive
+      return item
+
+    case .openAnnotate:
+      let item = NSMenuItem(
+        title: L10n.Actions.openAnnotate,
+        action: #selector(openAnnotateAction),
+        keyEquivalent: ""
+      )
+      applyConfiguredShortcut(item, for: .annotate, using: shortcutManager)
+      item.target = self
+      item.image = NSImage(
+        systemSymbolName: "pencil.and.outline", accessibilityDescription: nil)
+      item.isEnabled = true
+      return item
+
+    case .combineImages:
+      let item = NSMenuItem(
+        title: L10n.Combine.open,
+        action: #selector(openCombineImagesAction),
+        keyEquivalent: ""
+      )
+      item.target = self
+      item.image = NSImage(
+        systemSymbolName: "rectangle.3.group", accessibilityDescription: nil)
+      item.isEnabled = true
+      return item
+
+    case .editVideo:
+      let item = NSMenuItem(
+        title: L10n.Menu.editVideo,
+        action: #selector(editVideoAction),
+        keyEquivalent: ""
+      )
+      applyConfiguredShortcut(item, for: .videoEditor, using: shortcutManager)
+      item.target = self
+      item.image = NSImage(systemSymbolName: "film", accessibilityDescription: nil)
+      item.isEnabled = true
+      return item
+
+    case .cloudUploads:
+      let item = NSMenuItem(
+        title: L10n.Actions.cloudUploads,
+        action: #selector(openCloudUploadsAction),
+        keyEquivalent: ""
+      )
+      applyConfiguredShortcut(item, for: .cloudUploads, using: shortcutManager)
+      item.target = self
+      item.image = NSImage(systemSymbolName: "icloud.and.arrow.up", accessibilityDescription: nil)
+      item.isEnabled = CloudManager.shared.isConfigured
+      return item
+
+    case .openHistory:
+      let item = NSMenuItem(
+        title: L10n.Actions.openHistory,
+        action: #selector(openHistoryAction),
+        keyEquivalent: ""
+      )
+      applyConfiguredShortcut(item, for: .history, using: shortcutManager)
+      item.target = self
+      item.image = NSImage(systemSymbolName: "clock.arrow.circlepath", accessibilityDescription: nil)
+      item.isEnabled = true
+      return item
+
+    case .shortcutList:
+      let item = NSMenuItem(
+        title: L10n.Menu.keyboardShortcuts,
+        action: #selector(showShortcutListAction),
+        keyEquivalent: ""
+      )
+      applyConfiguredShortcut(item, for: .shortcutList, using: shortcutManager)
+      item.target = self
+      item.image = NSImage(systemSymbolName: "list.bullet.rectangle", accessibilityDescription: nil)
+      item.isEnabled = true
+      return item
+
+    case .checkForUpdates:
+      let item = NSMenuItem(
+        title: L10n.Menu.checkForUpdates,
+        action: #selector(checkForUpdatesAction),
+        keyEquivalent: ""
+      )
+      item.target = self
+      item.image = NSImage(
+        systemSymbolName: "arrow.triangle.2.circlepath", accessibilityDescription: nil)
+      item.isEnabled = true
+      return item
+    }
   }
 
   // MARK: - Menu Actions

--- a/Snapzy/App/MenuBarCustomizationStore.swift
+++ b/Snapzy/App/MenuBarCustomizationStore.swift
@@ -1,0 +1,165 @@
+//
+//  MenuBarCustomizationStore.swift
+//  Snapzy
+//
+//  UserDefaults-backed menu bar item order, visibility, and icon style.
+//
+
+import Combine
+import Foundation
+
+@MainActor
+final class MenuBarCustomizationStore: ObservableObject {
+  static let shared = MenuBarCustomizationStore()
+
+  /// Flat order of all customizable items. Only relative order within each
+  /// group is meaningful; rendering filters per group.
+  @Published private(set) var itemOrder: [MenuBarItemKind]
+  @Published private(set) var hiddenItems: Set<MenuBarItemKind>
+  @Published private(set) var iconStyle: MenuBarIconStyle
+
+  private let defaults: UserDefaults
+
+  init(defaults: UserDefaults = .standard) {
+    self.defaults = defaults
+    itemOrder = Self.normalizedOrder(from: defaults.stringArray(forKey: PreferencesKeys.menuBarItemOrder))
+    hiddenItems = Self.normalizedHiddenItems(from: defaults.stringArray(forKey: PreferencesKeys.menuBarHiddenItems))
+    iconStyle = Self.normalizedIconStyle(from: defaults.string(forKey: PreferencesKeys.menuBarIconStyle))
+  }
+
+  // MARK: - Queries
+
+  /// Visible items for a group in the user's configured order.
+  func orderedVisibleItems(for group: MenuBarItemGroup) -> [MenuBarItemKind] {
+    orderedItems(for: group).filter { !hiddenItems.contains($0) }
+  }
+
+  /// All items for a group (visible and hidden) in the user's configured order.
+  func orderedItems(for group: MenuBarItemGroup) -> [MenuBarItemKind] {
+    itemOrder.filter { $0.group == group }
+  }
+
+  func isHidden(_ item: MenuBarItemKind) -> Bool {
+    hiddenItems.contains(item)
+  }
+
+  // MARK: - Mutations
+
+  func setHidden(_ item: MenuBarItemKind, hidden: Bool) {
+    guard item.isCustomizable || item.isHideableOnly else { return }
+    var updated = hiddenItems
+    if hidden {
+      updated.insert(item)
+    } else {
+      updated.remove(item)
+    }
+    hiddenItems = updated
+    save()
+  }
+
+  /// Reorder within a group. Indices address the group's full item list
+  /// (visible + hidden), matching the settings UI rows.
+  func moveItem(from source: IndexSet, to destination: Int, in group: MenuBarItemGroup) {
+    guard !source.isEmpty else { return }
+
+    var groupItems = orderedItems(for: group)
+    let moving = source.sorted().map { groupItems[$0] }
+    for index in source.sorted(by: >) {
+      groupItems.remove(at: index)
+    }
+
+    let removedBeforeDestination = source.filter { $0 < destination }.count
+    let insertionIndex = max(0, min(destination - removedBeforeDestination, groupItems.count))
+    groupItems.insert(contentsOf: moving, at: insertionIndex)
+
+    // Rebuild the flat order, replacing this group's subsequence in place and
+    // leaving other groups untouched.
+    var updated: [MenuBarItemKind] = []
+    var groupIterator = groupItems.makeIterator()
+    for item in itemOrder {
+      if item.group == group, let next = groupIterator.next() {
+        updated.append(next)
+      } else {
+        updated.append(item)
+      }
+    }
+    itemOrder = Self.normalizedOrder(from: updated.map(\.rawValue))
+    save()
+  }
+
+  func setIconStyle(_ style: MenuBarIconStyle) {
+    iconStyle = style
+    save()
+  }
+
+  func resetToDefaults() {
+    itemOrder = MenuBarItemKind.allCases.filter(\.isCustomizable)
+    hiddenItems = []
+    iconStyle = .default
+    save()
+  }
+
+  /// Applies imported TOML configuration values (nil leaves the value untouched).
+  func applyConfiguration(
+    order: [MenuBarItemKind]?,
+    hiddenItems: Set<MenuBarItemKind>?,
+    iconStyle: MenuBarIconStyle?
+  ) {
+    if let order {
+      itemOrder = Self.normalizedOrder(from: order.map(\.rawValue))
+    }
+    if let hiddenItems {
+      self.hiddenItems = hiddenItems.filter { $0.isCustomizable || $0.isHideableOnly }
+    }
+    if let iconStyle {
+      self.iconStyle = iconStyle
+    }
+    save()
+  }
+
+  // MARK: - Persistence
+
+  private func save() {
+    defaults.set(itemOrder.map(\.rawValue), forKey: PreferencesKeys.menuBarItemOrder)
+    defaults.set(hiddenItems.map(\.rawValue).sorted(), forKey: PreferencesKeys.menuBarHiddenItems)
+    defaults.set(iconStyle.rawValue, forKey: PreferencesKeys.menuBarIconStyle)
+  }
+
+  // MARK: - Normalization
+
+  private static func normalizedOrder(from rawIDs: [String]?) -> [MenuBarItemKind] {
+    let customizable = MenuBarItemKind.allCases.filter(\.isCustomizable)
+    var seen = Set<MenuBarItemKind>()
+    var ordered: [MenuBarItemKind] = []
+
+    for rawID in rawIDs ?? [] {
+      guard let item = MenuBarItemKind(rawValue: rawID),
+            item.isCustomizable,
+            !seen.contains(item) else { continue }
+      ordered.append(item)
+      seen.insert(item)
+    }
+
+    // Items missing from storage (fresh install or added in a later release)
+    // append in default order; per-group filtering keeps them positioned
+    // correctly within their own group.
+    for item in customizable where !seen.contains(item) {
+      ordered.append(item)
+    }
+
+    return ordered
+  }
+
+  private static func normalizedHiddenItems(from rawIDs: [String]?) -> Set<MenuBarItemKind> {
+    guard let rawIDs else { return [] }
+    return Set(rawIDs.compactMap(MenuBarItemKind.init(rawValue:)))
+      .filter { $0.isCustomizable || $0.isHideableOnly }
+  }
+
+  private static func normalizedIconStyle(from rawValue: String?) -> MenuBarIconStyle {
+    guard let rawValue, let style = MenuBarIconStyle(rawValue: rawValue) else {
+      return .default
+    }
+    return style
+  }
+}

--- a/Snapzy/App/MenuBarIconRenderer.swift
+++ b/Snapzy/App/MenuBarIconRenderer.swift
@@ -1,0 +1,260 @@
+//
+//  MenuBarIconRenderer.swift
+//  Snapzy
+//
+//  Renders 18pt template status bar images for each menu bar icon style and
+//  manages the user-imported custom icon file.
+//
+
+import AppKit
+
+@MainActor
+final class MenuBarIconRenderer {
+  static let shared = MenuBarIconRenderer()
+
+  private let fileManager = FileManager.default
+  private let appSupportFolderName = "Snapzy"
+  private let customIconFolderName = "MenuBarIcon"
+  private let customIconFileName = "custom.png"
+
+  private init() {}
+
+  // MARK: - Rendering
+
+  /// 18pt template image for the given style. Falls back to the bundled
+  /// default artwork when a custom icon is missing or undecodable.
+  func statusImage(for style: MenuBarIconStyle) -> NSImage? {
+    switch style {
+    case .default:
+      return makeBundledStatusImage()
+    case .custom:
+      if let custom = makeCustomStatusImage() {
+        return custom
+      }
+      return makeBundledStatusImage()
+    default:
+      return makeSymbolStatusImage(symbolName: style.symbolName)
+    }
+  }
+
+  /// Current bundled-artwork rendering (moved from AppStatusBarController).
+  private func makeBundledStatusImage() -> NSImage? {
+    guard let appIcon = NSImage(named: "MenubarIcon") else { return nil }
+
+    let canvasSize = NSSize(width: 18, height: 18)
+    let targetVisibleOccupancy: CGFloat = 0.89
+    // Current MenubarIcon PNG alpha bounds occupy 75.28% of its transparent canvas.
+    let sourceVisibleOccupancy: CGFloat = 0.7528
+    let drawSize = NSSize(
+      width: canvasSize.width * targetVisibleOccupancy / sourceVisibleOccupancy,
+      height: canvasSize.height * targetVisibleOccupancy / sourceVisibleOccupancy
+    )
+    let drawRect = NSRect(
+      x: (canvasSize.width - drawSize.width) / 2,
+      y: (canvasSize.height - drawSize.height) / 2,
+      width: drawSize.width,
+      height: drawSize.height
+    )
+
+    let resizedIcon = NSImage(size: canvasSize)
+    resizedIcon.lockFocus()
+    appIcon.draw(
+      in: drawRect,
+      from: NSRect(origin: .zero, size: appIcon.size),
+      operation: .copy,
+      fraction: 1.0
+    )
+    resizedIcon.unlockFocus()
+    // Template images let AppKit adapt the glyph color to the current menu bar material.
+    resizedIcon.isTemplate = true
+    return resizedIcon
+  }
+
+  private func makeSymbolStatusImage(symbolName: String?) -> NSImage? {
+    guard let symbolName else { return nil }
+    let config = NSImage.SymbolConfiguration(pointSize: 15, weight: .regular)
+    let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?
+      .withSymbolConfiguration(config)
+    image?.isTemplate = true
+    return image
+  }
+
+  /// Renders the user-imported PNG with alpha-bounds normalization so its
+  /// visible content matches the bundled icon's 89% canvas occupancy.
+  private func makeCustomStatusImage() -> NSImage? {
+    guard let url = customIconURL,
+          fileManager.fileExists(atPath: url.path),
+          let source = NSImage(contentsOf: url),
+          let cgImage = source.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+      return nil
+    }
+
+    let canvasSize = NSSize(width: 18, height: 18)
+    let targetVisibleOccupancy: CGFloat = 0.89
+    let imageSize = NSSize(width: cgImage.width, height: cgImage.height)
+
+    let drawSize: NSSize
+    if let alphaBounds = Self.alphaBoundingBox(of: cgImage), !alphaBounds.isEmpty {
+      // Scale so the larger visible dimension fills the target occupancy.
+      let sourceOccupancy = max(
+        alphaBounds.width / imageSize.width,
+        alphaBounds.height / imageSize.height
+      )
+      guard sourceOccupancy > 0 else { return nil }
+      let scale = targetVisibleOccupancy / sourceOccupancy
+      drawSize = NSSize(width: imageSize.width * scale, height: imageSize.height * scale)
+    } else {
+      // Fully opaque (or undetectable bounds): fit the longest side to the target.
+      let fit = min(
+        canvasSize.width * targetVisibleOccupancy / imageSize.width,
+        canvasSize.height * targetVisibleOccupancy / imageSize.height
+      )
+      drawSize = NSSize(width: imageSize.width * fit, height: imageSize.height * fit)
+    }
+
+    let drawRect = NSRect(
+      x: (canvasSize.width - drawSize.width) / 2,
+      y: (canvasSize.height - drawSize.height) / 2,
+      width: drawSize.width,
+      height: drawSize.height
+    )
+
+    let rendered = NSImage(size: canvasSize)
+    rendered.lockFocus()
+    source.draw(
+      in: drawRect,
+      from: NSRect(origin: .zero, size: source.size),
+      operation: .copy,
+      fraction: 1.0
+    )
+    rendered.unlockFocus()
+    // Template rendering makes any imported PNG monochrome automatically.
+    rendered.isTemplate = true
+    return rendered
+  }
+
+  // MARK: - Custom Icon Storage
+
+  /// URL of the stored custom icon: Application Support/Snapzy/MenuBarIcon/custom.png
+  var customIconURL: URL? {
+    guard
+      let appSupportURL = fileManager.urls(
+        for: .applicationSupportDirectory, in: .userDomainMask
+      ).first
+    else {
+      return nil
+    }
+
+    return appSupportURL
+      .appendingPathComponent(appSupportFolderName, isDirectory: true)
+      .appendingPathComponent(customIconFolderName, isDirectory: true)
+      .appendingPathComponent(customIconFileName, isDirectory: false)
+  }
+
+  var hasCustomIcon: Bool {
+    guard let url = customIconURL else { return false }
+    return fileManager.fileExists(atPath: url.path)
+  }
+
+  /// Modification date of the stored custom icon, used for cache invalidation.
+  var customIconModificationDate: Date? {
+    guard let url = customIconURL else { return nil }
+    return try? fileManager.attributesOfItem(atPath: url.path)[.modificationDate] as? Date
+  }
+
+  /// Validates and copies a user-picked PNG into Application Support.
+  @discardableResult
+  func saveCustomIcon(from sourceURL: URL) -> Bool {
+    guard let destinationURL = customIconURL else { return false }
+
+    // Validate the pick decodes as an image before replacing the stored copy.
+    guard let image = NSImage(contentsOf: sourceURL),
+          image.cgImage(forProposedRect: nil, context: nil, hints: nil) != nil else {
+      DiagnosticLogger.shared.log(
+        .warning, .ui, "Custom menu bar icon rejected: undecodable image",
+        context: ["path": sourceURL.path]
+      )
+      return false
+    }
+
+    do {
+      let directory = destinationURL.deletingLastPathComponent()
+      try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+      if fileManager.fileExists(atPath: destinationURL.path) {
+        try fileManager.removeItem(at: destinationURL)
+      }
+      try fileManager.copyItem(at: sourceURL, to: destinationURL)
+      DiagnosticLogger.shared.log(.info, .ui, "Custom menu bar icon imported")
+      return true
+    } catch {
+      DiagnosticLogger.shared.log(
+        .error, .ui, "Custom menu bar icon import failed",
+        context: ["error": error.localizedDescription]
+      )
+      return false
+    }
+  }
+
+  func removeCustomIcon() {
+    guard let url = customIconURL, fileManager.fileExists(atPath: url.path) else { return }
+    try? fileManager.removeItem(at: url)
+  }
+
+  // MARK: - Alpha Bounds
+
+  /// Alpha bounding box of the image in pixel coordinates, detected on a
+  /// downsampled bitmap. Returns nil when the image has no transparent pixels.
+  static nonisolated func alphaBoundingBox(of cgImage: CGImage) -> CGRect? {
+    let sampleSize = 128
+    var bitmap = [UInt8](repeating: 0, count: sampleSize * sampleSize * 4)
+
+    guard let colorSpace = CGColorSpace(name: CGColorSpace.sRGB),
+          let context = CGContext(
+            data: &bitmap,
+            width: sampleSize,
+            height: sampleSize,
+            bitsPerComponent: 8,
+            bytesPerRow: sampleSize * 4,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+          )
+    else {
+      return nil
+    }
+
+    context.draw(cgImage, in: CGRect(x: 0, y: 0, width: sampleSize, height: sampleSize))
+
+    var minX = sampleSize
+    var minY = sampleSize
+    var maxX = -1
+    var maxY = -1
+    var foundTransparent = false
+
+    for y in 0..<sampleSize {
+      for x in 0..<sampleSize {
+        let alpha = bitmap[(y * sampleSize + x) * 4 + 3]
+        if alpha < 8 {
+          foundTransparent = true
+          continue
+        }
+        minX = min(minX, x)
+        minY = min(minY, y)
+        maxX = max(maxX, x)
+        maxY = max(maxY, y)
+      }
+    }
+
+    // No transparent pixels means the content fills the canvas; normalization
+    // by alpha bounds would be meaningless.
+    guard foundTransparent, maxX >= minX, maxY >= minY else { return nil }
+
+    let scaleX = CGFloat(cgImage.width) / CGFloat(sampleSize)
+    let scaleY = CGFloat(cgImage.height) / CGFloat(sampleSize)
+    return CGRect(
+      x: CGFloat(minX) * scaleX,
+      y: CGFloat(minY) * scaleY,
+      width: CGFloat(maxX - minX + 1) * scaleX,
+      height: CGFloat(maxY - minY + 1) * scaleY
+    )
+  }
+}

--- a/Snapzy/App/MenuBarIconStyle.swift
+++ b/Snapzy/App/MenuBarIconStyle.swift
@@ -1,0 +1,34 @@
+//
+//  MenuBarIconStyle.swift
+//  Snapzy
+//
+//  Selectable menu bar icon styles.
+//
+
+import Foundation
+
+/// Menu bar icon choices: the bundled default artwork, built-in SF Symbol
+/// alternates, or a user-imported custom PNG.
+/// Raw values are persisted in UserDefaults and TOML config — never rename.
+enum MenuBarIconStyle: String, CaseIterable, Identifiable {
+  case `default`
+  case cameraViewfinder
+  case cameraFill
+  case scissors
+  case photoOnRectangle
+  case custom
+
+  var id: String { rawValue }
+
+  /// SF Symbol backing built-in alternates. `nil` for the bundled default
+  /// artwork and the user-imported custom icon.
+  var symbolName: String? {
+    switch self {
+    case .cameraViewfinder: return "camera.viewfinder"
+    case .cameraFill: return "camera.fill"
+    case .scissors: return "scissors"
+    case .photoOnRectangle: return "photo.on.rectangle"
+    case .default, .custom: return nil
+    }
+  }
+}

--- a/Snapzy/App/MenuBarItemKind.swift
+++ b/Snapzy/App/MenuBarItemKind.swift
@@ -1,0 +1,122 @@
+//
+//  MenuBarItemKind.swift
+//  Snapzy
+//
+//  Stable identifiers for customizable status bar menu entries.
+//
+
+import Foundation
+
+/// Logical sections of the status bar menu. Group order is fixed; users reorder
+/// items only within a group, and separators render between non-empty groups.
+enum MenuBarItemGroup: String, CaseIterable {
+  case capture
+  case recording
+  case tools
+}
+
+/// Identifiers for menu entries the user can hide and/or reorder.
+/// Raw values are persisted in UserDefaults and TOML config — never rename.
+/// Pinned entries (recording status block, permission prompt, What's New,
+/// Preferences, Quit) are intentionally not represented here.
+enum MenuBarItemKind: String, CaseIterable {
+  // Capture
+  case captureArea
+  case captureAreaAnnotate
+  case captureApplication
+  case captureFullscreen
+  case captureActiveWindow
+  case scrollingCapture
+  case captureOCR
+  case captureSmartElement
+  case captureObjectCutout
+
+  // Recording
+  case recordScreen
+  case recordApplication
+
+  // Tools
+  case openAnnotate
+  case combineImages
+  case editVideo
+  case cloudUploads
+  case openHistory
+  case shortcutList
+
+  // App (fixed position, hideable only)
+  case checkForUpdates
+
+  var group: MenuBarItemGroup? {
+    switch self {
+    case .captureArea, .captureAreaAnnotate, .captureApplication, .captureFullscreen,
+         .captureActiveWindow, .scrollingCapture, .captureOCR, .captureSmartElement,
+         .captureObjectCutout:
+      return .capture
+    case .recordScreen, .recordApplication:
+      return .recording
+    case .openAnnotate, .combineImages, .editVideo, .cloudUploads, .openHistory, .shortcutList:
+      return .tools
+    case .checkForUpdates:
+      return nil
+    }
+  }
+
+  /// Items the user can both hide and reorder within their group.
+  var isCustomizable: Bool { group != nil }
+
+  /// Items the user can hide but not move from their default position.
+  var isHideableOnly: Bool { self == .checkForUpdates }
+
+  /// Title shown in the settings list. Reuses the same L10n keys as the menu.
+  var settingsTitle: String {
+    switch self {
+    case .captureArea: return L10n.Actions.captureArea
+    case .captureAreaAnnotate: return L10n.Actions.captureAreaAnnotate
+    case .captureApplication: return L10n.PreferencesShortcuts.applicationCaptureTitle
+    case .captureFullscreen: return L10n.Actions.captureFullscreen
+    case .captureActiveWindow: return L10n.Actions.captureActiveWindow
+    case .scrollingCapture: return L10n.Actions.scrollingCapture
+    case .captureOCR: return L10n.Actions.captureTextOCR
+    case .captureSmartElement: return L10n.Actions.captureSmartElement
+    case .captureObjectCutout: return GlobalShortcutKind.objectCutout.displayName
+    case .recordScreen: return L10n.Menu.recordScreen
+    case .recordApplication: return L10n.PreferencesShortcuts.applicationRecordingTitle
+    case .openAnnotate: return L10n.Actions.openAnnotate
+    case .combineImages: return L10n.Combine.open
+    case .editVideo: return L10n.Menu.editVideo
+    case .cloudUploads: return L10n.Actions.cloudUploads
+    case .openHistory: return L10n.Actions.openHistory
+    case .shortcutList: return L10n.Menu.keyboardShortcuts
+    case .checkForUpdates: return L10n.Menu.checkForUpdates
+    }
+  }
+
+  /// SF Symbol matching the icon used by the menu entry.
+  var systemImage: String {
+    switch self {
+    case .captureArea: return "crop"
+    case .captureAreaAnnotate: return "pencil.and.scribble"
+    case .captureApplication: return "macwindow"
+    case .captureFullscreen: return "rectangle.dashed"
+    case .captureActiveWindow: return "macwindow.on.rectangle"
+    case .scrollingCapture: return "arrow.up.and.down"
+    case .captureOCR: return "text.viewfinder"
+    case .captureSmartElement: return "dot.viewfinder"
+    case .captureObjectCutout: return "person.crop.rectangle"
+    case .recordScreen: return "record.circle"
+    case .recordApplication: return "square.on.square"
+    case .openAnnotate: return "pencil.and.outline"
+    case .combineImages: return "rectangle.3.group"
+    case .editVideo: return "film"
+    case .cloudUploads: return "icloud.and.arrow.up"
+    case .openHistory: return "clock.arrow.circlepath"
+    case .shortcutList: return "list.bullet.rectangle"
+    case .checkForUpdates: return "arrow.triangle.2.circlepath"
+    }
+  }
+
+  /// Default in-group order for customizable items of a group.
+  static func defaultOrder(for group: MenuBarItemGroup) -> [MenuBarItemKind] {
+    allCases.filter { $0.group == group }
+  }
+}

--- a/Snapzy/Features/Preferences/Components/PreferencesMenuBarSettingsView.swift
+++ b/Snapzy/Features/Preferences/Components/PreferencesMenuBarSettingsView.swift
@@ -1,0 +1,487 @@
+//
+//  PreferencesMenuBarSettingsView.swift
+//  Snapzy
+//
+//  Menu Bar preferences tab: icon style picker and menu item visibility/order.
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+extension UTType {
+  static let menuBarItemReorder = UTType("com.snapzy.menu-bar-reorder") ?? .text
+}
+
+struct MenuBarSettingsView: View {
+  @ObservedObject private var store = MenuBarCustomizationStore.shared
+  @State private var draggedItem: MenuBarItemKind?
+  @State private var activeDragID: UUID?
+  @State private var mouseUpMonitor: Any?
+  @State private var iconRefreshID = UUID()
+  @State private var showImportError = false
+  @State private var isCustomDropTargeted = false
+
+  private let iconRenderer = MenuBarIconRenderer.shared
+
+  var body: some View {
+    Form {
+      iconSection
+
+      ForEach(MenuBarItemGroup.allCases, id: \.self) { group in
+        itemGroupSection(group)
+      }
+
+      Section(L10n.PreferencesMenuBar.appSection) {
+        SettingRow(
+          icon: MenuBarItemKind.checkForUpdates.systemImage,
+          title: MenuBarItemKind.checkForUpdates.settingsTitle,
+          description: nil
+        ) {
+          Toggle("", isOn: Binding(
+            get: { !store.isHidden(.checkForUpdates) },
+            set: { store.setHidden(.checkForUpdates, hidden: !$0) }
+          ))
+          .labelsHidden()
+        }
+      }
+
+      Section {
+        HStack {
+          Spacer()
+          Button(L10n.PreferencesMenuBar.resetButton) {
+            store.resetToDefaults()
+            iconRefreshID = UUID()
+          }
+          .buttonStyle(.bordered)
+          .controlSize(.small)
+        }
+      } footer: {
+        Text(L10n.PreferencesMenuBar.itemsDescription)
+      }
+    }
+    .formStyle(.grouped)
+    .alert(L10n.PreferencesMenuBar.importFailedTitle, isPresented: $showImportError) {
+      Button(L10n.Common.ok, role: .cancel) {}
+    } message: {
+      Text(L10n.PreferencesMenuBar.importFailedMessage)
+    }
+  }
+
+  // MARK: - Icon Section
+
+  private var iconSection: some View {
+    Section(L10n.PreferencesMenuBar.iconSection) {
+      VStack(alignment: .leading, spacing: 10) {
+        HStack(spacing: 12) {
+          ForEach(MenuBarIconStyle.allCases) { style in
+            MenuBarIconTile(
+              style: style,
+              isSelected: store.iconStyle == style,
+              hasCustomIcon: iconRenderer.hasCustomIcon,
+              isDropTargeted: style == .custom && isCustomDropTargeted,
+              previewImage: previewImage(for: style),
+              title: iconTitle(style),
+              action: { selectIconStyle(style) }
+            )
+            .onDrop(
+              of: style == .custom ? [.fileURL] : [],
+              isTargeted: $isCustomDropTargeted,
+              perform: { providers in
+                guard style == .custom else { return false }
+                return handleCustomIconDrop(providers)
+              }
+            )
+          }
+        }
+        .id(iconRefreshID)
+
+        Text(L10n.PreferencesMenuBar.iconSectionDescription)
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+
+        if store.iconStyle == .custom {
+          HStack(spacing: 8) {
+            Button(L10n.PreferencesMenuBar.importButton) {
+              presentImportPanel()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+
+            Button(L10n.PreferencesMenuBar.removeCustomButton) {
+              iconRenderer.removeCustomIcon()
+              store.setIconStyle(.default)
+              iconRefreshID = UUID()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+          }
+          .transition(.opacity.combined(with: .move(edge: .top)))
+        }
+      }
+      .padding(.vertical, 4)
+      .animation(.easeInOut(duration: 0.15), value: store.iconStyle)
+    }
+  }
+
+  private func previewImage(for style: MenuBarIconStyle) -> NSImage? {
+    switch style {
+    case .default:
+      return iconRenderer.statusImage(for: .default)
+    case .custom:
+      return iconRenderer.hasCustomIcon ? iconRenderer.statusImage(for: .custom) : nil
+    default:
+      return nil
+    }
+  }
+
+  private func iconTitle(_ style: MenuBarIconStyle) -> String {
+    switch style {
+    case .default: return L10n.PreferencesMenuBar.iconDefault
+    case .custom: return L10n.PreferencesMenuBar.iconCustom
+    default: return style.rawValue.capitalized
+    }
+  }
+
+  private func selectIconStyle(_ style: MenuBarIconStyle) {
+    // The custom slot is an add action until an icon has been imported.
+    if style == .custom && !iconRenderer.hasCustomIcon {
+      presentImportPanel()
+      return
+    }
+    store.setIconStyle(style)
+  }
+
+  private func presentImportPanel() {
+    let panel = NSOpenPanel()
+    panel.allowedContentTypes = [.png]
+    panel.allowsMultipleSelection = false
+    panel.canChooseDirectories = false
+    panel.prompt = L10n.PreferencesMenuBar.importButton
+
+    guard panel.runModal() == .OK, let url = panel.url else { return }
+    importCustomIcon(from: url)
+  }
+
+  private func handleCustomIconDrop(_ providers: [NSItemProvider]) -> Bool {
+    guard let provider = providers.first else { return false }
+    _ = provider.loadObject(ofClass: URL.self) { url, _ in
+      guard let url else { return }
+      Task { @MainActor in
+        if url.pathExtension.lowercased() == "png" {
+          self.importCustomIcon(from: url)
+        } else {
+          self.showImportError = true
+        }
+      }
+    }
+    return true
+  }
+
+  private func importCustomIcon(from url: URL) {
+    if iconRenderer.saveCustomIcon(from: url) {
+      store.setIconStyle(.custom)
+      iconRefreshID = UUID()
+    } else {
+      showImportError = true
+    }
+  }
+
+  // MARK: - Item Group Sections
+
+  private func itemGroupSection(_ group: MenuBarItemGroup) -> some View {
+    Section(itemGroupTitle(group)) {
+      VStack(spacing: 0) {
+        ForEach(Array(store.orderedItems(for: group).enumerated()), id: \.element.rawValue) { index, item in
+          MenuBarItemRow(
+            item: item,
+            index: index,
+            group: group,
+            store: store,
+            isVisible: Binding(
+              get: { !store.isHidden(item) },
+              set: { store.setHidden(item, hidden: !$0) }
+            ),
+            draggedItem: $draggedItem,
+            activeDragID: $activeDragID
+          )
+
+          if index < store.orderedItems(for: group).count - 1 {
+            Divider()
+          }
+        }
+      }
+      .padding(.vertical, 4)
+      .onAppear {
+        // Authoritative drag-end signal: leftMouseUp always fires on the main
+        // thread at the end of every drag, even when SwiftUI replaces a row's
+        // drop delegate mid-reorder.
+        mouseUpMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseUp) { event in
+          if self.draggedItem != nil {
+            self.draggedItem = nil
+          }
+          if self.activeDragID != nil {
+            self.activeDragID = nil
+          }
+          return event
+        }
+      }
+      .onDisappear {
+        if let monitor = mouseUpMonitor {
+          NSEvent.removeMonitor(monitor)
+          mouseUpMonitor = nil
+        }
+      }
+    }
+  }
+
+  private func itemGroupTitle(_ group: MenuBarItemGroup) -> String {
+    switch group {
+    case .capture: return L10n.PreferencesMenuBar.captureSection
+    case .recording: return L10n.PreferencesMenuBar.recordingSection
+    case .tools: return L10n.PreferencesMenuBar.toolsSection
+    }
+  }
+}
+
+// MARK: - Icon Tile
+
+/// Menu bar icon choice tile. Label-less for a consistent grid rhythm; the
+/// custom slot renders as a dashed "add" action until an icon is imported.
+private struct MenuBarIconTile: View {
+  let style: MenuBarIconStyle
+  let isSelected: Bool
+  let hasCustomIcon: Bool
+  let isDropTargeted: Bool
+  let previewImage: NSImage?
+  let title: String
+  let action: () -> Void
+
+  @State private var isHovered = false
+
+  private var showsAddAction: Bool {
+    style == .custom && !hasCustomIcon
+  }
+
+  var body: some View {
+    Button(action: action) {
+      ZStack {
+        tileBackground
+
+        tileContent
+      }
+      .frame(width: 44, height: 44)
+      .overlay(
+        RoundedRectangle(cornerRadius: 10)
+          .strokeBorder(
+            isSelected ? Color.accentColor : Color.clear,
+            lineWidth: 2.5
+          )
+      )
+      .overlay(alignment: .bottomTrailing) {
+        if isSelected {
+          selectionBadge
+        }
+      }
+      .contentShape(RoundedRectangle(cornerRadius: 10))
+    }
+    .buttonStyle(.plain)
+    .onHover { isHovered = $0 }
+    .help(title)
+    .accessibilityLabel(title)
+    .accessibilityAddTraits(isSelected ? .isSelected : [])
+  }
+
+  @ViewBuilder
+  private var tileBackground: some View {
+    if showsAddAction {
+      // Dashed "add" affordance — reads as an action, not a choice.
+      RoundedRectangle(cornerRadius: 10)
+        .strokeBorder(
+          style: StrokeStyle(lineWidth: 1.5, dash: [4, 3])
+        )
+        .foregroundStyle(isDropTargeted ? Color.accentColor : Color.secondary.opacity(0.5))
+        .background(
+          RoundedRectangle(cornerRadius: 10)
+            .fill(isDropTargeted ? Color.accentColor.opacity(0.12) : Color.clear)
+        )
+    } else {
+      RoundedRectangle(cornerRadius: 10)
+        .fill(fillColor)
+        .overlay(
+          RoundedRectangle(cornerRadius: 10)
+            .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
+        )
+    }
+  }
+
+  private var fillColor: Color {
+    if isSelected {
+      return Color.accentColor.opacity(0.15)
+    }
+    if isHovered {
+      return Color.primary.opacity(0.1)
+    }
+    return Color.primary.opacity(0.05)
+  }
+
+  @ViewBuilder
+  private var tileContent: some View {
+    if showsAddAction {
+      Image(systemName: "plus")
+        .font(.system(size: 16, weight: .medium))
+        .foregroundStyle(isDropTargeted ? Color.accentColor : Color.secondary)
+    } else if let symbolName = style.symbolName {
+      Image(systemName: symbolName)
+        .font(.system(size: 19))
+        .foregroundStyle(isSelected ? Color.accentColor : Color.primary)
+    } else if let previewImage {
+      Image(nsImage: previewImage)
+        .resizable()
+        .interpolation(.high)
+        .aspectRatio(contentMode: .fit)
+        .frame(width: 20, height: 20)
+        .foregroundStyle(isSelected ? Color.accentColor : Color.primary)
+    }
+  }
+
+  private var selectionBadge: some View {
+    Image(systemName: "checkmark.circle.fill")
+      .font(.system(size: 14))
+      .foregroundStyle(.white, Color.accentColor)
+      .background(Circle().fill(Color.accentColor))
+      .offset(x: 5, y: 5)
+  }
+}
+
+// MARK: - Item Row
+
+private struct MenuBarItemRow: View {
+  let item: MenuBarItemKind
+  let index: Int
+  let group: MenuBarItemGroup
+  let store: MenuBarCustomizationStore
+  @Binding var isVisible: Bool
+  @Binding var draggedItem: MenuBarItemKind?
+  @Binding var activeDragID: UUID?
+  @State private var isHandleHovered = false
+
+  var body: some View {
+    HStack(spacing: 10) {
+      // Drag handle — reorder within the group only
+      Image(systemName: "line.3.horizontal")
+        .font(.system(size: 11, weight: .medium))
+        .foregroundStyle(isHandleHovered ? .secondary : .quaternary)
+        .frame(width: 14)
+        .contentShape(Rectangle().inset(by: -4))
+        .onHover { isHandleHovered = $0 }
+        .onDrag {
+          let dragID = UUID()
+          self.activeDragID = dragID
+          self.draggedItem = item
+
+          let provider = MenuBarDragTrackingItemProvider()
+          if let data = item.rawValue.data(using: .utf8) {
+            provider.registerDataRepresentation(
+              forTypeIdentifier: UTType.menuBarItemReorder.identifier,
+              visibility: .all
+            ) { completion in
+              completion(data, nil)
+              return nil
+            }
+          }
+
+          provider.onDeinit = { [dragID] in
+            Task { @MainActor in
+              if self.activeDragID == dragID {
+                self.activeDragID = nil
+                self.draggedItem = nil
+              }
+            }
+          }
+          return provider
+        } preview: {
+          // No visual ghost — handle-drag is a reorder-only gesture.
+          Color.clear.frame(width: 1, height: 1)
+        }
+
+      Image(systemName: item.systemImage)
+        .font(.system(size: 14, weight: .semibold))
+        .foregroundStyle(.secondary)
+        .frame(width: 18)
+
+      Text(item.settingsTitle)
+        .lineLimit(1)
+
+      Spacer()
+
+      Toggle("", isOn: $isVisible)
+        .labelsHidden()
+    }
+    .padding(.horizontal, 10)
+    .padding(.vertical, 8)
+    .opacity(isVisible ? 1.0 : 0.6)
+    .background(draggedItem == item ? Color(NSColor.selectedControlColor).opacity(0.15) : Color.clear)
+    .onDrop(of: [UTType.menuBarItemReorder], delegate: MenuBarReorderDropDelegate(
+      targetItem: item,
+      targetIndex: index,
+      group: group,
+      store: store,
+      draggedItem: $draggedItem
+    ))
+  }
+}
+
+private struct MenuBarReorderDropDelegate: DropDelegate {
+  let targetItem: MenuBarItemKind
+  let targetIndex: Int
+  let group: MenuBarItemGroup
+  let store: MenuBarCustomizationStore
+  @Binding var draggedItem: MenuBarItemKind?
+
+  func validateDrop(info: DropInfo) -> Bool {
+    draggedItem != nil
+  }
+
+  func dropEntered(info: DropInfo) {
+    guard let sourceItem = draggedItem,
+          sourceItem != targetItem else { return }
+
+    let groupItems = store.orderedItems(for: group)
+    guard let sourceIndex = groupItems.firstIndex(of: sourceItem) else { return }
+
+    if sourceIndex != targetIndex {
+      withAnimation(.default) {
+        store.moveItem(
+          from: IndexSet(integer: sourceIndex),
+          to: targetIndex > sourceIndex ? targetIndex + 1 : targetIndex,
+          in: group
+        )
+      }
+    }
+  }
+
+  func performDrop(info: DropInfo) -> Bool {
+    // Belt-and-suspenders: also reset here for cases where the monitor fires late.
+    Task { @MainActor in
+      draggedItem = nil
+    }
+    return true
+  }
+
+  func dropUpdated(info: DropInfo) -> DropProposal? {
+    DropProposal(operation: .move)
+  }
+}
+
+private final class MenuBarDragTrackingItemProvider: NSItemProvider {
+  var onDeinit: (() -> Void)?
+  deinit {
+    onDeinit?()
+  }
+}
+
+#Preview {
+  MenuBarSettingsView()
+    .frame(width: 600, height: 500)
+}

--- a/Snapzy/Features/Preferences/Models/PreferencesKeys.swift
+++ b/Snapzy/Features/Preferences/Models/PreferencesKeys.swift
@@ -32,6 +32,11 @@ enum PreferencesKeys {
   static let wallpaperDirectoryBookmark = "wallpaper.directoryBookmark"
   static let customWallpaperBookmarks = "wallpaper.customBookmarks"
 
+  // Menu Bar
+  static let menuBarItemOrder = "menuBar.itemOrder"
+  static let menuBarHiddenItems = "menuBar.hiddenItems"
+  static let menuBarIconStyle = "menuBar.iconStyle"
+
   /// Appearance
   static let appearanceMode = "appearanceMode"
 

--- a/Snapzy/Features/Preferences/Models/PreferencesNavigationState.swift
+++ b/Snapzy/Features/Preferences/Models/PreferencesNavigationState.swift
@@ -9,6 +9,7 @@ import Combine
 
 enum PreferencesTab: Hashable {
   case general
+  case menuBar
   case capture
   case annotate
   case quickAccess

--- a/Snapzy/Features/Preferences/PreferencesView.swift
+++ b/Snapzy/Features/Preferences/PreferencesView.swift
@@ -17,6 +17,10 @@ struct PreferencesView: View {
         .tabItem { Label(L10n.Preferences.generalTab, systemImage: "gearshape.fill") }
         .tag(PreferencesTab.general)
 
+      LazyView(MenuBarSettingsView())
+        .tabItem { Label(L10n.Preferences.menuBarTab, systemImage: "menubar.rectangle") }
+        .tag(PreferencesTab.menuBar)
+
       LazyView(CaptureSettingsView())
         .tabItem { Label(L10n.Preferences.captureTab, systemImage: "camera.fill") }
         .tag(PreferencesTab.capture)

--- a/Snapzy/Resources/Localization/Features/Settings.xcstrings
+++ b/Snapzy/Resources/Localization/Features/Settings.xcstrings
@@ -12736,6 +12736,966 @@
           }
         }
       }
+    },
+    "preferences.tab.menu-bar": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menüleiste"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menu Bar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Barra de menús"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Barre des menus"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メニューバー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "메뉴 막대"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Строка меню"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thanh menu"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "菜单栏"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選單列"
+          }
+        }
+      }
+    },
+    "preferences-menubar.icon-section": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menüleisten-Symbol"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menu Bar Icon"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icono de la barra de menús"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Icône de la barre des menus"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メニューバーアイコン"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "메뉴 막대 아이콘"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Значок строки меню"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Biểu tượng thanh menu"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "菜单栏图标"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選單列圖示"
+          }
+        }
+      }
+    },
+    "preferences-menubar.icon-section-description": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wähle ein integriertes Symbol oder klicke auf + bzw. lege ein PNG ab, um ein eigenes hinzuzufügen (18×18 empfohlen). Symbole werden in der Menüleiste als monochrome Vorlagen dargestellt."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a built-in icon, or click + or drop a PNG to add your own (18×18 recommended). Icons render as monochrome templates in the menu bar."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige un icono integrado, o haz clic en + o suelta un PNG para añadir el tuyo (se recomienda 18×18). Los iconos se muestran como plantillas monocromas en la barra de menús."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez une icône intégrée, ou cliquez sur + ou déposez un PNG pour ajouter la vôtre (18×18 recommandé). Les icônes s'affichent en monochrome dans la barre des menus."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "内蔵アイコンを選択するか、+ をクリックまたは PNG をドロップして独自のアイコンを追加します（18×18 推奨）。アイコンはメニューバーでモノクロテンプレートとして表示されます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "내장 아이콘을 선택하거나 +를 클릭 또는 PNG를 드롭하여 직접 추가하세요(18×18 권장). 아이콘은 메뉴 막대에 단색 템플릿으로 표시됩니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите встроенный значок или нажмите + либо перетащите PNG, чтобы добавить свой (рекомендуется 18×18). Значки отображаются в строке меню как монохромные шаблоны."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chọn biểu tượng có sẵn, hoặc nhấn + hay thả tệp PNG để thêm biểu tượng riêng (khuyến nghị 18×18). Biểu tượng hiển thị dạng đơn sắc trên thanh menu."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择内置图标，或点击 + 或拖入 PNG 添加自定义图标（建议 18×18）。图标在菜单栏中以单色模板显示。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇內建圖示，或按 + 或拖放 PNG 加入自訂圖示（建議 18×18）。圖示在選單列中以單色樣板呈現。"
+          }
+        }
+      }
+    },
+    "preferences-menubar.icon-default": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predeterminado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Par défaut"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルト"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본값"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По умолчанию"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mặc định"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "預設"
+          }
+        }
+      }
+    },
+    "preferences-menubar.icon-custom": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eigene"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custom"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personalizado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Personnalisée"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カスタム"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용자 지정"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Свой"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tùy chỉnh"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自訂"
+          }
+        }
+      }
+    },
+    "preferences-menubar.import-button": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PNG importieren…"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import PNG…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importar PNG…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importer un PNG…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PNG を読み込む…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PNG 가져오기…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Импорт PNG…"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nhập PNG…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导入 PNG…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輸入 PNG…"
+          }
+        }
+      }
+    },
+    "preferences-menubar.import-failed-title": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import fehlgeschlagen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import Failed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error al importar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de l'importation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "読み込みに失敗しました"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "가져오기 실패"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ошибка импорта"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nhập thất bại"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导入失败"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輸入失敗"
+          }
+        }
+      }
+    },
+    "preferences-menubar.import-failed-message": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die ausgewählte Datei konnte nicht gelesen werden. Bitte wähle ein gültiges PNG-Bild."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The selected file could not be read. Please choose a valid PNG image."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo leer el archivo seleccionado. Elige una imagen PNG válida."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de lire le fichier sélectionné. Veuillez choisir une image PNG valide."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したファイルを読み込めませんでした。有効な PNG 画像を選択してください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택한 파일을 읽을 수 없습니다. 유효한 PNG 이미지를 선택하세요."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось прочитать выбранный файл. Выберите корректное изображение PNG."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không thể đọc tệp đã chọn. Vui lòng chọn ảnh PNG hợp lệ."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法读取所选文件。请选择有效的 PNG 图片。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法讀取所選檔案。請選擇有效的 PNG 圖片。"
+          }
+        }
+      }
+    },
+    "preferences-menubar.capture-section": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Captura"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャプチャ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "캡처"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Съёмка"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chụp"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "截图"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "截圖"
+          }
+        }
+      }
+    },
+    "preferences-menubar.recording-section": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufzeichnung"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grabación"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrement"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録画"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "녹화"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запись"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghi hình"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录制"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "錄製"
+          }
+        }
+      }
+    },
+    "preferences-menubar.tools-section": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Werkzeuge"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tools"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Herramientas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Outils"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ツール"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도구"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Инструменты"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Công cụ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工具"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工具"
+          }
+        }
+      }
+    },
+    "preferences-menubar.app-section": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "앱"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приложение"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ứng dụng"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App"
+          }
+        }
+      }
+    },
+    "preferences-menubar.items-description": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schalte Einträge ein oder aus, um sie in der Menüleiste ein- oder auszublenden. Ziehe am Griff, um innerhalb eines Abschnitts neu anzuordnen. Ausgeblendete Funktionen bleiben über Tastaturkurzbefehle verfügbar."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toggle items to show or hide them in the menu bar. Drag the handle to reorder within a section. Hidden features remain available via keyboard shortcuts."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa o desactiva elementos para mostrarlos u ocultarlos en la barra de menús. Arrastra el control para reordenar dentro de una sección. Las funciones ocultas siguen disponibles mediante atajos de teclado."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activez ou désactivez des éléments pour les afficher ou les masquer dans la barre des menus. Faites glisser la poignée pour réorganiser au sein d'une section. Les fonctionnalités masquées restent accessibles via les raccourcis clavier."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スイッチでメニューバー項目の表示・非表示を切り替えます。ハンドルをドラッグするとセクション内で並べ替えできます。非表示の機能もキーボードショートカットから利用できます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "토글로 메뉴 막대에서 항목을 표시하거나 숨길 수 있습니다. 핸들을 드래그하여 섹션 내에서 순서를 변경하세요. 숨긴 기능은 키보드 단축키로 계속 사용할 수 있습니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включайте и выключайте элементы, чтобы показывать или скрывать их в строке меню. Перетаскивайте за ручку, чтобы менять порядок внутри раздела. Скрытые функции остаются доступны через сочетания клавиш."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bật/tắt để hiện hoặc ẩn mục trên thanh menu. Kéo tay cầm để sắp xếp lại trong một mục. Tính năng bị ẩn vẫn dùng được qua phím tắt."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用开关在菜单栏中显示或隐藏项目。拖动手柄可在分组内重新排序。隐藏的功能仍可通过键盘快捷键使用。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用開關在選單列中顯示或隱藏項目。拖曳控制柄可在區段內重新排序。隱藏的功能仍可透過鍵盤快捷鍵使用。"
+          }
+        }
+      }
+    },
+    "preferences-menubar.reset-button": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auf Standard zurücksetzen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset to Defaults"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer valores predeterminados"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rétablir les valeurs par défaut"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルトに戻す"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본값으로 재설정"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сбросить настройки"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đặt lại mặc định"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复默认设置"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置為預設值"
+          }
+        }
+      }
+    },
+    "preferences-menubar.remove-custom-button": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entfernen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supprimer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제거"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xóa"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Snapzy/Resources/Localization/manifest.json
+++ b/Snapzy/Resources/Localization/manifest.json
@@ -78,6 +78,7 @@
         "preferences-advanced.",
         "preferences-general.",
         "preferences-history.",
+        "preferences-menubar.",
         "preferences.tab."
       ]
     },

--- a/Snapzy/Services/Configuration/SnapzyConfigurationExporter.swift
+++ b/Snapzy/Services/Configuration/SnapzyConfigurationExporter.swift
@@ -17,6 +17,7 @@ enum SnapzyConfigurationExporter {
     writer.root("snapzy_min_version", Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.20.0")
 
     writeGeneral(&writer, defaults: defaults)
+    writeMenuBar(&writer)
     writeCapture(&writer, defaults: defaults)
     writeRecording(&writer, defaults: defaults)
     writeQuickAccess(&writer)
@@ -51,6 +52,15 @@ enum SnapzyConfigurationExporter {
       defaults.object(forKey: PreferencesKeys.diagnosticsRetentionDays) as? Int
         ?? LogCleanupScheduler.defaultRetentionDays
     )
+  }
+
+  private static func writeMenuBar(_ writer: inout SimpleTOMLWriter) {
+    let store = MenuBarCustomizationStore.shared
+
+    writer.section("menu_bar")
+    writer.value("icon_style", store.iconStyle.rawValue)
+    writer.stringArray("item_order", store.itemOrder.map(\.rawValue))
+    writer.stringArray("hidden_items", store.hiddenItems.map(\.rawValue).sorted())
   }
 
   private static func writeCapture(_ writer: inout SimpleTOMLWriter, defaults: UserDefaults) {

--- a/Snapzy/Services/Configuration/SnapzyConfigurationImporter.swift
+++ b/Snapzy/Services/Configuration/SnapzyConfigurationImporter.swift
@@ -54,6 +54,7 @@ enum SnapzyConfigurationImporter {
 
     validateSchema(&reader)
     collectGeneral(&reader, defaults: defaults, mutations: &mutations)
+    collectMenuBar(&reader, mutations: &mutations)
     collectCapture(&reader, defaults: defaults, mutations: &mutations)
     collectRecording(&reader, defaults: defaults, mutations: &mutations)
     collectQuickAccess(&reader, mutations: &mutations)
@@ -124,6 +125,36 @@ enum SnapzyConfigurationImporter {
     }
     collectInt(&reader, "diagnostics", "retention_days", range: LogCleanupScheduler.retentionDaysRange, mutations: &mutations) {
       defaults.set($0, forKey: PreferencesKeys.diagnosticsRetentionDays)
+    }
+  }
+
+  private static func collectMenuBar(
+    _ reader: inout SnapzyConfigurationReader,
+    mutations: inout [() -> Void]
+  ) {
+    if let iconStyleStr = reader.string("menu_bar", "icon_style") {
+      guard let style = MenuBarIconStyle(rawValue: iconStyleStr) else {
+        reader.error("menu_bar.icon_style is invalid")
+        return
+      }
+      mutations.append {
+        // The custom PNG file is not portable across machines; fall back to
+        // the bundled default when no custom icon exists locally.
+        let resolved = (style == .custom && !MenuBarIconRenderer.shared.hasCustomIcon) ? .default : style
+        MenuBarCustomizationStore.shared.setIconStyle(resolved)
+      }
+    }
+
+    let order = reader.stringArray("menu_bar", "item_order")?.compactMap(MenuBarItemKind.init(rawValue:))
+    let hidden = reader.stringArray("menu_bar", "hidden_items")?.compactMap(MenuBarItemKind.init(rawValue:))
+    if order != nil || hidden != nil {
+      mutations.append {
+        MenuBarCustomizationStore.shared.applyConfiguration(
+          order: order,
+          hiddenItems: hidden.map(Set.init),
+          iconStyle: nil
+        )
+      }
     }
   }
 

--- a/Snapzy/Shared/Localization/L10n.swift
+++ b/Snapzy/Shared/Localization/L10n.swift
@@ -23,6 +23,7 @@ nonisolated enum L10n {
     ("sponsor.", "Onboarding"),
     ("preferences.tab.", "Settings"),
     ("preferences-general.", "Settings"),
+    ("preferences-menubar.", "Settings"),
     ("preferences-capture.", "Capture"),
     ("preferences-shortcuts.", "Shortcuts"),
     ("preferences-cloud-history.", "Cloud"),
@@ -154,6 +155,11 @@ nonisolated enum L10n {
       defaultValue: "Capture",
       comment: "Preferences tab title"
     )
+    static let menuBarTab = string(
+      "preferences.tab.menu-bar",
+      defaultValue: "Menu Bar",
+      comment: "Preferences tab title"
+    )
     static let annotateTab = string(
       "preferences.tab.annotate",
       defaultValue: "Annotate",
@@ -193,6 +199,79 @@ nonisolated enum L10n {
       "preferences.tab.about",
       defaultValue: "About",
       comment: "Preferences tab title"
+    )
+  }
+
+  enum PreferencesMenuBar {
+    static let iconSection = string(
+      "preferences-menubar.icon-section",
+      defaultValue: "Menu Bar Icon",
+      comment: "Menu Bar preferences icon customization section title"
+    )
+    static let iconSectionDescription = string(
+      "preferences-menubar.icon-section-description",
+      defaultValue: "Choose a built-in icon, or click + or drop a PNG to add your own (18×18 recommended). Icons render as monochrome templates in the menu bar.",
+      comment: "Menu Bar preferences icon customization section description"
+    )
+    static let iconDefault = string(
+      "preferences-menubar.icon-default",
+      defaultValue: "Default",
+      comment: "Menu Bar preferences default icon choice label"
+    )
+    static let iconCustom = string(
+      "preferences-menubar.icon-custom",
+      defaultValue: "Custom",
+      comment: "Menu Bar preferences custom icon choice label"
+    )
+    static let importButton = string(
+      "preferences-menubar.import-button",
+      defaultValue: "Import PNG…",
+      comment: "Menu Bar preferences import custom icon button title"
+    )
+    static let importFailedTitle = string(
+      "preferences-menubar.import-failed-title",
+      defaultValue: "Import Failed",
+      comment: "Menu Bar preferences custom icon import failure alert title"
+    )
+    static let importFailedMessage = string(
+      "preferences-menubar.import-failed-message",
+      defaultValue: "The selected file could not be read. Please choose a valid PNG image.",
+      comment: "Menu Bar preferences custom icon import failure alert message"
+    )
+    static let removeCustomButton = string(
+      "preferences-menubar.remove-custom-button",
+      defaultValue: "Remove",
+      comment: "Menu Bar preferences remove custom icon button title"
+    )
+    static let captureSection = string(
+      "preferences-menubar.capture-section",
+      defaultValue: "Capture",
+      comment: "Menu Bar preferences capture items section title"
+    )
+    static let recordingSection = string(
+      "preferences-menubar.recording-section",
+      defaultValue: "Recording",
+      comment: "Menu Bar preferences recording items section title"
+    )
+    static let toolsSection = string(
+      "preferences-menubar.tools-section",
+      defaultValue: "Tools",
+      comment: "Menu Bar preferences tools items section title"
+    )
+    static let appSection = string(
+      "preferences-menubar.app-section",
+      defaultValue: "App",
+      comment: "Menu Bar preferences app items section title"
+    )
+    static let itemsDescription = string(
+      "preferences-menubar.items-description",
+      defaultValue: "Toggle items to show or hide them in the menu bar. Drag the handle to reorder within a section. Hidden features remain available via keyboard shortcuts.",
+      comment: "Menu Bar preferences menu items customization description"
+    )
+    static let resetButton = string(
+      "preferences-menubar.reset-button",
+      defaultValue: "Reset to Defaults",
+      comment: "Menu Bar preferences reset customization button title"
     )
   }
 

--- a/SnapzyTests/App/MenuBarCustomizationStoreTests.swift
+++ b/SnapzyTests/App/MenuBarCustomizationStoreTests.swift
@@ -1,0 +1,209 @@
+//
+//  MenuBarCustomizationStoreTests.swift
+//  SnapzyTests
+//
+//  Unit tests for menu bar item order/visibility and icon style persistence.
+//
+
+import XCTest
+@testable import Snapzy
+
+@MainActor
+final class MenuBarCustomizationStoreTests: XCTestCase {
+  // Keep MainActor ObservableObjects alive for the test process; XCTest scope
+  // cleanup can crash while deinitializing app-level observable stores.
+  private static var retainedStores: [MenuBarCustomizationStore] = []
+
+  func testStore_usesDefaultOrderWithNothingHiddenAndDefaultIcon() {
+    let store = makeStore(defaults: makeIsolatedDefaults())
+
+    XCTAssertEqual(store.itemOrder, MenuBarItemKind.allCases.filter(\.isCustomizable))
+    XCTAssertTrue(store.hiddenItems.isEmpty)
+    XCTAssertEqual(store.iconStyle, .default)
+
+    for group in MenuBarItemGroup.allCases {
+      XCTAssertEqual(
+        store.orderedVisibleItems(for: group),
+        MenuBarItemKind.defaultOrder(for: group)
+      )
+    }
+  }
+
+  func testStore_filtersUnknownIdsAndAppendsMissingItems() {
+    let defaults = makeIsolatedDefaults()
+    defaults.set(
+      [
+        MenuBarItemKind.editVideo.rawValue,
+        "future-item",
+        MenuBarItemKind.captureArea.rawValue,
+        MenuBarItemKind.captureArea.rawValue,
+        MenuBarItemKind.checkForUpdates.rawValue,  // pinned: never part of the order list
+      ],
+      forKey: PreferencesKeys.menuBarItemOrder
+    )
+
+    let store = makeStore(defaults: defaults)
+
+    XCTAssertEqual(store.itemOrder.first, .editVideo)
+    XCTAssertEqual(store.itemOrder.count, MenuBarItemKind.allCases.filter(\.isCustomizable).count)
+    XCTAssertFalse(store.itemOrder.contains(.checkForUpdates))
+    XCTAssertTrue(store.itemOrder.contains(.captureOCR))  // missing items appended
+    // Relative order within a group is preserved even across groups in the flat list.
+    XCTAssertEqual(
+      store.orderedItems(for: .capture).first,
+      .captureArea
+    )
+  }
+
+  func testStore_hidingItemRemovesItFromVisibleItemsOnly() {
+    let defaults = makeIsolatedDefaults()
+    let store = makeStore(defaults: defaults)
+
+    store.setHidden(.captureArea, hidden: true)
+
+    XCTAssertTrue(store.isHidden(.captureArea))
+    XCTAssertFalse(store.orderedVisibleItems(for: .capture).contains(.captureArea))
+    XCTAssertTrue(store.orderedItems(for: .capture).contains(.captureArea))
+
+    store.setHidden(.captureArea, hidden: false)
+
+    XCTAssertFalse(store.isHidden(.captureArea))
+    XCTAssertTrue(store.orderedVisibleItems(for: .capture).contains(.captureArea))
+  }
+
+  func testStore_hidingPinnedEntryIsIgnored() {
+    let defaults = makeIsolatedDefaults()
+    defaults.set(
+      ["quit", "preferences", "captureArea"],
+      forKey: PreferencesKeys.menuBarHiddenItems
+    )
+
+    let store = makeStore(defaults: defaults)
+
+    XCTAssertEqual(store.hiddenItems, [.captureArea])
+  }
+
+  func testStore_hidesFixedPositionCheckForUpdates() {
+    let defaults = makeIsolatedDefaults()
+    let store = makeStore(defaults: defaults)
+
+    store.setHidden(.checkForUpdates, hidden: true)
+
+    XCTAssertTrue(store.isHidden(.checkForUpdates))
+
+    let reloaded = makeStore(defaults: defaults)
+    XCTAssertTrue(reloaded.isHidden(.checkForUpdates))
+  }
+
+  func testStore_persistsHiddenItemsAcrossInstances() {
+    let defaults = makeIsolatedDefaults()
+    let store = makeStore(defaults: defaults)
+
+    store.setHidden(.openHistory, hidden: true)
+    store.setHidden(.recordScreen, hidden: true)
+
+    let reloaded = makeStore(defaults: defaults)
+    XCTAssertEqual(reloaded.hiddenItems, [.openHistory, .recordScreen])
+    XCTAssertFalse(reloaded.orderedVisibleItems(for: .tools).contains(.openHistory))
+    XCTAssertFalse(reloaded.orderedVisibleItems(for: .recording).contains(.recordScreen))
+  }
+
+  func testStore_moveItemReordersWithinGroupOnly() {
+    let defaults = makeIsolatedDefaults()
+    let store = makeStore(defaults: defaults)
+    let captureBefore = store.orderedItems(for: .capture)
+    let toolsBefore = store.orderedItems(for: .tools)
+
+    // Move first capture item to the end of the capture group.
+    store.moveItem(from: IndexSet(integer: 0), to: captureBefore.count, in: .capture)
+
+    let captureAfter = store.orderedItems(for: .capture)
+    XCTAssertEqual(captureAfter.last, captureBefore.first)
+    XCTAssertEqual(Array(captureAfter.dropLast()), Array(captureBefore.dropFirst()))
+    XCTAssertEqual(store.orderedItems(for: .tools), toolsBefore)
+  }
+
+  func testStore_moveItemHandlesHiddenItemsInIndexMath() {
+    let defaults = makeIsolatedDefaults()
+    let store = makeStore(defaults: defaults)
+    store.setHidden(.captureAreaAnnotate, hidden: true)  // index 1 in capture group
+
+    // Move captureArea (index 0) past captureFullscreen — indices address the
+    // full group list including the hidden row, matching the settings UI.
+    store.moveItem(from: IndexSet(integer: 0), to: 3, in: .capture)
+
+    let captureOrder = store.orderedItems(for: .capture)
+    XCTAssertEqual(
+      captureOrder,
+      [.captureAreaAnnotate, .captureApplication, .captureArea, .captureFullscreen,
+       .captureActiveWindow, .scrollingCapture, .captureOCR, .captureSmartElement,
+       .captureObjectCutout]
+    )
+    XCTAssertTrue(store.isHidden(.captureAreaAnnotate))
+  }
+
+  func testStore_resetToDefaultsRestoresOrderVisibilityAndIcon() {
+    let defaults = makeIsolatedDefaults()
+    let store = makeStore(defaults: defaults)
+    store.setHidden(.captureArea, hidden: true)
+    store.moveItem(from: IndexSet(integer: 0), to: 2, in: .capture)
+    store.setIconStyle(.scissors)
+
+    store.resetToDefaults()
+
+    XCTAssertEqual(store.itemOrder, MenuBarItemKind.allCases.filter(\.isCustomizable))
+    XCTAssertTrue(store.hiddenItems.isEmpty)
+    XCTAssertEqual(store.iconStyle, .default)
+  }
+
+  func testStore_applyConfigurationNormalizesImportedValues() {
+    let defaults = makeIsolatedDefaults()
+    let store = makeStore(defaults: defaults)
+
+    store.applyConfiguration(
+      order: [.shortcutList, .captureOCR],
+      hiddenItems: [.captureOCR],
+      iconStyle: .cameraFill
+    )
+
+    XCTAssertEqual(store.orderedItems(for: .tools).first, .shortcutList)
+    XCTAssertEqual(store.orderedItems(for: .capture).first, .captureOCR)
+    XCTAssertTrue(store.isHidden(.captureOCR))
+    XCTAssertEqual(store.iconStyle, .cameraFill)
+    XCTAssertEqual(store.itemOrder.count, MenuBarItemKind.allCases.filter(\.isCustomizable).count)
+  }
+
+  func testStore_iconStyleFallsBackToDefaultForUnknownRawValue() {
+    let defaults = makeIsolatedDefaults()
+    defaults.set("future-style", forKey: PreferencesKeys.menuBarIconStyle)
+
+    let store = makeStore(defaults: defaults)
+
+    XCTAssertEqual(store.iconStyle, .default)
+  }
+
+  func testStore_persistsIconStyleAcrossInstances() {
+    let defaults = makeIsolatedDefaults()
+    let store = makeStore(defaults: defaults)
+
+    store.setIconStyle(.cameraViewfinder)
+
+    let reloaded = makeStore(defaults: defaults)
+    XCTAssertEqual(reloaded.iconStyle, .cameraViewfinder)
+  }
+
+  // MARK: - Helpers
+
+  private func makeIsolatedDefaults() -> UserDefaults {
+    let suiteName = "SnapzyTests.MenuBar.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    return defaults
+  }
+
+  private func makeStore(defaults: UserDefaults) -> MenuBarCustomizationStore {
+    let store = MenuBarCustomizationStore(defaults: defaults)
+    Self.retainedStores.append(store)
+    return store
+  }
+}

--- a/SnapzyTests/Services/Configuration/SnapzyConfigurationImporterTests.swift
+++ b/SnapzyTests/Services/Configuration/SnapzyConfigurationImporterTests.swift
@@ -399,4 +399,53 @@ final class SnapzyConfigurationImporterTests: XCTestCase {
     let result3 = SnapzyConfigurationImporter.importTOML(sourceInvalidAnim, defaults: defaults)
     XCTAssertTrue(result3.hasErrors)
   }
+
+  func testImportAppliesMenuBarCustomization() {
+    let defaults = UserDefaultsFactory.make()
+    let store = MenuBarCustomizationStore.shared
+    let originalOrder = store.itemOrder
+    let originalHidden = store.hiddenItems
+    let originalStyle = store.iconStyle
+    defer {
+      store.applyConfiguration(
+        order: originalOrder,
+        hiddenItems: originalHidden,
+        iconStyle: originalStyle
+      )
+    }
+    let source = """
+    schema_version = 1
+
+    [menu_bar]
+    icon_style = "cameraFill"
+    item_order = ["shortcutList", "captureOCR"]
+    hidden_items = ["openHistory"]
+    """
+
+    let result = SnapzyConfigurationImporter.importTOML(source, defaults: defaults)
+
+    XCTAssertFalse(result.hasErrors)
+    XCTAssertEqual(store.iconStyle, .cameraFill)
+    XCTAssertEqual(store.orderedItems(for: .tools).first, .shortcutList)
+    XCTAssertEqual(store.orderedItems(for: .capture).first, .captureOCR)
+    XCTAssertTrue(store.isHidden(.openHistory))
+  }
+
+  func testImportRejectsInvalidMenuBarIconStyle() {
+    let defaults = UserDefaultsFactory.make()
+    let store = MenuBarCustomizationStore.shared
+    let originalStyle = store.iconStyle
+    defer { store.setIconStyle(originalStyle) }
+    let source = """
+    schema_version = 1
+
+    [menu_bar]
+    icon_style = "invalid_style"
+    """
+
+    let result = SnapzyConfigurationImporter.importTOML(source, defaults: defaults)
+
+    XCTAssertTrue(result.hasErrors)
+    XCTAssertEqual(store.iconStyle, originalStyle)
+  }
 }

--- a/docs/APP_LIFECYCLE.md
+++ b/docs/APP_LIFECYCLE.md
@@ -94,7 +94,7 @@ State machine (`SplashScreen`): `splash` → `language` → `sponsor` (only when
 
 ## Menu bar
 
-`AppStatusBarController` (`Snapzy/App/AppStatusBarController.swift`) — singleton owning the `NSStatusItem` (variable length, template `MenubarIcon` rescaled to 18 pt).
+`AppStatusBarController` (`Snapzy/App/AppStatusBarController.swift`) — singleton owning the `NSStatusItem` (variable length, template icon rendered at 18 pt by `MenuBarIconRenderer`).
 
 - Click behavior: button `sendAction(on: [.leftMouseUp, .rightMouseUp])` — both left and right click rebuild and open the same menu (`buildMenu()` runs on every open to refresh state).
 - Menu structure (verified in `buildMenu()`):
@@ -105,6 +105,8 @@ State machine (`SplashScreen`): `splash` → `language` → `sponsor` (only when
   - Conditional: **Grant Permission** (when screen permission missing), **What's New** (pending `FeatureIntroManager` campaign).
   - Check for Updates, Preferences `⌘,`, Quit `⌘Q`.
   - Configured shortcut key equivalents are attached to menu items via `applyConfiguredShortcut(_:for:using:)`; overlay shortcuts (Application Capture/Recording) render as child-key suffixes (see [SHORTCUTS.md](SHORTCUTS.md)).
+- Menu customization (`MenuBarCustomizationStore`, Preferences → Menu Bar): capture/recording/tools items can be hidden and reordered within their group (`menuBar.itemOrder`, `menuBar.hiddenItems`); `buildMenu()` filters via `orderedVisibleItems(for:)`, renders separators only between non-empty groups, and keeps Check for Updates/Preferences/Quit pinned (Check for Updates is hideable). Hidden actions still work via shortcuts and the URL scheme.
+- Icon customization (`MenuBarIconRenderer` + `MenuBarIconStyle`, `menuBar.iconStyle`): bundled default (occupancy-normalized), SF Symbol alternates, or custom PNG from `Application Support/Snapzy/MenuBarIcon/custom.png` (alpha-bounds normalized, template-rendered monochrome). The cached idle image invalidates on style or custom-file change.
 - Recording state rendering: while recording, the title shows a monospaced-digit timer (`recorder.formattedDuration`); when paused it is prefixed with `|| `; tooltip mirrors state. `setProcessing(_:)` swaps the icon for an `NSProgressIndicator` spinner (used e.g. during OCR) on Core Animation so it keeps animating.
 - Visibility: `showMenuBarIcon` pref toggles the status item (`syncStatusItemVisibility`).
 - Preferences activation-policy dance (`presentPreferencesWindow`): elevates `.accessory` → `.regular` so Snapzy appears in the app menu/Cmd+Tab, triggers the Settings scene (synthesized `⌘,` key equivalent on macOS 14+, `showSettingsWindow:` before), tracks the window (12 retry passes), and reverts to `.accessory` in `windowDidClose` when no other normal windows remain. While recording, the tracked Preferences window is added to the recorder's runtime exclusion list so Snapzy's own window isn't captured.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -46,6 +46,7 @@ step and grant access later from Settings -> Advanced.
 The TOML file covers portable app preferences:
 
 - General settings: language, appearance, sounds, URL scheme integration, show menu bar icon, login item, export folder path.
+- Menu bar customization: icon style, item order, hidden items (`[menu_bar]`). The custom icon PNG file itself is not portable — `icon_style = "custom"` falls back to `default` on a Mac without a locally imported custom icon.
 - Updates: automatic check/download and the Sparkle update channel (`stable` or `beta`).
 - Capture settings: naming templates, screenshot format, cursor/app inclusion, freeze area, show selection area overlay, reverse magnifier zoom direction, scrolling hints, OCR notification, object cutout auto-crop.
 - After-capture actions for screenshot and recording: `save`, `quick_access`, `copy_file`, and `open_annotate` under `[capture.after.screenshot]` / `[capture.after.recording]`. Cloud upload is not part of this matrix — it is manual-only from Quick Access, Annotate, Video Editor, and History surfaces.
@@ -112,6 +113,11 @@ export_location = "~/Desktop"
 check_automatically = true
 download_automatically = false
 channel = "stable" # "stable" | "beta" — invalid values are rejected on import
+
+[menu_bar]
+icon_style = "default" # "default" | "cameraViewfinder" | "cameraFill" | "scissors" | "photoOnRectangle" | "custom"
+item_order = ["captureArea", "captureAreaAnnotate", "captureApplication", "captureFullscreen", "captureActiveWindow", "scrollingCapture", "captureOCR", "captureSmartElement", "captureObjectCutout", "recordScreen", "recordApplication", "openAnnotate", "combineImages", "editVideo", "cloudUploads", "openHistory", "shortcutList"]
+hidden_items = []
 
 [capture]
 hide_desktop_icons = false

--- a/docs/PREFERENCES.md
+++ b/docs/PREFERENCES.md
@@ -24,6 +24,13 @@ Reference for the Settings window: tab structure, every section, and how prefere
 - **Updates**: Check Automatically / Download Automatically (bound to `SPUUpdater`), Last Checked — see [UPDATES.md](UPDATES.md).
 - **Help**: Restart Onboarding (`OnboardingFlowView.resetOnboarding()` + `.showOnboarding`), Report Issue (opens bug-report page; full bundle flow in [UPDATES.md](UPDATES.md)).
 
+### Menu Bar (`PreferencesMenuBarSettingsView.swift`)
+
+- **Menu Bar Icon**: label-less tile picker for the status item icon — bundled default, built-in SF Symbol alternates (`camera.viewfinder`, `camera.fill`, `scissors`, `photo.on.rectangle`), or a custom PNG. The custom slot is a dashed "+" add tile: click opens an `NSOpenPanel`, or drop a PNG onto it; the file is validated, copied to `Application Support/Snapzy/MenuBarIcon/custom.png`, alpha-bounds normalized, and rendered as a monochrome template. Replace/Remove controls appear while custom is selected. Backed by `MenuBarIconStyle` + `MenuBarIconRenderer` (`menuBar.iconStyle`).
+- **Capture / Recording / Tools**: per-item visibility toggles and drag-to-reorder within each section, backed by `MenuBarCustomizationStore` (`menuBar.itemOrder`, `menuBar.hiddenItems`). Hidden features remain available via keyboard shortcuts and the `snapzy://` URL scheme; group order and separators are fixed (separators render only between non-empty groups).
+- **App**: Check for Updates visibility toggle (fixed position; Preferences and Quit are pinned and not customizable).
+- **Reset to Defaults** restores order, visibility, and the bundled icon.
+
 ### Capture (`PreferencesCaptureSettingsView.swift`)
 
 Segmented into three panes (`CaptureSettingsPane`): General / Screenshot / Recording.


### PR DESCRIPTION
## Summary

Implements the personalization requests from #396: a new **Menu Bar** settings tab where users can tailor the status bar menu to their workflow — hide commands they rarely use, reorder items within sections, and pick a menu bar icon that fits their setup (bundled default, built-in alternates, or a custom PNG).

Hiding only affects menu visibility: every feature remains fully available through keyboard shortcuts and the `snapzy://` URL scheme. Nothing is removed or changed by default.

Closes #396

## What's new

**Customize menu items**
- Per-item visibility toggles for all Capture, Recording, and Tools entries, plus Check for Updates
- Drag handles to reorder items within their section (Capture / Recording / Tools); section order is fixed and separators render only between non-empty groups
- Pinned by design: recording status actions, permission prompt, What's New, Preferences, and Quit — so users can never lock themselves out of Settings
- Reset to Defaults restores the stock menu

**Customize menu bar icon**
- Bundled default icon or four built-in SF Symbol alternates (`camera.viewfinder`, `camera.fill`, `scissors`, `photo.on.rectangle`)
- Custom monochrome PNG: click the dashed **+** tile or drag & drop a PNG onto it (18×18 recommended)
- Imported icons are validated, stored in `Application Support/Snapzy/MenuBarIcon/custom.png`, alpha-bounds normalized to match the default icon's menu bar occupancy, and template-rendered (monochrome automatically, adapts to light/dark menu bar)
- Replace / Remove controls while a custom icon is selected
- Icon changes apply live; the recording timer/stop states are unaffected

## Implementation

- `MenuBarItemKind` / `MenuBarItemGroup` — stable identifiers for customizable entries (raw values persisted; pinned entries are not representable)
- `MenuBarCustomizationStore` — UserDefaults-backed order/hidden/icon-style store with normalization (unknown ids dropped, new items appended), mirroring the Quick Access configuration store
- `MenuBarIconRenderer` — 18pt template rendering for all styles + custom icon storage/validation
- `AppStatusBarController` — `buildMenu()` now composes from the store via a per-item factory (titles, icons, actions, shortcut equivalents, and enabled states unchanged); idle icon cache invalidates on style or custom-file change
- Preferences: new `MenuBar` tab (label-less tile grid with accent ring + check badge; Quick-Actions-style reorder rows)
- TOML sync: new `[menu_bar]` section (`icon_style`, `item_order`, `hidden_items`); `custom` falls back to `default` on machines without an imported PNG
- Localization: 15 new keys × 10 locales (`preferences-menubar.*`, `preferences.tab.menu-bar`)
- Docs: `PREFERENCES.md`, `APP_LIFECYCLE.md`, `CONFIGURATION.md`

## Testing

- [x] `xcodebuild -project Snapzy.xcodeproj -scheme Snapzy -configuration Debug build`
- [x] `xcodebuild test -project Snapzy.xcodeproj -scheme Snapzy -configuration Debug` — 13 new `MenuBarCustomizationStoreTests` (order normalization, hide/show persistence, within-group move incl. hidden-row index math, reset, TOML application, icon style fallback) + 2 new TOML import tests; full suite green
- [x] Localization CatalogTool verify: 1475 keys, 0 missing/extra across 10 locales
- [x] Manual smoke: hide/reorder items → menu reflects on next open; shortcuts still fire; icon styles + custom PNG swap live and persist across relaunch

## Notes for reviewers

- Default behavior is unchanged — no migration needed; all customization is opt-in.
- Non-English translations for the new keys are machine-assisted drafts; native review welcome.
