### PR TITLE
fix(history): surface hours in capture/video duration labels

### DIFF
--- a/Snapzy/Features/QuickAccess/Models/QuickAccessItem.swift
+++ b/Snapzy/Features/QuickAccess/Models/QuickAccessItem.swift
@@ -104,13 +104,18 @@ struct QuickAccessItem: Identifiable, Equatable {
     itemType == .video
   }
 
-  /// Formatted duration string for display (e.g., "01:30s")
+  /// Formatted duration string for display (e.g., "01:30s", "1:01:01s")
   var formattedDuration: String? {
     guard let duration = duration, duration.isFinite, duration >= 0 else {
       return nil
     }
-    let mins = Int(duration) / 60
-    let secs = Int(duration) % 60
+    let totalSeconds = Int(duration)
+    let hours = totalSeconds / 3600
+    let mins = (totalSeconds % 3600) / 60
+    let secs = totalSeconds % 60
+    if hours > 0 {
+      return String(format: "%d:%02d:%02ds", hours, mins, secs)
+    }
     return String(format: "%02d:%02ds", mins, secs)
   }
 }

--- a/Snapzy/Services/History/CaptureHistoryRecord.swift
+++ b/Snapzy/Services/History/CaptureHistoryRecord.swift
@@ -50,13 +50,18 @@ struct CaptureHistoryRecord: Identifiable, Codable, Equatable, FetchableRecord, 
     HistoryFormatterCache.recordDate.string(from: capturedAt)
   }
 
-  /// Formatted duration string for display (e.g., "01:30s")
+  /// Formatted duration string for display (e.g., "01:30s", "1:01:01s")
   var formattedDuration: String? {
     guard let duration = duration, duration.isFinite, duration >= 0 else {
       return nil
     }
-    let mins = Int(duration) / 60
-    let secs = Int(duration) % 60
+    let totalSeconds = Int(duration)
+    let hours = totalSeconds / 3600
+    let mins = (totalSeconds % 3600) / 60
+    let secs = totalSeconds % 60
+    if hours > 0 {
+      return String(format: "%d:%02d:%02ds", hours, mins, secs)
+    }
     return String(format: "%02d:%02ds", mins, secs)
   }
 

--- a/SnapzyTests/Features/QuickAccess/QuickAccessCoreTests.swift
+++ b/SnapzyTests/Features/QuickAccess/QuickAccessCoreTests.swift
@@ -38,6 +38,13 @@ final class QuickAccessCoreTests: XCTestCase {
 
     XCTAssertTrue(video.isVideo)
     XCTAssertEqual(video.formattedDuration, "01:30s")
+    // Durations >= 1 hour surface the hours field instead of overflowing minutes.
+    let hourLongVideo = QuickAccessItem(
+      url: URL(fileURLWithPath: "/tmp/long.mov"),
+      thumbnail: thumbnail,
+      duration: 3661
+    )
+    XCTAssertEqual(hourLongVideo.formattedDuration, "1:01:01s")
     XCTAssertNil(invalidVideo.formattedDuration)
     XCTAssertFalse(screenshot.isVideo)
     XCTAssertNil(screenshot.formattedDuration)

--- a/SnapzyTests/Services/History/CaptureHistoryRecordTests.swift
+++ b/SnapzyTests/Services/History/CaptureHistoryRecordTests.swift
@@ -16,6 +16,13 @@ final class CaptureHistoryRecordTests: XCTestCase {
     XCTAssertEqual(makeRecord(duration: 0).formattedDuration, "00:00s")
   }
 
+  func testFormattedDuration_surfacesHoursInsteadOfOverflowingMinutes() {
+    XCTAssertEqual(makeRecord(duration: 3661).formattedDuration, "1:01:01s")
+    XCTAssertEqual(makeRecord(duration: 3600).formattedDuration, "1:00:00s")
+    // Sub-hour durations are byte-identical to the legacy minute-only format.
+    XCTAssertEqual(makeRecord(duration: 3599.9).formattedDuration, "59:59s")
+  }
+
   func testFormattedDuration_omitsInvalidDurations() {
     XCTAssertNil(makeRecord(duration: nil).formattedDuration)
     XCTAssertNil(makeRecord(duration: -1).formattedDuration)


### PR DESCRIPTION
## Problem

Duration labels used a minute-only format that overflowed past 59 for any capture/recording at or above one hour: a 1 h 1 m 1 s clip rendered as `61:01s` instead of `1:01:01s`. Two unrelated display helpers diverged from `VideoEditorState.formatTime`, which already formats hours correctly.

## Solution

- `CaptureHistoryRecord.formattedDuration` and `QuickAccessItem.formattedDuration` now divide out hours and switch to `%d:%02d:%02ds` when `hours > 0`, mirroring `VideoEditorState.formatTime`.
- Sub-hour output is byte-identical to the previous `%02d:%02ds` format, so no existing label changes.

## Scope

- Tests: `CaptureHistoryRecordTests/testFormattedDuration_surfacesHoursInsteadOfOverflowingMinutes` (3661s -> `1:01:01s`, 3600s -> `1:00:00s`, 3599.9s -> `59:59s`) and a `QuickAccessCoreTests` assertion (3661s -> `1:01:01s`).
- NOT changed: `VideoEditorState.formatTime`, persistence/session formats, capture/recording logic, any UI layout.

## Validation

- Catalog localization verify: OK (no new user-facing strings).
- `xcodebuild test ... CODE_SIGNING_ALLOWED=NO`: the project builds and the test target compiles. (A local headless test run hit Snapzy's known GUI-runner launch hang unrelated to this change — the affected `CaptureHistoryRecordTests`/`QuickAccessCoreTests` are pure formatting assertions; CI runs the full suite on a `macos-15` GUI runner.) Xcode 26.4.1 locally; Release-config build deferred to CI (26.2-pinned).
- `git diff --check` clean.
