### PR TITLE
fix: keep space-to-move selection locked to the pointer

### DIFF
--- a/Snapzy/Services/Capture/AreaSelectionMoveLogic.swift
+++ b/Snapzy/Services/Capture/AreaSelectionMoveLogic.swift
@@ -2,28 +2,19 @@
 //  AreaSelectionMoveLogic.swift
 //  Snapzy
 //
-//  Pure geometry for space-to-move, extracted so it can be tested without a live overlay session.
-//
 
 import CoreGraphics
 
 /// Anchors captured at the instant a space-to-move begins.
 struct AreaSelectionMoveAnchors: Equatable {
-  /// The selection's start point when the move began.
   var originStart: CGPoint
-  /// The point the translation is measured from — the selection's current point when the move
-  /// began, not a fresh pointer read. Anchoring here makes both seams zero: the selection neither
-  /// resizes when Space goes down nor snaps when it comes back up.
+  /// The selection's current point when the move began, not a fresh pointer read.
   var anchor: CGPoint
 }
 
 enum AreaSelectionMoveLogic {
-  /// Translate the selection to follow `pointer`, preserving its size.
-  ///
-  /// Computed absolutely rather than accumulated per event. Four sources feed the selection — the
-  /// local and global drag monitors, the overlay's drag delegate and the live-passthrough tap —
-  /// and they sample the pointer at different instants. Absolute means a stale, duplicate or
-  /// out-of-order sample lands on the same rect instead of accumulating into its position.
+  /// Translate the selection to follow `pointer`, preserving its size. Computed absolutely so a
+  /// stale or duplicate sample from another event source cannot accumulate into the position.
   static func movedSelection(
     pointer: CGPoint,
     anchors: AreaSelectionMoveAnchors

--- a/Snapzy/Services/Capture/AreaSelectionMoveLogic.swift
+++ b/Snapzy/Services/Capture/AreaSelectionMoveLogic.swift
@@ -1,0 +1,38 @@
+//
+//  AreaSelectionMoveLogic.swift
+//  Snapzy
+//
+//  Pure geometry for space-to-move, extracted so it can be tested without a live overlay session.
+//
+
+import CoreGraphics
+
+/// Anchors captured at the instant a space-to-move begins.
+struct AreaSelectionMoveAnchors: Equatable {
+  /// The selection's start point when the move began.
+  var originStart: CGPoint
+  /// The point the translation is measured from — the selection's current point when the move
+  /// began, not a fresh pointer read. Anchoring here makes both seams zero: the selection neither
+  /// resizes when Space goes down nor snaps when it comes back up.
+  var anchor: CGPoint
+}
+
+enum AreaSelectionMoveLogic {
+  /// Translate the selection to follow `pointer`, preserving its size.
+  ///
+  /// Computed absolutely rather than accumulated per event. Four sources feed the selection — the
+  /// local and global drag monitors, the overlay's drag delegate and the live-passthrough tap —
+  /// and they sample the pointer at different instants. Absolute means a stale, duplicate or
+  /// out-of-order sample lands on the same rect instead of accumulating into its position.
+  static func movedSelection(
+    pointer: CGPoint,
+    anchors: AreaSelectionMoveAnchors
+  ) -> (start: CGPoint, current: CGPoint) {
+    let dx = pointer.x - anchors.anchor.x
+    let dy = pointer.y - anchors.anchor.y
+    return (
+      start: CGPoint(x: anchors.originStart.x + dx, y: anchors.originStart.y + dy),
+      current: CGPoint(x: anchors.anchor.x + dx, y: anchors.anchor.y + dy)
+    )
+  }
+}

--- a/Snapzy/Services/Capture/AreaSelectionRenderGate.swift
+++ b/Snapzy/Services/Capture/AreaSelectionRenderGate.swift
@@ -1,0 +1,27 @@
+//
+//  AreaSelectionRenderGate.swift
+//  Snapzy
+//
+//  Decides whether a pooled area-selection overlay has to render on a given pointer event.
+//  Extracted so the skip decision can be tested without a multi-display rig.
+//
+
+import CoreGraphics
+
+/// Whether a pooled overlay has to run a manual-selection render pass this pointer event.
+///
+/// `renderManualSelectionIfNeeded()` fans every pointer event out to all pooled windows, so the
+/// per-event cost scales with display count: a skipped view still pays a coordinate conversion and
+/// a `CATransaction` round-trip only to re-hide layers that are already hidden.
+///
+/// `hasContentOnScreen` reports what the previous pass left drawn, which is what makes skipping
+/// safe — the pass that clears a display always runs, and only the ones after it are skipped.
+enum AreaSelectionRenderGate {
+  static func shouldRender(
+    hasContentOnScreen: Bool,
+    pointerIsOverView: Bool,
+    selectionIntersectsView: Bool
+  ) -> Bool {
+    hasContentOnScreen || pointerIsOverView || selectionIntersectsView
+  }
+}

--- a/Snapzy/Services/Capture/AreaSelectionRenderGate.swift
+++ b/Snapzy/Services/Capture/AreaSelectionRenderGate.swift
@@ -2,20 +2,13 @@
 //  AreaSelectionRenderGate.swift
 //  Snapzy
 //
-//  Decides whether a pooled area-selection overlay has to render on a given pointer event.
-//  Extracted so the skip decision can be tested without a multi-display rig.
-//
 
 import CoreGraphics
 
 /// Whether a pooled overlay has to run a manual-selection render pass this pointer event.
 ///
-/// `renderManualSelectionIfNeeded()` fans every pointer event out to all pooled windows, so the
-/// per-event cost scales with display count: a skipped view still pays a coordinate conversion and
-/// a `CATransaction` round-trip only to re-hide layers that are already hidden.
-///
-/// `hasContentOnScreen` reports what the previous pass left drawn, which is what makes skipping
-/// safe — the pass that clears a display always runs, and only the ones after it are skipped.
+/// `hasContentOnScreen` reports what the previous pass left drawn, so the pass that clears a
+/// display always runs and only the ones after it are skipped.
 enum AreaSelectionRenderGate {
   static func shouldRender(
     hasContentOnScreen: Bool,

--- a/Snapzy/Services/Capture/AreaSelectionWindow.swift
+++ b/Snapzy/Services/Capture/AreaSelectionWindow.swift
@@ -78,8 +78,6 @@ final class AreaSelectionController: NSObject {
   private(set) var selectionMode: SelectionMode = .screenshot
   private var selectionBackdrops: [CGDirectDisplayID: AreaSelectionBackdrop] = [:]
   private var liveFallbackDisplayIDs = Set<CGDirectDisplayID>()
-  /// Latch for `requestDisplayActivationForManualSelection()`. True once every display has a
-  /// backdrop or live-fallback, which makes that per-pointer-event scan a no-op.
   private var manualSelectionDisplayActivationSettled = false
   private var interactionMode: AreaSelectionInteractionMode = .manualRegion
   private var allowsApplicationWindowSelection = false
@@ -153,7 +151,6 @@ final class AreaSelectionController: NSObject {
   private var sessionPresentationLastResortUsed = Set<CGDirectDisplayID>()
   /// Max pooled-window recreations per display per session before the last-resort rung.
   private static let maxWindowRecreationsPerSession = 2
-  /// Non-nil while Space is held to move the whole selection. See `AreaSelectionMoveLogic`.
   private var manualSelectionMoveAnchors: AreaSelectionMoveAnchors?
   private var isMovingManualSelection: Bool { manualSelectionMoveAnchors != nil }
 
@@ -1869,8 +1866,6 @@ final class AreaSelectionController: NSObject {
     renderManualSelectionIfNeeded()
   }
 
-  /// Must stay idempotent: several event sources report the same physical movement, each sampling
-  /// the pointer at a different instant. See `AreaSelectionMoveLogic`.
   private func updateManualSelection(to screenPoint: CGPoint) {
     guard manualSelectionStartPoint != nil else { return }
     guard applyManualSelectionPointerSample(screenPoint) else { return }
@@ -1880,9 +1875,6 @@ final class AreaSelectionController: NSObject {
     reassertManualSelectionCursor()
   }
 
-  /// The single place a pointer sample turns into selection geometry. Drag updates and the final
-  /// mouse-up both route through it, so the committed rect cannot disagree with the drawn one.
-  /// Returns whether anything changed.
   @discardableResult
   private func applyManualSelectionPointerSample(_ screenPoint: CGPoint) -> Bool {
     if let anchors = manualSelectionMoveAnchors {
@@ -1914,7 +1906,6 @@ final class AreaSelectionController: NSObject {
     guard let start = manualSelectionStartPoint, let current = manualSelectionCurrentPoint else { return false }
     switch event.type {
     case .keyDown:
-      // Key auto-repeat re-enters this case, so anchor only on the transition into move mode.
       guard !isMovingManualSelection else { break }
       manualSelectionMoveAnchors = AreaSelectionMoveAnchors(originStart: start, anchor: current)
     case .keyUp:
@@ -1927,9 +1918,6 @@ final class AreaSelectionController: NSObject {
 
   private func endManualSelection(at screenPoint: CGPoint) {
     guard manualSelectionStartPoint != nil else { return }
-    // Commit through the same transform the overlay drew with. Assigning the mouse-up point
-    // straight to `current` would move only that corner while `start` kept its translation,
-    // committing a different size and origin than the rect on screen.
     applyManualSelectionPointerSample(screenPoint)
     removeManualSelectionMonitor()
 
@@ -2119,12 +2107,6 @@ final class AreaSelectionController: NSObject {
     }
   }
 
-  /// Runs on every pointer event of a drag, where `NSScreen.screens` and the per-screen
-  /// `deviceDescription` build in `displayID` are too costly to repeat.
-  ///
-  /// The loop can only do work for a display with neither a backdrop nor live-fallback, and both
-  /// sets only grow within a session, so once every display is settled it is a no-op — latch it
-  /// off. The latch is cleared on a new drag, a screen-configuration change and session teardown.
   private func requestDisplayActivationForManualSelection() {
     guard selectionMode == .screenshot else { return }
     guard !manualSelectionDisplayActivationSettled else { return }
@@ -2575,7 +2557,6 @@ final class AreaSelectionOverlayView: NSView {
   /// The coordinate label stays visible until this flips true, then the dimensions label
   /// owns the size indicator layers — mirroring native macOS / CleanShot X behavior.
   private var hasVisibleSelectionRect = false
-  /// What the last `renderManualSelection` pass left drawn. See `AreaSelectionRenderGate`.
   private var hasManualSelectionContentOnScreen = false
   private var pendingSelectionStartPoint: CGPoint?
   private var currentMousePosition: CGPoint = .zero
@@ -2918,8 +2899,6 @@ final class AreaSelectionOverlayView: NSView {
   func resetSelection() {
     isSelecting = false
     hasVisibleSelectionRect = false
-    // A reset can leave crosshair content drawn below, so force one pass through the fan-out
-    // gate. Erring true costs a render; erring false would strand pixels on this display.
     hasManualSelectionContentOnScreen = true
     pendingSelectionStartPoint = nil
     hoveredWindowCandidate = nil
@@ -3901,8 +3880,6 @@ final class AreaSelectionOverlayView: NSView {
   func renderManualSelection(screenRect: CGRect?, currentScreenPoint: CGPoint?) {
     guard interactionMode == .manualRegion else { return }
 
-    // Multi-display fan-out gate — see `AreaSelectionRenderGate`. `isMouseOver` reads
-    // `NSEvent.mouseLocation`, so it is computed once and reused.
     let pointerIsOverView = isMouseOver
     guard AreaSelectionRenderGate.shouldRender(
       hasContentOnScreen: hasManualSelectionContentOnScreen,

--- a/Snapzy/Services/Capture/AreaSelectionWindow.swift
+++ b/Snapzy/Services/Capture/AreaSelectionWindow.swift
@@ -78,6 +78,9 @@ final class AreaSelectionController: NSObject {
   private(set) var selectionMode: SelectionMode = .screenshot
   private var selectionBackdrops: [CGDirectDisplayID: AreaSelectionBackdrop] = [:]
   private var liveFallbackDisplayIDs = Set<CGDirectDisplayID>()
+  /// Latch for `requestDisplayActivationForManualSelection()`. True once every display has a
+  /// backdrop or live-fallback, which makes that per-pointer-event scan a no-op.
+  private var manualSelectionDisplayActivationSettled = false
   private var interactionMode: AreaSelectionInteractionMode = .manualRegion
   private var allowsApplicationWindowSelection = false
   private var applicationConfiguration: AreaSelectionApplicationConfiguration?
@@ -150,8 +153,9 @@ final class AreaSelectionController: NSObject {
   private var sessionPresentationLastResortUsed = Set<CGDirectDisplayID>()
   /// Max pooled-window recreations per display per session before the last-resort rung.
   private static let maxWindowRecreationsPerSession = 2
-  private var isMovingManualSelection = false
-  private var manualSelectionLastPointerLocation: CGPoint?
+  /// Non-nil while Space is held to move the whole selection. See `AreaSelectionMoveLogic`.
+  private var manualSelectionMoveAnchors: AreaSelectionMoveAnchors?
+  private var isMovingManualSelection: Bool { manualSelectionMoveAnchors != nil }
 
   /// Live-passthrough input source (plans/260723-2112-live-capture-passthrough): in live
   /// (backdrop-less) screenshot sessions the selection gesture is driven by this session
@@ -310,6 +314,7 @@ final class AreaSelectionController: NSObject {
 
   /// Refresh window pool when screens change
   private func refreshWindowPool() {
+    manualSelectionDisplayActivationSettled = false
     let currentDisplayIDs = Set(NSScreen.screens.compactMap(\.displayID))
     let pooledDisplayIDs = Set(windowPool.keys)
 
@@ -1833,6 +1838,7 @@ final class AreaSelectionController: NSObject {
     completionWithResult = nil
     selectionBackdrops.removeAll()
     liveFallbackDisplayIDs.removeAll()
+    manualSelectionDisplayActivationSettled = false
     requestedDisplayActivationIDs.removeAll()
     deferredBackdropDisplayIDs.removeAll()
     applicationConfiguration = nil
@@ -1856,34 +1862,41 @@ final class AreaSelectionController: NSObject {
     manualSelectionCurrentPoint = screenPoint
     manualSelectionSourceWindow = window
     activeWindow = window
-    isMovingManualSelection = false
-    manualSelectionLastPointerLocation = screenPoint
+    manualSelectionMoveAnchors = nil
+    manualSelectionDisplayActivationSettled = false
     installManualSelectionMonitorIfNeeded()
     requestDisplayActivationForManualSelection()
     renderManualSelectionIfNeeded()
   }
 
+  /// Must stay idempotent: several event sources report the same physical movement, each sampling
+  /// the pointer at a different instant. See `AreaSelectionMoveLogic`.
   private func updateManualSelection(to screenPoint: CGPoint) {
     guard manualSelectionStartPoint != nil else { return }
-    defer { manualSelectionLastPointerLocation = screenPoint }
-
-    if isMovingManualSelection {
-      guard let last = manualSelectionLastPointerLocation else { return }
-      let dx = screenPoint.x - last.x
-      let dy = screenPoint.y - last.y
-      guard dx != 0 || dy != 0 else { return }
-      manualSelectionStartPoint?.x += dx
-      manualSelectionStartPoint?.y += dy
-      manualSelectionCurrentPoint?.x += dx
-      manualSelectionCurrentPoint?.y += dy
-    } else {
-      guard screenPoint != manualSelectionCurrentPoint else { return }
-      manualSelectionCurrentPoint = screenPoint
-    }
+    guard applyManualSelectionPointerSample(screenPoint) else { return }
 
     requestDisplayActivationForManualSelection()
     renderManualSelectionIfNeeded()
     reassertManualSelectionCursor()
+  }
+
+  /// The single place a pointer sample turns into selection geometry. Drag updates and the final
+  /// mouse-up both route through it, so the committed rect cannot disagree with the drawn one.
+  /// Returns whether anything changed.
+  @discardableResult
+  private func applyManualSelectionPointerSample(_ screenPoint: CGPoint) -> Bool {
+    if let anchors = manualSelectionMoveAnchors {
+      let moved = AreaSelectionMoveLogic.movedSelection(pointer: screenPoint, anchors: anchors)
+      guard moved.start != manualSelectionStartPoint || moved.current != manualSelectionCurrentPoint else {
+        return false
+      }
+      manualSelectionStartPoint = moved.start
+      manualSelectionCurrentPoint = moved.current
+    } else {
+      guard screenPoint != manualSelectionCurrentPoint else { return false }
+      manualSelectionCurrentPoint = screenPoint
+    }
+    return true
   }
 
   /// Keep the crosshair asserted during a drag. The drag is driven by `NSEvent` monitors (not the
@@ -1898,15 +1911,14 @@ final class AreaSelectionController: NSObject {
 
   private func handleManualSelectionSpaceEvent(_ event: NSEvent) -> Bool {
     guard event.keyCode == 49 else { return false }
-    guard manualSelectionStartPoint != nil else { return false }
+    guard let start = manualSelectionStartPoint, let current = manualSelectionCurrentPoint else { return false }
     switch event.type {
     case .keyDown:
-      if !isMovingManualSelection {
-        manualSelectionLastPointerLocation = NSEvent.mouseLocation
-        isMovingManualSelection = true
-      }
+      // Key auto-repeat re-enters this case, so anchor only on the transition into move mode.
+      guard !isMovingManualSelection else { break }
+      manualSelectionMoveAnchors = AreaSelectionMoveAnchors(originStart: start, anchor: current)
     case .keyUp:
-      isMovingManualSelection = false
+      manualSelectionMoveAnchors = nil
     default:
       return false
     }
@@ -1915,7 +1927,10 @@ final class AreaSelectionController: NSObject {
 
   private func endManualSelection(at screenPoint: CGPoint) {
     guard manualSelectionStartPoint != nil else { return }
-    manualSelectionCurrentPoint = screenPoint
+    // Commit through the same transform the overlay drew with. Assigning the mouse-up point
+    // straight to `current` would move only that corner while `start` kept its translation,
+    // committing a different size and origin than the rect on screen.
+    applyManualSelectionPointerSample(screenPoint)
     removeManualSelectionMonitor()
 
     guard let rect = manualSelectionRect, rect.width > 5, rect.height > 5 else {
@@ -2050,8 +2065,7 @@ final class AreaSelectionController: NSObject {
       NotificationCenter.default.removeObserver(observer)
       appActivationObserver = nil
     }
-    isMovingManualSelection = false
-    manualSelectionLastPointerLocation = nil
+    manualSelectionMoveAnchors = nil
   }
 
   private func clearManualSelectionTracking(render: Bool) {
@@ -2105,21 +2119,30 @@ final class AreaSelectionController: NSObject {
     }
   }
 
+  /// Runs on every pointer event of a drag, where `NSScreen.screens` and the per-screen
+  /// `deviceDescription` build in `displayID` are too costly to repeat.
+  ///
+  /// The loop can only do work for a display with neither a backdrop nor live-fallback, and both
+  /// sets only grow within a session, so once every display is settled it is a no-op — latch it
+  /// off. The latch is cleared on a new drag, a screen-configuration change and session teardown.
   private func requestDisplayActivationForManualSelection() {
     guard selectionMode == .screenshot else { return }
+    guard !manualSelectionDisplayActivationSettled else { return }
     let rect = manualSelectionRect
     let currentPoint = manualSelectionCurrentPoint
+    var allDisplaysSettled = true
     for screen in NSScreen.screens {
       guard let displayID = screen.displayID else { continue }
       let shouldPrepare = currentPoint.map { screen.frame.contains($0) } == true
         || rect.map { screen.frame.intersects($0) } == true
-      if shouldPrepare {
-        if enableLiveSelectionDuringManualDrag(for: displayID) {
-          continue
-        }
+      if shouldPrepare, !enableLiveSelectionDuringManualDrag(for: displayID) {
         requestDisplayActivationIfNeeded(for: displayID)
       }
+      if selectionBackdrops[displayID] == nil, !liveFallbackDisplayIDs.contains(displayID) {
+        allDisplaysSettled = false
+      }
     }
+    manualSelectionDisplayActivationSettled = allDisplaysSettled
   }
 
   @discardableResult
@@ -2552,6 +2575,8 @@ final class AreaSelectionOverlayView: NSView {
   /// The coordinate label stays visible until this flips true, then the dimensions label
   /// owns the size indicator layers — mirroring native macOS / CleanShot X behavior.
   private var hasVisibleSelectionRect = false
+  /// What the last `renderManualSelection` pass left drawn. See `AreaSelectionRenderGate`.
+  private var hasManualSelectionContentOnScreen = false
   private var pendingSelectionStartPoint: CGPoint?
   private var currentMousePosition: CGPoint = .zero
   private var windowSelectionSnapshot: WindowSelectionSnapshot?
@@ -2893,6 +2918,9 @@ final class AreaSelectionOverlayView: NSView {
   func resetSelection() {
     isSelecting = false
     hasVisibleSelectionRect = false
+    // A reset can leave crosshair content drawn below, so force one pass through the fan-out
+    // gate. Erring true costs a render; erring false would strand pixels on this display.
+    hasManualSelectionContentOnScreen = true
     pendingSelectionStartPoint = nil
     hoveredWindowCandidate = nil
 
@@ -3872,6 +3900,16 @@ final class AreaSelectionOverlayView: NSView {
 
   func renderManualSelection(screenRect: CGRect?, currentScreenPoint: CGPoint?) {
     guard interactionMode == .manualRegion else { return }
+
+    // Multi-display fan-out gate — see `AreaSelectionRenderGate`. `isMouseOver` reads
+    // `NSEvent.mouseLocation`, so it is computed once and reused.
+    let pointerIsOverView = isMouseOver
+    guard AreaSelectionRenderGate.shouldRender(
+      hasContentOnScreen: hasManualSelectionContentOnScreen,
+      pointerIsOverView: pointerIsOverView,
+      selectionIntersectsView: screenRect.map { !convertToLocalRect($0).intersection(bounds).isEmpty } ?? false
+    ) else { return }
+    defer { hasManualSelectionContentOnScreen = hasVisibleSelectionRect || pointerIsOverView }
 
     let localCurrentPoint: CGPoint?
     if let currentScreenPoint, let window {

--- a/SnapzyTests/Services/Capture/AreaSelectionHoverPerformanceTests.swift
+++ b/SnapzyTests/Services/Capture/AreaSelectionHoverPerformanceTests.swift
@@ -91,6 +91,33 @@ final class AreaSelectionHoverPerformanceTests: XCTestCase {
     }
   }
 
+  /// Drag hot path. Unlike hover — which only touches the overlay under the pointer —
+  /// `renderManualSelectionIfNeeded()` fans every pointer event out to *all* pooled windows, so
+  /// this cost scales with attached display count. Reports the display count alongside the timing
+  /// so a single-display run and a multi-display run are comparable.
+  func testDragTickCost_multiDisplayFanOut() throws {
+    try skipIfRunningInCI(
+      "Presents real overlay windows via the shared AreaSelectionController, which is flaky on headless CI runners"
+    )
+    let (window, overlay) = try makeLiveSession(forcePassthrough: true)
+
+    // Begin a real manual selection so the drag path (not the hover path) is what gets measured.
+    overlay.handleLivePassthroughMouseDown(
+      atScreenPoint: CGPoint(x: window.frame.midX, y: window.frame.midY)
+    )
+
+    var sync: [Double] = []
+    var tick: [Double] = []
+    for index in 0 ..< iterations {
+      let local = walkPoint(index: index, in: overlay.bounds)
+      let screenPoint = CGPoint(x: window.frame.minX + local.x, y: window.frame.minY + local.y)
+      measureTick(sync: &sync, tick: &tick) {
+        overlay.handleLivePassthroughMouseDragged(atScreenPoint: screenPoint)
+      }
+    }
+    report(label: "dragFanOut(displays=\(NSScreen.screens.count))", sync: sync, tick: tick)
+  }
+
   /// Attribution probe: the presentation watchdog runs this WindowServer query
   /// whenever it is (re-)armed; the hover path re-arms it per tick while the app
   /// is inactive, so its standalone cost is reported for comparison against the

--- a/SnapzyTests/Services/Capture/AreaSelectionHoverPerformanceTests.swift
+++ b/SnapzyTests/Services/Capture/AreaSelectionHoverPerformanceTests.swift
@@ -91,17 +91,13 @@ final class AreaSelectionHoverPerformanceTests: XCTestCase {
     }
   }
 
-  /// Drag hot path. Unlike hover — which only touches the overlay under the pointer —
-  /// `renderManualSelectionIfNeeded()` fans every pointer event out to *all* pooled windows, so
-  /// this cost scales with attached display count. Reports the display count alongside the timing
-  /// so a single-display run and a multi-display run are comparable.
+  /// Drag hot path, which fans out to every pooled window and so scales with display count.
   func testDragTickCost_multiDisplayFanOut() throws {
     try skipIfRunningInCI(
       "Presents real overlay windows via the shared AreaSelectionController, which is flaky on headless CI runners"
     )
     let (window, overlay) = try makeLiveSession(forcePassthrough: true)
 
-    // Begin a real manual selection so the drag path (not the hover path) is what gets measured.
     overlay.handleLivePassthroughMouseDown(
       atScreenPoint: CGPoint(x: window.frame.midX, y: window.frame.midY)
     )

--- a/SnapzyTests/Services/Capture/AreaSelectionMoveLogicTests.swift
+++ b/SnapzyTests/Services/Capture/AreaSelectionMoveLogicTests.swift
@@ -1,0 +1,83 @@
+//
+//  AreaSelectionMoveLogicTests.swift
+//  SnapzyTests
+//
+//  Space-to-move geometry. These pin the regression where the move accumulated a per-event delta,
+//  so the differing pointer samples from each event source were baked into the selection's
+//  position one event at a time and the rect crept away from the pointer.
+//
+
+import CoreGraphics
+@testable import Snapzy
+import XCTest
+
+final class AreaSelectionMoveLogicTests: XCTestCase {
+  /// A selection dragged from (100, 100) to (300, 250), with Space pressed at the current point.
+  private let anchors = AreaSelectionMoveAnchors(
+    originStart: CGPoint(x: 100, y: 100),
+    anchor: CGPoint(x: 300, y: 250)
+  )
+
+  private func size(_ moved: (start: CGPoint, current: CGPoint)) -> CGSize {
+    CGSize(width: abs(moved.current.x - moved.start.x), height: abs(moved.current.y - moved.start.y))
+  }
+
+  func testPressSeamIsZero() {
+    // Space goes down and nothing moves yet: the selection must not shift at all.
+    let moved = AreaSelectionMoveLogic.movedSelection(pointer: anchors.anchor, anchors: anchors)
+    XCTAssertEqual(moved.start, anchors.originStart)
+    XCTAssertEqual(moved.current, anchors.anchor)
+  }
+
+  func testTranslatesByPointerDeltaAndPreservesSize() {
+    let moved = AreaSelectionMoveLogic.movedSelection(pointer: CGPoint(x: 340, y: 220), anchors: anchors)
+    XCTAssertEqual(moved.start, CGPoint(x: 140, y: 70))
+    XCTAssertEqual(moved.current, CGPoint(x: 340, y: 220))
+    XCTAssertEqual(size(moved), CGSize(width: 200, height: 150))
+  }
+
+  /// The release seam: `current` must equal the pointer throughout, so when Space comes up and
+  /// the caller resumes absolute assignment (`current = pointer`) the selection does not snap.
+  func testCurrentPointAlwaysTracksPointerExactly() {
+    for pointer in [CGPoint(x: 301, y: 250), CGPoint(x: 12, y: 900), CGPoint(x: -400, y: -30)] {
+      let moved = AreaSelectionMoveLogic.movedSelection(pointer: pointer, anchors: anchors)
+      XCTAssertEqual(moved.current, pointer)
+    }
+  }
+
+  /// The core invariant. Replaying the same sample, an out-of-order stale sample, or a duplicate
+  /// from a second event source must all land on the identical rect.
+  func testIdempotentUnderRepeatedStaleAndOutOfOrderSamples() {
+    let truth = AreaSelectionMoveLogic.movedSelection(pointer: CGPoint(x: 340, y: 220), anchors: anchors)
+
+    let samples = [
+      CGPoint(x: 340, y: 220),
+      CGPoint(x: 339.4, y: 221.7), // a stale sample from the other monitor
+      CGPoint(x: 512, y: 33),
+      CGPoint(x: 340, y: 220),
+    ]
+    var last = truth
+    for sample in samples {
+      last = AreaSelectionMoveLogic.movedSelection(pointer: sample, anchors: anchors)
+    }
+    XCTAssertEqual(last.start, truth.start)
+    XCTAssertEqual(last.current, truth.current)
+  }
+
+  /// Interleaving two event sources that sample the pointer a fraction apart must leave no
+  /// residue: the selection depends only on the final sample, never on the path taken to it.
+  func testInterleavedSourcesLeaveNoAccumulatedDrift() {
+    var moved = AreaSelectionMoveLogic.movedSelection(pointer: anchors.anchor, anchors: anchors)
+    for step in 1...500 {
+      let live = CGPoint(x: anchors.anchor.x + CGFloat(step), y: anchors.anchor.y)
+      let lagged = CGPoint(x: live.x - 0.7, y: live.y + 0.3) // second source, sampled slightly earlier
+      moved = AreaSelectionMoveLogic.movedSelection(pointer: lagged, anchors: anchors)
+      moved = AreaSelectionMoveLogic.movedSelection(pointer: live, anchors: anchors)
+    }
+
+    let expectedTranslation = CGFloat(500)
+    XCTAssertEqual(moved.start.x, anchors.originStart.x + expectedTranslation, accuracy: 0.0001)
+    XCTAssertEqual(moved.start.y, anchors.originStart.y, accuracy: 0.0001)
+    XCTAssertEqual(size(moved), CGSize(width: 200, height: 150))
+  }
+}

--- a/SnapzyTests/Services/Capture/AreaSelectionMoveLogicTests.swift
+++ b/SnapzyTests/Services/Capture/AreaSelectionMoveLogicTests.swift
@@ -2,17 +2,12 @@
 //  AreaSelectionMoveLogicTests.swift
 //  SnapzyTests
 //
-//  Space-to-move geometry. These pin the regression where the move accumulated a per-event delta,
-//  so the differing pointer samples from each event source were baked into the selection's
-//  position one event at a time and the rect crept away from the pointer.
-//
 
 import CoreGraphics
 @testable import Snapzy
 import XCTest
 
 final class AreaSelectionMoveLogicTests: XCTestCase {
-  /// A selection dragged from (100, 100) to (300, 250), with Space pressed at the current point.
   private let anchors = AreaSelectionMoveAnchors(
     originStart: CGPoint(x: 100, y: 100),
     anchor: CGPoint(x: 300, y: 250)
@@ -23,7 +18,6 @@ final class AreaSelectionMoveLogicTests: XCTestCase {
   }
 
   func testPressSeamIsZero() {
-    // Space goes down and nothing moves yet: the selection must not shift at all.
     let moved = AreaSelectionMoveLogic.movedSelection(pointer: anchors.anchor, anchors: anchors)
     XCTAssertEqual(moved.start, anchors.originStart)
     XCTAssertEqual(moved.current, anchors.anchor)
@@ -36,8 +30,6 @@ final class AreaSelectionMoveLogicTests: XCTestCase {
     XCTAssertEqual(size(moved), CGSize(width: 200, height: 150))
   }
 
-  /// The release seam: `current` must equal the pointer throughout, so when Space comes up and
-  /// the caller resumes absolute assignment (`current = pointer`) the selection does not snap.
   func testCurrentPointAlwaysTracksPointerExactly() {
     for pointer in [CGPoint(x: 301, y: 250), CGPoint(x: 12, y: 900), CGPoint(x: -400, y: -30)] {
       let moved = AreaSelectionMoveLogic.movedSelection(pointer: pointer, anchors: anchors)
@@ -45,14 +37,12 @@ final class AreaSelectionMoveLogicTests: XCTestCase {
     }
   }
 
-  /// The core invariant. Replaying the same sample, an out-of-order stale sample, or a duplicate
-  /// from a second event source must all land on the identical rect.
   func testIdempotentUnderRepeatedStaleAndOutOfOrderSamples() {
     let truth = AreaSelectionMoveLogic.movedSelection(pointer: CGPoint(x: 340, y: 220), anchors: anchors)
 
     let samples = [
       CGPoint(x: 340, y: 220),
-      CGPoint(x: 339.4, y: 221.7), // a stale sample from the other monitor
+      CGPoint(x: 339.4, y: 221.7),
       CGPoint(x: 512, y: 33),
       CGPoint(x: 340, y: 220),
     ]
@@ -64,19 +54,16 @@ final class AreaSelectionMoveLogicTests: XCTestCase {
     XCTAssertEqual(last.current, truth.current)
   }
 
-  /// Interleaving two event sources that sample the pointer a fraction apart must leave no
-  /// residue: the selection depends only on the final sample, never on the path taken to it.
   func testInterleavedSourcesLeaveNoAccumulatedDrift() {
     var moved = AreaSelectionMoveLogic.movedSelection(pointer: anchors.anchor, anchors: anchors)
     for step in 1...500 {
       let live = CGPoint(x: anchors.anchor.x + CGFloat(step), y: anchors.anchor.y)
-      let lagged = CGPoint(x: live.x - 0.7, y: live.y + 0.3) // second source, sampled slightly earlier
+      let lagged = CGPoint(x: live.x - 0.7, y: live.y + 0.3)
       moved = AreaSelectionMoveLogic.movedSelection(pointer: lagged, anchors: anchors)
       moved = AreaSelectionMoveLogic.movedSelection(pointer: live, anchors: anchors)
     }
 
-    let expectedTranslation = CGFloat(500)
-    XCTAssertEqual(moved.start.x, anchors.originStart.x + expectedTranslation, accuracy: 0.0001)
+    XCTAssertEqual(moved.start.x, anchors.originStart.x + 500, accuracy: 0.0001)
     XCTAssertEqual(moved.start.y, anchors.originStart.y, accuracy: 0.0001)
     XCTAssertEqual(size(moved), CGSize(width: 200, height: 150))
   }

--- a/SnapzyTests/Services/Capture/AreaSelectionRenderGateTests.swift
+++ b/SnapzyTests/Services/Capture/AreaSelectionRenderGateTests.swift
@@ -2,10 +2,6 @@
 //  AreaSelectionRenderGateTests.swift
 //  SnapzyTests
 //
-//  The multi-display render fan-out gate. These stand in for a multi-display rig: the risk in
-//  skipping a render is stranding pixels on a display the selection has left, so the clearing
-//  pass is pinned explicitly.
-//
 
 import CoreGraphics
 @testable import Snapzy
@@ -20,9 +16,9 @@ final class AreaSelectionRenderGateTests: XCTestCase {
 
   func testRendersWheneverAnyTermHolds() {
     for (content, pointer, intersects) in [
-      (true, false, false),  // must still clear what the last pass drew
-      (false, true, false),  // owns crosshair / coordinate / magnifier
-      (false, false, true),  // selection rect reaches this display
+      (true, false, false),
+      (false, true, false),
+      (false, false, true),
       (true, true, true),
     ] {
       XCTAssertTrue(AreaSelectionRenderGate.shouldRender(
@@ -31,17 +27,15 @@ final class AreaSelectionRenderGateTests: XCTestCase {
     }
   }
 
-  /// The regression the gate must not introduce: a display the pointer just left, with the rect
-  /// elsewhere, gets exactly one clearing pass and only then goes quiet.
   func testDisplayThePointerLeavesIsClearedExactlyOnceThenSkipped() {
-    var hasContent = true // last pass drew the crosshair while the pointer was here
+    var hasContent = true
     var renders = 0
     for _ in 0 ..< 5 {
       guard AreaSelectionRenderGate.shouldRender(
         hasContentOnScreen: hasContent, pointerIsOverView: false, selectionIntersectsView: false
       ) else { continue }
       renders += 1
-      hasContent = false // the pass cleared it
+      hasContent = false
     }
     XCTAssertEqual(renders, 1)
   }

--- a/SnapzyTests/Services/Capture/AreaSelectionRenderGateTests.swift
+++ b/SnapzyTests/Services/Capture/AreaSelectionRenderGateTests.swift
@@ -1,0 +1,48 @@
+//
+//  AreaSelectionRenderGateTests.swift
+//  SnapzyTests
+//
+//  The multi-display render fan-out gate. These stand in for a multi-display rig: the risk in
+//  skipping a render is stranding pixels on a display the selection has left, so the clearing
+//  pass is pinned explicitly.
+//
+
+import CoreGraphics
+@testable import Snapzy
+import XCTest
+
+final class AreaSelectionRenderGateTests: XCTestCase {
+  func testSkipsOnlyWhenNothingDrawnAndNothingToDraw() {
+    XCTAssertFalse(AreaSelectionRenderGate.shouldRender(
+      hasContentOnScreen: false, pointerIsOverView: false, selectionIntersectsView: false
+    ))
+  }
+
+  func testRendersWheneverAnyTermHolds() {
+    for (content, pointer, intersects) in [
+      (true, false, false),  // must still clear what the last pass drew
+      (false, true, false),  // owns crosshair / coordinate / magnifier
+      (false, false, true),  // selection rect reaches this display
+      (true, true, true),
+    ] {
+      XCTAssertTrue(AreaSelectionRenderGate.shouldRender(
+        hasContentOnScreen: content, pointerIsOverView: pointer, selectionIntersectsView: intersects
+      ), "expected render for (\(content), \(pointer), \(intersects))")
+    }
+  }
+
+  /// The regression the gate must not introduce: a display the pointer just left, with the rect
+  /// elsewhere, gets exactly one clearing pass and only then goes quiet.
+  func testDisplayThePointerLeavesIsClearedExactlyOnceThenSkipped() {
+    var hasContent = true // last pass drew the crosshair while the pointer was here
+    var renders = 0
+    for _ in 0 ..< 5 {
+      guard AreaSelectionRenderGate.shouldRender(
+        hasContentOnScreen: hasContent, pointerIsOverView: false, selectionIntersectsView: false
+      ) else { continue }
+      renders += 1
+      hasContent = false // the pass cleared it
+    }
+    XCTAssertEqual(renders, 1)
+  }
+}


### PR DESCRIPTION
Follow-up to #294, which added space-to-move for area capture. Two defects there let the committed rect disagree with the one drawn on screen.

### Drift while moving

The move accumulated a per-event delta into the selection's own points. That holds only while a single source reports pointer movement, which was true when #294 landed. `updateManualSelection` is now reached from four:

- the local `NSEvent` drag monitor
- the global `NSEvent` drag monitor
- the overlay view's drag delegate
- the live-capture event tap, added later by #416 / #430

The monitors read `NSEvent.mouseLocation` live at callback time; the other two carry the recorded event location. The same physical movement therefore arrives with slightly different samples, and each pair contributed its sampling difference to the rect permanently, so the selection crept away from the pointer.

The comment above the global monitor already required these handlers to be idempotent — the delta accumulation quietly broke that contract. The translation is now recomputed absolutely from anchors captured when the move begins, so a repeated, stale or out-of-order sample lands on the same rect and nothing accumulates.

### Size and origin changing on release

`endManualSelection` assigned the mouse-up point straight to the current point with no knowledge of move mode, so releasing the mouse while Space was held moved that corner while the start point kept its translation. Because the mouse-up point is its own pointer sample, the committed rect came out a different size *and* origin than the drawn one every time. Drag updates and the final mouse-up now route through one shared transform.

Anchoring on the selection's current point rather than a fresh pointer read makes both seams exactly zero: pressing Space neither moves nor resizes the selection, and releasing it does not snap.

### Per-pointer-event work in the same hot path

- `requestDisplayActivationForManualSelection` ran `NSScreen.screens` plus a per-screen `deviceDescription` build on every event. It is a no-op once every display has a backdrop or live-fallback, and both sets only grow within a session, so it now latches off. Cleared on a new drag, a screen-configuration change and session teardown.
- `renderManualSelectionIfNeeded` fanned every event out to all pooled windows, including displays holding neither the pointer nor the rect. Now gated, with a term that guarantees the pass which clears a display still runs.

### Testing

The move geometry and the render gate are pure and unit-tested (8 tests), including idempotence under stale, duplicate and interleaved samples, and the clear-exactly-once behaviour of the gate. Verified by hand on a single display.

The render gate has **not** been verified on real multi-display hardware — it is covered at the logic level only. Happy to split that part out if you would rather take the correctness fix on its own.