### PR TITLE
fix(capture): pin DateFormatter to Gregorian locale for filename tokens

### DIFF
--- a/Snapzy/Services/Capture/CaptureOutputNaming.swift
+++ b/Snapzy/Services/Capture/CaptureOutputNaming.swift
@@ -212,11 +212,12 @@ enum CaptureOutputNaming {
 
   private static func format(_ date: Date, style: String) -> String {
     let formatter = DateFormatter()
-    // Force a Gregorian, POSIX-stable locale so date tokens always resolve to
-    // Gregorian values regardless of the user's system calendar. Without this,
-    // users on a Buddhist calendar (e.g. Thai `th_TH`) get the Buddhist year
-    // (e.g. 2569) instead of the Gregorian year (e.g. 2026) in filenames.
-    formatter.locale = Locale(identifier: "en_US_POSIX")
+    // Pin only the calendar so date tokens always resolve to Gregorian values
+    // regardless of the user's system calendar. Without this, users on a
+    // Buddhist calendar (e.g. Thai `th_TH`) get the Buddhist year (e.g. 2569)
+    // instead of the Gregorian year (e.g. 2026) in filenames. The locale is
+    // left alone so `{monthName}`/`{monthShort}` stay localized.
+    formatter.calendar = Calendar(identifier: .gregorian)
     formatter.dateFormat = style
     return formatter.string(from: date)
   }

--- a/Snapzy/Services/Capture/CaptureOutputNaming.swift
+++ b/Snapzy/Services/Capture/CaptureOutputNaming.swift
@@ -212,6 +212,11 @@ enum CaptureOutputNaming {
 
   private static func format(_ date: Date, style: String) -> String {
     let formatter = DateFormatter()
+    // Force a Gregorian, POSIX-stable locale so date tokens always resolve to
+    // Gregorian values regardless of the user's system calendar. Without this,
+    // users on a Buddhist calendar (e.g. Thai `th_TH`) get the Buddhist year
+    // (e.g. 2569) instead of the Gregorian year (e.g. 2026) in filenames.
+    formatter.locale = Locale(identifier: "en_US_POSIX")
     formatter.dateFormat = style
     return formatter.string(from: date)
   }

--- a/SnapzyTests/Services/Capture/CaptureOutputNamingTests.swift
+++ b/SnapzyTests/Services/Capture/CaptureOutputNamingTests.swift
@@ -500,8 +500,9 @@ final class CaptureOutputNamingTests: XCTestCase {
       defaults: defaults
     )
 
-    // Fallback format: "Snapzy_{yyyy-MM-dd_HH-mm-ss-SSS}"
-    XCTAssertTrue(result.hasPrefix("Snapzy_"), "Expected fallback name, got: \(result)")
+    // Fallback format: "Snapzy_{yyyy-MM-dd_HH-mm-ss-SSS}" — also pin the Gregorian
+    // year so the fallback path (which routes through `format`) is covered too.
+    XCTAssertTrue(result.hasPrefix("Snapzy_2026"), "Expected fallback name with Gregorian year 2026, got: \(result)")
   }
 
   // MARK: - App Name Tokens
@@ -548,5 +549,87 @@ final class CaptureOutputNamingTests: XCTestCase {
     // When appName is missing, it should resolve to empty string
     // Resulting in App_
     XCTAssertEqual(result, "App_")
+  }
+
+  // MARK: - Locale / Gregorian Calendar
+
+  /// Regression test for the system-calendar locale bug: a `DateFormatter` that
+  /// adopts the user's locale renders the Buddhist year under a Thai (`th_TH`)
+  /// locale (e.g. 2569 for the Gregorian year 2026). Snapzy must always emit the
+  /// Gregorian year in filenames regardless of the user's system calendar.
+  ///
+  /// Note: the process locale cannot be swapped at runtime (`Locale.current` is
+  /// cached for the XCTest host process), so this test cannot deterministically
+  /// fail pre-fix on a Gregorian CI runner. Instead it (1) proves the Buddhist
+  /// calendar actually shifts the year for the reference date, and (2) pins the
+  /// Gregorian contract for Snapzy's output. It WILL fail on a Buddhist-locale
+  /// machine if the `en_US_POSIX` locale on the internal formatter is reverted.
+  func testYearToken_alwaysGregorian_notBuddhistCalendarYear() {
+    var gregorian = Calendar(identifier: .gregorian)
+    gregorian.timeZone = TimeZone(secondsFromGMT: 0)!
+    let date = gregorian.date(from: DateComponents(year: 2026, month: 1, day: 15))!
+
+    // Premise guard (not a regression guard): under a Thai (Buddhist) locale the
+    // bare `yyyy` year differs from the Gregorian year for this date. This only
+    // protects the test's assumption against future Foundation locale-data drift;
+    // it cannot detect a fix regression on its own (see the note above).
+    let buddhist = DateFormatter()
+    buddhist.locale = Locale(identifier: "th_TH")
+    buddhist.dateFormat = "yyyy"
+    let buddhistYear = buddhist.string(from: date)
+    let gregorianYear = String(gregorian.component(.year, from: date))
+    XCTAssertNotEqual(
+      buddhistYear, gregorianYear,
+      "Precondition: th_TH must render a Buddhist year (\(buddhistYear)) that differs " +
+      "from the Gregorian year (\(gregorianYear)) for this date."
+    )
+
+    defaults.set("{year}", forKey: PreferencesKeys.screenshotFileNameTemplate)
+
+    let result = CaptureOutputNaming.resolveBaseName(
+      customName: nil,
+      kind: .screenshot,
+      date: date,
+      defaults: defaults
+    )
+
+    XCTAssertEqual(
+      result, "2026",
+      "Filename year must be Gregorian (2026), not the Buddhist year (\(buddhistYear))."
+    )
+  }
+
+  /// End-to-end guard over the default screenshot template: the generated name
+  /// must start with the Gregorian year, never a Buddhist-calendar year, even on
+  /// systems whose calendar is non-Gregorian.
+  ///
+  /// Same runtime-locale caveat as `testYearToken_alwaysGregorian_notBuddhistCalendarYear`:
+  /// this cannot deterministically fail pre-fix on a Gregorian CI runner (the
+  /// process locale is cached), but it pins the Gregorian contract and will fail
+  /// on a Buddhist-locale machine if the `en_US_POSIX` locale is reverted.
+  func testDefaultTemplate_startsGregorianYear_notBuddhistYear() {
+    var gregorian = Calendar(identifier: .gregorian)
+    gregorian.timeZone = TimeZone(secondsFromGMT: 0)!
+    let date = gregorian.date(from: DateComponents(year: 2026, month: 1, day: 15))!
+
+    // Reference: Buddhist year for this date.
+    let buddhist = DateFormatter()
+    buddhist.locale = Locale(identifier: "th_TH")
+    buddhist.dateFormat = "yyyy"
+    let buddhistYear = buddhist.string(from: date)
+
+    // Default template: "Snapzy_{datetime}_{ms}"
+    let result = CaptureOutputNaming.resolveBaseName(
+      customName: nil,
+      kind: .screenshot,
+      date: date,
+      defaults: defaults
+    )
+
+    XCTAssertTrue(result.hasPrefix("Snapzy_2026-"), "Default name must start with Gregorian year, got: \(result)")
+    XCTAssertFalse(
+      result.hasPrefix("Snapzy_\(buddhistYear)-"),
+      "Default name must not use the Buddhist year \(buddhistYear), got: \(result)"
+    )
   }
 }

