### PR TITLE
fix(config): correct TOML string unescape so backslash+n/t round-trips on import

### DIFF
--- a/Snapzy/Services/Configuration/SimpleTOMLParser.swift
+++ b/Snapzy/Services/Configuration/SimpleTOMLParser.swift
@@ -171,11 +171,41 @@ enum SimpleTOMLParser {
     return result
   }
 
+  /// Decodes TOML escape sequences in a single left-to-right pass.
+  ///
+  /// Each `\` is consumed together with the character that follows it, so a
+  /// pass can never re-process output produced by an earlier pass. This is the
+  /// exact inverse of `SimpleTOMLWriter.quote`, which makes export/import
+  /// lossless — a value containing a backslash followed by `n`/`t` (e.g.
+  /// `a\nb`) survives the round-trip instead of being turned into a real
+  /// newline/tab. Unknown escapes (`\x`) and a trailing backslash are kept
+  /// literal.
   private static func unescape(_ value: String) -> String {
-    value
-      .replacingOccurrences(of: "\\\"", with: "\"")
-      .replacingOccurrences(of: "\\\\", with: "\\")
-      .replacingOccurrences(of: "\\n", with: "\n")
-      .replacingOccurrences(of: "\\t", with: "\t")
+    var result = ""
+    result.reserveCapacity(value.count)
+    var index = value.startIndex
+    while index < value.endIndex {
+      if value[index] == "\\" {
+        let next = value.index(after: index)
+        guard next < value.endIndex else {
+          result.append("\\")
+          break
+        }
+        switch value[next] {
+        case "\"": result.append("\"")
+        case "\\": result.append("\\")
+        case "n": result.append("\n")
+        case "t": result.append("\t")
+        default:
+          result.append("\\")
+          result.append(value[next])
+        }
+        index = value.index(after: next)
+      } else {
+        result.append(value[index])
+        index = value.index(after: index)
+      }
+    }
+    return result
   }
 }

--- a/SnapzyTests/Services/Configuration/SimpleTOMLParserTests.swift
+++ b/SnapzyTests/Services/Configuration/SimpleTOMLParserTests.swift
@@ -54,4 +54,49 @@ final class SimpleTOMLParserTests: XCTestCase {
       XCTAssertEqual(error as? SimpleTOMLError, .invalidValue(1, "nope"))
     }
   }
