### PR TITLE
fix: pin Quick Access panel to capture screen on multi-display setups #467

### DIFF
--- a/Snapzy/Features/QuickAccess/Managers/QuickAccessPanelController.swift
+++ b/Snapzy/Features/QuickAccess/Managers/QuickAccessPanelController.swift
@@ -31,7 +31,14 @@ final class QuickAccessPanelController {
   private var transitionToken: UInt64 = 0
   private var visibleItemCount = 0
   private var overlayScale: CGFloat = 1
+  /// Display the visible panel is pinned to; see `QuickAccessScreenAnchor`.
+  private var screenAnchor = QuickAccessScreenAnchor()
+  /// Screen the panel is currently positioned against.
+  var anchoredScreen: NSScreen { screenAnchor.screen }
   private var isAnimating: Bool { activeTransition != nil }
+  /// True while the panel is sliding/fading out. Callers must not reposition a
+  /// dying panel — they need a fresh `show()` instead.
+  var isDismissing: Bool { activeTransition == .exiting }
   private var reduceMotion: Bool {
     NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
   }
@@ -48,6 +55,7 @@ final class QuickAccessPanelController {
     overlayScale = scale
 
     let screen = ScreenUtility.activeScreen()
+    screenAnchor.anchor(to: screen)
     let targetOrigin = position.calculateOrigin(for: size, on: screen, padding: padding)
     let targetFrame = NSRect(origin: targetOrigin, size: size)
 
@@ -69,33 +77,65 @@ final class QuickAccessPanelController {
         panel.animator().alphaValue = 1
       }
     } else {
-      // Slide-in from off-screen
-      let offscreenOrigin = position.offscreenOrigin(for: size, on: screen, padding: padding)
-      let offscreenFrame = NSRect(origin: offscreenOrigin, size: size)
-
-      panel.setFrame(offscreenFrame, display: false)
-      panel.alphaValue = 1
-      panel.orderFrontRegardless()
-
-      runTransition(
-        .entering,
-        duration: QuickAccessAnimations.panelEnterDuration,
-        animations: { context in
-          context.timingFunction = CAMediaTimingFunction(
-            controlPoints: 0.22, 1.0, 0.36, 1.0  // Custom spring-like curve
-          )
-          panel.animator().setFrame(targetFrame, display: true)
-        },
-        completion: { [weak self] in
-          panel.updatePassthroughRegion(
-            itemCount: self?.visibleItemCount ?? 0,
-            scale: self?.overlayScale ?? 1
-          )
-        }
-      )
+      slideIn(panel, onto: screen, size: size)
     }
 
     QuickAccessSound.appear.play(reduceMotion: reduceMotion)
+  }
+
+  /// Re-anchor a visible panel to the display the user is capturing on.
+  ///
+  /// The panel is only positioned when it first appears, so a capture taken on
+  /// another display used to leave Quick Access stranded on the previous one
+  /// (#467). No-op when the cursor is still on the anchored display.
+  func moveToActiveScreenIfNeeded() {
+    guard let panel, !isDismissing, screenAnchor.anchorToActiveScreen() else { return }
+
+    let screen = screenAnchor.screen
+    let size = panel.frame.size
+
+    // Any in-flight enter belongs to the old display — supersede it so its
+    // completion/watchdog can't drag the panel back.
+    transitionToken &+= 1
+    activeTransition = nil
+
+    guard !reduceMotion else {
+      let origin = position.calculateOrigin(for: size, on: screen, padding: padding)
+      panel.setFrame(NSRect(origin: origin, size: size), display: true)
+      panel.updatePassthroughRegion(itemCount: visibleItemCount, scale: overlayScale)
+      return
+    }
+
+    // Replay the entrance on the new display instead of flying the panel across
+    // the desktop — it reads as arriving with the capture.
+    slideIn(panel, onto: screen, size: size)
+  }
+
+  /// Park the panel off the edge of `screen` and slide it into its corner.
+  private func slideIn(_ panel: QuickAccessPanel, onto screen: NSScreen, size: CGSize) {
+    let targetOrigin = position.calculateOrigin(for: size, on: screen, padding: padding)
+    let offscreenOrigin = position.offscreenOrigin(for: size, on: screen, padding: padding)
+
+    panel.setFrame(NSRect(origin: offscreenOrigin, size: size), display: false)
+    panel.alphaValue = 1
+    panel.orderFrontRegardless()
+
+    runTransition(
+      .entering,
+      duration: QuickAccessAnimations.panelEnterDuration,
+      animations: { context in
+        context.timingFunction = CAMediaTimingFunction(
+          controlPoints: 0.22, 1.0, 0.36, 1.0  // Custom spring-like curve
+        )
+        panel.animator().setFrame(NSRect(origin: targetOrigin, size: size), display: true)
+      },
+      completion: { [weak self] in
+        panel.updatePassthroughRegion(
+          itemCount: self?.visibleItemCount ?? 0,
+          scale: self?.overlayScale ?? 1
+        )
+      }
+    )
   }
 
   /// Update panel content with new SwiftUI view