--- a/SnapzyTests/Services/Capture/CaptureOutputNamingTests.swift
+++ b/SnapzyTests/Services/Capture/CaptureOutputNamingTests.swift
@@ -258,8 +258,12 @@ final class CaptureOutputNamingTests: XCTestCase {
     XCTAssertEqual(result, "Shots/\(Int(fixedDate.timeIntervalSince1970))/Snapzy_123")
   }
 
+  /// Mirror of the production formatter in `CaptureOutputNaming`: Gregorian
+  /// calendar so the year is Gregorian, locale left to the system so expected
+  /// month names track what production emits on the machine running the tests.
   private static func format(_ date: Date, style: String) -> String {
     let formatter = DateFormatter()
+    formatter.calendar = Calendar(identifier: .gregorian)
     formatter.dateFormat = style
     return formatter.string(from: date)
   }
@@ -563,7 +567,8 @@ final class CaptureOutputNamingTests: XCTestCase {
   /// fail pre-fix on a Gregorian CI runner. Instead it (1) proves the Buddhist
   /// calendar actually shifts the year for the reference date, and (2) pins the
   /// Gregorian contract for Snapzy's output. It WILL fail on a Buddhist-locale
-  /// machine if the `en_US_POSIX` locale on the internal formatter is reverted.
+  /// machine if the Gregorian calendar override on the internal formatter is
+  /// reverted.
   func testYearToken_alwaysGregorian_notBuddhistCalendarYear() {
     var gregorian = Calendar(identifier: .gregorian)
     gregorian.timeZone = TimeZone(secondsFromGMT: 0)!
@@ -606,7 +611,7 @@ final class CaptureOutputNamingTests: XCTestCase {
   /// Same runtime-locale caveat as `testYearToken_alwaysGregorian_notBuddhistCalendarYear`:
   /// this cannot deterministically fail pre-fix on a Gregorian CI runner (the
   /// process locale is cached), but it pins the Gregorian contract and will fail
-  /// on a Buddhist-locale machine if the `en_US_POSIX` locale is reverted.
+  /// on a Buddhist-locale machine if the Gregorian calendar override is reverted.
   func testDefaultTemplate_startsGregorianYear_notBuddhistYear() {
     var gregorian = Calendar(identifier: .gregorian)
     gregorian.timeZone = TimeZone(secondsFromGMT: 0)!
@@ -630,6 +635,43 @@ final class CaptureOutputNamingTests: XCTestCase {
     XCTAssertFalse(
       result.hasPrefix("Snapzy_\(buddhistYear)-"),
       "Default name must not use the Buddhist year \(buddhistYear), got: \(result)"
+    )
+  }
+
+  /// Pins the narrower contract of the calendar-only fix: a Gregorian calendar
+  /// keeps the year Gregorian under non-Gregorian system calendars while the
+  /// locale stays untouched, so `{monthName}`/`{monthShort}` remain localized.
+  ///
+  /// The production formatter is private and adopts the process locale, which
+  /// XCTest cannot swap at runtime, so this test rebuilds the production
+  /// configuration (`DateFormatter` + `Calendar(identifier: .gregorian)`) with
+  /// an explicit `th_TH` locale — the harshest case, where the bare formatter
+  /// emits the Buddhist year — and asserts both halves of the contract.
+  func testGregorianCalendarOverride_keepsLocalizedMonthNames() {
+    var gregorian = Calendar(identifier: .gregorian)
+    gregorian.timeZone = TimeZone(secondsFromGMT: 0)!
+    let date = gregorian.date(from: DateComponents(year: 2026, month: 1, day: 15))!
+
+    // Premise: without the calendar override a th_TH formatter emits the
+    // Buddhist year, not the Gregorian one.
+    let bare = DateFormatter()
+    bare.locale = Locale(identifier: "th_TH")
+    bare.dateFormat = "yyyy"
+    let bareYear = bare.string(from: date)
+    XCTAssertNotEqual(
+      bareYear, "2026",
+      "Precondition: th_TH must render the Buddhist year (\(bareYear)), not the Gregorian year."
+    )
+
+    // Production configuration with an explicit th_TH locale: Gregorian year
+    // plus the localized (Thai) month name.
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "th_TH")
+    formatter.calendar = Calendar(identifier: .gregorian)
+    formatter.dateFormat = "yyyy MMMM"
+    XCTAssertEqual(
+      formatter.string(from: date), "2026 มกราคม",
+      "Gregorian calendar + th_TH locale must yield the Gregorian year with the localized month name."
     )
   }
 }


### PR DESCRIPTION
## Summary

Date tokens in capture filename templates (`{datetime}`, `{year}`, etc.) were resolved against the user's **system calendar** via a `DateFormatter` that did not pin its calendar. On a system using a Buddhist calendar (e.g. Thai `th_TH`), `yyyy` produced the **Buddhist year** (2569) instead of the Gregorian year (2026), so screenshots/recordings were named with the wrong year.

## Root cause

`CaptureOutputNaming.format(_:style:)` created a `DateFormatter` and set only `dateFormat`, leaving the calendar to whatever the current locale's calendar is. When that calendar is non-Gregorian (Buddhist, Hebrew, etc.), `DateFormatter` adopts it for token resolution.

## Fix

Pin the internal formatter's **calendar** to `Calendar(identifier: .gregorian)` — the narrower of the two options from the review. The year is always Gregorian (verified: `th_TH` + Gregorian calendar renders `2026 มกราคม` for `yyyy MMMM`), while `{monthName}` / `{monthShort}` keep following the system locale instead of being forced to English, so non-English users keep localized month names in their templates. File-format and template parsing are unchanged; only the date-token rendering path is affected.

## Tests

- `testYearToken_alwaysGregorian_notBuddhistCalendarYear` — `{year}` resolves to the Gregorian year (2026); includes a precondition guard proving `th_TH` would have rendered a different (Buddhist) year for the same date.
- `testDefaultTemplate_startsGregorianYear_notBuddhistYear` — the default template emits a Gregorian-year prefix, not a Buddhist-year prefix.
- `testGregorianCalendarOverride_keepsLocalizedMonthNames` — pins the calendar-override contract: a `th_TH` formatter with the Gregorian calendar yields the Gregorian year **with** the localized month name (`2026 มกราคม`).
- The month-name test helper now mirrors the production formatter (Gregorian calendar, locale left to the system) instead of using an unpinned `DateFormatter`, so its expectations match production output on any test-machine locale.

> Note: `Locale.current` is cached for the XCTest host process lifetime, so these tests cannot deterministically *fail pre-fix* on a Gregorian CI runner. They pin the Gregorian contract and will fail on a Buddhist-locale machine if the Gregorian calendar override is reverted.

## Verified

- `swift tools/localization/CatalogTool.swift verify` — unchanged (no string-table edits).
- `xcodebuild test -only-testing:CaptureOutputNamingTests` — 41 passed, 0 failed.