+
+  func testUnescapePreservesBackslashFollowedByN() throws {
+    // In TOML, `\\` is an escaped backslash, so the quoted literal "a\\nb"
+    // decodes to the 4-char value a, \, n, b — NOT "a" + newline + "b".
+    let document = try SimpleTOMLParser.parse(#"key = "a\\nb""#)
+
+    XCTAssertEqual(document.value(at: "key")?.stringValue, "a\\nb")
+    XCTAssertEqual(document.value(at: "key")?.stringValue?.count, 4)
+  }
+
+  func testUnescapePreservesBackslashFollowedByT() throws {
+    // Mirror of the above for `\t`: the literal "a\\tb" decodes to a, \, t, b.
+    let document = try SimpleTOMLParser.parse(#"key = "a\\tb""#)
+
+    XCTAssertEqual(document.value(at: "key")?.stringValue, "a\\tb")
+    XCTAssertEqual(document.value(at: "key")?.stringValue?.count, 4)
+  }
+
+  func testRoundTripPreservesBackslashFollowedByNAndT() throws {
+    // A stored value that literally contains a backslash followed by n/t must
+    // survive a writer → parser round-trip. Real newline/tab are mixed in to
+    // prove the legitimate `\n` / `\t` escapes still round-trip too.
+    let original = "a\\nb\nc\td" // a, \, n, b, <newline>, c, <tab>, d
+    var writer = SimpleTOMLWriter()
+    writer.value("key", original)
+
+    let document = try SimpleTOMLParser.parse(writer.output)
+
+    XCTAssertEqual(document.value(at: "key")?.stringValue, original)
+    XCTAssertEqual(document.value(at: "key")?.stringValue?.count, original.count)
+  }
+
+  func testRoundTripPreservesEmbeddedDoubleQuote() throws {
+    // An embedded double quote is the one remaining escape `quote()` emits
+    // (`\"`); guard that the `\"` → `"` branch round-trips so it cannot be
+    // silently removed.
+    let original = "a\"b" // a, ", b
+    var writer = SimpleTOMLWriter()
+    writer.value("key", original)
+
+    let document = try SimpleTOMLParser.parse(writer.output)
+
+    XCTAssertEqual(document.value(at: "key")?.stringValue, original)
+    XCTAssertEqual(document.value(at: "key")?.stringValue?.count, 3)
+  }
 }


### PR DESCRIPTION
> **Title:** `fix(config): correct TOML string unescape so backslash+n/t round-trips on import`

### Problem

A stored config value that literally contains a backslash followed by `n` or `t`
(e.g. a path fragment, a regex, a key sequence) is corrupted when the config is
exported and re-imported. The exporter correctly doubles the backslash to `\\`,
but the importer's `unescape` runs its `\\`→`\` replacement *before* the `\n`/`\t`
replacements, so it manufactures a new `\n`/`\t` out of the just-collapsed
backslash and converts it into a real newline/tab. The 4-char value `a\nb`
round-trips into the 3-char `a<NL>b`.

### Solution

- Replaced the four sequential `replacingOccurrences` passes in
  `SimpleTOMLParser.unescape` with a single left-to-right scanner that consumes
  each `\` together with the following character (`\"`→`"`, `\\`→`\`,
  `\n`→newline, `\t`→tab; unknown `\x` and a trailing `\` kept literal).
- A single pass cannot re-process its own output, so no escape sequence is ever
  manufactured. The scanner is the exact inverse of `SimpleTOMLWriter.quote`,
  making the export→import round-trip lossless.
- `SimpleTOMLWriter.quote` is unchanged (the quoting side was already correct).

### Scope

- **Added** `SimpleTOMLParserTests`:
  `testUnescapePreservesBackslashFollowedByN`, `testUnescapePreservesBackslashFollowedByT`
  (the `\n` / `\t` mirrors), `testRoundTripPreservesBackslashFollowedByNAndT`
  (full `SimpleTOMLWriter` → `SimpleTOMLParser` round-trip mixing a literal
  backslash-n with real newline/tab), and `testRoundTripPreservesEmbeddedDoubleQuote`
  (guards the previously-untested `\"`→`"` branch).
- **Updated** `CHANGELOG.md` (Unreleased → Bug Fixes).
- **Not changed:** `SimpleTOMLWriter`, any other `SimpleTOMLParser` method, the
  int-overflow concern, localization strings (no catalog keys touched).

### Validation

- `swift -module-cache-path build/swift-module-cache tools/localization/CatalogTool.swift verify` → `Localization verify passed` (1521 keys, 10 locales, missing=0, extra=0).
- `xcodebuild test ... -only-testing:SnapzyTests/SimpleTOMLParserTests CODE_SIGNING_ALLOWED=NO` → `** TEST SUCCEEDED **`, 7 passed / 0 failed (Xcode 26.4.1, Debug).
- Confidence: `SimpleTOMLParserTests` + `SnapzyConfigurationServiceTests` + `SnapzyConfigurationImporterTests` → 53 passed / 0 failed.
- Red-before-green: the 3 new tests failed on the old implementation, pass after the fix.
- `git diff --check` clean (no whitespace errors).
- Release (`-O`) build intentionally skipped locally — only Xcode 26.4.1 available, which crashes `swift-frontend` above 26.2; CI (pinned 26.2) covers it.

### Notes

- No CLA / DCO / sign-off required for this repo (`projects/Snapzy.md`).
- Release-config (`-O`) build intentionally not run locally: only Xcode 26.4.1 is
  available and it crashes `swift-frontend` on this project above 26.2; the
  Debug test run and localization verify both pass on 26.4.1. CI (pinned to
  Xcode 26.2) covers the Release-config check