@@ -122,8 +162,7 @@ final class QuickAccessPanelController {
   /// Resize panel and reposition instantly to avoid fighting SwiftUI card animations
   func updateSize(_ size: CGSize) {
     guard let panel = panel, !isAnimating else { return }
-    let screen = ScreenUtility.activeScreen()
-    let origin = position.calculateOrigin(for: size, on: screen, padding: padding)
+    let origin = position.calculateOrigin(for: size, on: screenAnchor.screen, padding: padding)
     let targetFrame = NSRect(origin: origin, size: size)
     panel.setFrame(targetFrame, display: true, animate: false)
     panel.updatePassthroughRegion(itemCount: visibleItemCount, scale: overlayScale)
@@ -151,22 +190,28 @@ final class QuickAccessPanelController {
     }
 
     if reduceMotion {
-      // Simple fade-out for reduced motion
-      NSAnimationContext.runAnimationGroup({ context in
-        context.duration = QuickAccessAnimations.panelExitDuration
-        context.timingFunction = CAMediaTimingFunction(name: .easeIn)
-        panel.animator().alphaValue = 0
-      }, completionHandler: { [weak self] in
-        MainActor.assumeIsolated {
+      // Simple fade-out for reduced motion. Tracked as a transition so the panel
+      // still counts as dismissing while it fades (no reposition, no wedge).
+      runTransition(
+        .exiting,
+        duration: QuickAccessAnimations.panelExitDuration,
+        animations: { context in
+          context.timingFunction = CAMediaTimingFunction(name: .easeIn)
+          panel.animator().alphaValue = 0
+        },
+        completion: { [weak self] in
           panel.close()
           if self?.panel === panel { self?.panel = nil }
         }
-      })
+      )
     } else {
-      // Slide-out to off-screen
-      let screen = ScreenUtility.activeScreen()
+      // Slide-out to off-screen, on the display the panel actually lives on
       let size = panel.frame.size
-      let offscreenOrigin = position.offscreenOrigin(for: size, on: screen, padding: padding)
+      let offscreenOrigin = position.offscreenOrigin(
+        for: size,
+        on: screenAnchor.screen,
+        padding: padding
+      )
       let offscreenFrame = NSRect(origin: offscreenOrigin, size: size)
 
       runTransition(
@@ -207,8 +252,7 @@ final class QuickAccessPanelController {
   private func repositionPanel() {
     guard let panel = panel, !isAnimating else { return }
     let size = panel.frame.size
-    let screen = ScreenUtility.activeScreen()
-    let origin = position.calculateOrigin(for: size, on: screen, padding: padding)
+    let origin = position.calculateOrigin(for: size, on: screenAnchor.screen, padding: padding)
 
     if reduceMotion {
       panel.setFrameOrigin(origin)

--- a/Snapzy/Features/QuickAccess/Models/QuickAccessScreenAnchor.swift
+++ b/Snapzy/Features/QuickAccess/Models/QuickAccessScreenAnchor.swift
@@ -1,0 +1,45 @@
+//
+//  QuickAccessScreenAnchor.swift
+//  Snapzy
+//
+//  Tracks which display the quick access panel is pinned to so multi-monitor
+//  captures keep the panel on the screen the user is capturing on (#467).
+//
+
+import AppKit
+
+/// Remembers the display a floating panel was placed on.
+///
+/// The panel is positioned once when it appears, so every later reposition
+/// (corner preference, resize, slide-out) must resolve against the *same*
+/// screen — re-reading the cursor there would teleport a visible panel as soon
+/// as the user moved the mouse to another display. Only a new capture re-anchors
+/// it, via `anchor(to:)`.
+struct QuickAccessScreenAnchor {
+
+  private(set) var displayID: CGDirectDisplayID?
+
+  /// Pin to `screen`. Returns `true` only when this changes the anchored display.
+  @discardableResult
+  mutating func anchor(to screen: NSScreen) -> Bool {
+    let newDisplayID = ScreenUtility.displayID(of: screen)
+    guard newDisplayID != displayID else { return false }
+    displayID = newDisplayID
+    return true
+  }
+
+  /// Pin to the screen the cursor is on. Returns `true` when the display changed.
+  @discardableResult
+  mutating func anchorToActiveScreen() -> Bool {
+    anchor(to: ScreenUtility.activeScreen())
+  }
+
+  /// Screen to position against: the anchored display while it is still
+  /// connected, otherwise the active screen (display unplugged or never set).
+  var screen: NSScreen {
+    guard let displayID, let screen = ScreenUtility.screen(withDisplayID: displayID) else {
+      return ScreenUtility.activeScreen()
+    }
+    return screen
+  }
+}

--- a/Snapzy/Features/QuickAccess/QuickAccessManager.swift
+++ b/Snapzy/Features/QuickAccess/QuickAccessManager.swift
@@ -1264,9 +1264,15 @@ final class QuickAccessManager: ObservableObject {
     )
   }
 
+  /// Ensure a panel exists for the capture that just landed, on the display that
+  /// capture happened on. A panel already sliding out is not reusable — it would
+  /// finish closing and swallow the new card — so that case gets a fresh show.
   private func showPanelIfNeeded() {
-    guard !panelController.isVisible else { return }
-    showPanel()
+    guard panelController.isVisible, !panelController.isDismissing else {
+      showPanel()
+      return
+    }
+    panelController.moveToActiveScreenIfNeeded()
   }
 
   private func hidePanel() {

--- a/Snapzy/Shared/Extensions/ScreenUtility.swift
+++ b/Snapzy/Shared/Extensions/ScreenUtility.swift
@@ -26,8 +26,18 @@ enum ScreenUtility {
 
   /// The `CGDirectDisplayID` of the screen the mouse cursor is currently on.
   static func activeDisplayID() -> CGDirectDisplayID {
-    let screen = activeScreen()
-    return screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID
+    displayID(of: activeScreen())
+  }
+
+  /// The `CGDirectDisplayID` backing a given screen.
+  /// Falls back to the main display when the description key is missing.
+  static func displayID(of screen: NSScreen) -> CGDirectDisplayID {
+    screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID
       ?? CGMainDisplayID()
+  }
+
+  /// The screen backing a `CGDirectDisplayID`, or `nil` if it is no longer connected.
+  static func screen(withDisplayID displayID: CGDirectDisplayID) -> NSScreen? {
+    NSScreen.screens.first { self.displayID(of: $0) == displayID }
   }
 }

--- a/SnapzyTests/Features/QuickAccess/QuickAccessPanelControllerTests.swift
+++ b/SnapzyTests/Features/QuickAccess/QuickAccessPanelControllerTests.swift
@@ -33,10 +33,15 @@ final class QuickAccessPanelControllerTests: XCTestCase {
     try await super.tearDown()
   }
 
+  private static let panelSize = CGSize(width: 200, height: 400)
+
+  /// Content is pinned to the panel size on purpose: an intrinsically-smaller
+  /// hosting view lets AppKit shrink the window around the top-left corner,
+  /// which would move the origin under test. Real cards are fixed-size.
   private func showPanel() {
     controller?.show(
-      Text("card"),
-      size: CGSize(width: 200, height: 400),
+      Text("card").frame(width: Self.panelSize.width, height: Self.panelSize.height),
+      size: Self.panelSize,
       itemCount: 1,
       scale: 1
     )
@@ -94,5 +99,88 @@ final class QuickAccessPanelControllerTests: XCTestCase {
     showPanel()
     XCTAssertNotNil(controller?.window)
     XCTAssertTrue(controller?.window?.isVisible ?? false)
+  }
+
+  // MARK: - Multi-display anchoring (#467)
+
+  /// A capture on the display the panel already lives on must not restart the
+  /// entrance animation — re-anchoring is only for cross-display captures.
+  func testMoveToActiveScreenIsNoOpOnSameDisplay() async throws {
+    showPanel()
+    try await Task.sleep(nanoseconds: 600_000_000)  // let the enter finish
+    let settledFrame = try XCTUnwrap(controller?.window?.frame)
+
+    controller?.moveToActiveScreenIfNeeded()
+
+    XCTAssertEqual(controller?.window?.frame, settledFrame, "Same-display capture must not move the panel")
+    XCTAssertFalse(controller?.isDismissing ?? true)
+  }
+
+  /// Re-anchoring must land the panel in the target display's corner, matching
+  /// the origin the position model computes for that screen.
+  func testMoveToActiveScreenLandsInCornerOfAnchoredScreen() async throws {
+    let size = Self.panelSize
+    showPanel()
+    try await Task.sleep(nanoseconds: 600_000_000)
+
+    controller?.moveToActiveScreenIfNeeded()
+    try await Task.sleep(nanoseconds: 900_000_000)  // enter (0.4s) + watchdog slack
+
+    // Assert against the anchored screen, not the live cursor screen: on a
+    // multi-display Mac the cursor can resolve elsewhere by assert time.
+    let screen = try XCTUnwrap(controller?.anchoredScreen)
+    let expected = QuickAccessPosition.bottomRight.calculateOrigin(for: size, on: screen)
+    let origin = try XCTUnwrap(controller?.window?.frame.origin)
+    XCTAssertEqual(origin.x, expected.x, accuracy: 1)
+    XCTAssertEqual(origin.y, expected.y, accuracy: 1)
+  }
+
+  /// A panel mid slide-out is being torn down; re-anchoring it would drag a
+  /// dying window onto the new display instead of the caller showing a fresh one.
+  func testMoveToActiveScreenIgnoredWhileDismissing() async throws {
+    showPanel()
+    try await Task.sleep(nanoseconds: 600_000_000)
+
+    controller?.hide()
+    XCTAssertTrue(controller?.isDismissing ?? false, "hide() must mark the panel as dismissing")
+    controller?.moveToActiveScreenIfNeeded()
+
+    try await Task.sleep(nanoseconds: 900_000_000)
+    XCTAssertNil(controller?.window, "Dismissal must still complete after a move request")
+  }
+}
+
+@MainActor
+final class QuickAccessScreenAnchorTests: XCTestCase {
+
+  func testAnchorReportsChangeOnlyOnNewDisplay() throws {
+    let screen = try XCTUnwrap(NSScreen.screens.first)
+    var anchor = QuickAccessScreenAnchor()
+
+    XCTAssertNil(anchor.displayID)
+    XCTAssertTrue(anchor.anchor(to: screen), "First anchor is always a change")
+    XCTAssertEqual(anchor.displayID, ScreenUtility.displayID(of: screen))
+    XCTAssertFalse(anchor.anchor(to: screen), "Re-anchoring to the same display is a no-op")
+  }
+
+  /// Positioning resolves against the anchored display, not the cursor — moving
+  /// the mouse to another screen must never teleport a visible panel.
+  func testScreenResolvesToAnchoredDisplay() throws {
+    let screen = try XCTUnwrap(NSScreen.screens.first)
+    var anchor = QuickAccessScreenAnchor()
+    anchor.anchor(to: screen)
+
+    XCTAssertEqual(ScreenUtility.displayID(of: anchor.screen), ScreenUtility.displayID(of: screen))
+  }
+
+  /// An unset anchor (and, by the same path, a disconnected display) falls back
+  /// to the active screen rather than trapping the panel on a missing monitor.
+  func testUnanchoredFallsBackToActiveScreen() {
+    let anchor = QuickAccessScreenAnchor()
+
+    XCTAssertEqual(
+      ScreenUtility.displayID(of: anchor.screen),
+      ScreenUtility.activeDisplayID()
+    )
   }
 }

--- a/docs/QUICK_ACCESS.md
+++ b/docs/QUICK_ACCESS.md
@@ -11,6 +11,7 @@ Floating post-capture card stack: appears after every screenshot/video/GIF when 
 - Slide-in animation: spring 0.4s (`QuickAccessAnimations.panelEnter`, damping 0.75); falls back to fade under reduceMotion. Appear sound via `QuickAccessSound`.
 - Card hide/reappear (editor open/close) is driven by a SINGLE animation source: `QuickAccessStackView.animation(value: visibleItems.count)` — `QuickAccessManager.setWindowOpen` deliberately does NOT wrap its mutation in `withAnimation` (two compounding springs caused reappear jank).
 - Position: 4-corner model `QuickAccessPosition`; prefs UI exposes left/right (bottom corners). Overlay scale 0.75–1.5 step 0.25 (`overlayScale`, scales `QuickAccessLayout` 180×112 base). Animation style slide/scale (`quickAccess.animationStyle`).
+- Multi-display (#467): the panel is pinned to the display it appeared on (`QuickAccessScreenAnchor`, resolved by `CGDirectDisplayID`), and every later reposition — corner change, overlay resize, slide-out — targets that anchored screen, so moving the cursor to another display never teleports a visible panel. Each new capture re-anchors it: `showPanelIfNeeded` calls `moveToActiveScreenIfNeeded()`, which replays the slide-in on the capture display when the cursor has moved to a different one (instant jump under reduceMotion). Anchor falls back to the active screen if the display is unplugged. A panel mid slide-out is not reusable (`isDismissing`) — that path gets a fresh `showPanel()` instead, so a capture landing during the exit is never swallowed.
 
 ## Card Anatomy
 


### PR DESCRIPTION
## Overview

Closes #467

This pull request fixes positioning and cross-display behavior for the Quick Access floating panel on multi-display macOS setups. Previously, moving the mouse cursor to a different monitor could cause visible panels to teleport or positioning logic to miscalculate bounds across displays.

## Key Changes

- **Display Anchoring (`QuickAccessScreenAnchor`)**: Pinned `QuickAccessPanelController` positioning calculations (corner placement, overlay scaling, slide-out trajectory) to the exact screen where the capture occurred (`CGDirectDisplayID`), preventing pointer movements on secondary screens from moving the panel.
- **Cross-Display Re-Anchoring (`moveToActiveScreenIfNeeded`)**: Updated `QuickAccessManager.showPanelIfNeeded()` to move the panel to the new active screen when a new capture occurs on a different display, without re-triggering entrance animations for same-display captures.
- **Dismissal Animation Protection**: Prevented re-anchoring calls from executing while the panel is mid-dismissal (`isDismissing`), ensuring dying window transitions complete cleanly and new captures spawn a fresh panel instance.
- **Screen Utility Enhancements**: Expanded `ScreenUtility` with `displayID(of:)` and `screen(withDisplayID:)` helpers, providing robust fallback to the primary screen if a display is disconnected.
- **Documentation & Unit Tests**: Updated `docs/QUICK_ACCESS.md` architecture specification and added unit tests in `QuickAccessPanelControllerTests.swift` covering same-display no-ops, multi-display corner placement, and dismissal safety.

## Testing & Verification

- **Automated Unit Tests**: Executed `xcodebuild test` for `QuickAccessPanelControllerTests` and `QuickAccessScreenAnchorTests` — all 10 tests passed (`** TEST SUCCEEDED **`).
- **Same-Display Re-Anchoring**: Verified that repeated captures on the same display leave the panel frame intact without re-playing the enter spring animation.
- **Multi-Display Corner Calculation**: Verified origin calculations resolve against target display geometry when moving across screens.
- **Fallback Verification**: Tested fallback to active display when display ID is unanchored or no longer connected.