### PR TITLE
fix: render canvas shadow in screenshot exports

### DIFF
--- a/Snapzy/Features/Annotate/AnnotateManager.swift
+++ b/Snapzy/Features/Annotate/AnnotateManager.swift
@@ -9,7 +9,10 @@ import AppKit
 import Foundation
 
 enum AnnotateCanvasDefaults {
-  static let cornerRadius: CGFloat = 0
+  nonisolated static let cornerRadius: CGFloat = 0
+  nonisolated static let shadowRadius: CGFloat = 15
+  nonisolated static let shadowOffsetX: CGFloat = 0
+  nonisolated static let shadowOffsetY: CGFloat = 8
 }
 
 /// In-memory annotation session data for re-editing annotations

--- a/Snapzy/Features/Annotate/Components/AnnotateCanvasView.swift
+++ b/Snapzy/Features/Annotate/Components/AnnotateCanvasView.swift
@@ -537,9 +537,9 @@ struct AnnotateCanvasView: View {
         .clipShape(RoundedRectangle(cornerRadius: currentCornerRadius, style: .continuous))
         .shadow(
           color: .black.opacity(state.backgroundStyle != .none ? currentShadowIntensity : 0),
-          radius: 15,
-          x: 0,
-          y: 8
+          radius: AnnotateCanvasDefaults.shadowRadius,
+          x: AnnotateCanvasDefaults.shadowOffsetX,
+          y: AnnotateCanvasDefaults.shadowOffsetY
         )
     }
   }

--- a/Snapzy/Features/Annotate/Services/AnnotateExporter.swift
+++ b/Snapzy/Features/Annotate/Services/AnnotateExporter.swift
@@ -342,15 +342,22 @@ final class AnnotateExporter {
       totalSize: totalSize,
       alignment: effects.imageAlignment
     )
+    let imageRect = CGRect(origin: destinationOrigin, size: effectiveBounds.size)
+
+    drawCanvasShadow(
+      imageRect: imageRect,
+      canvasRect: CGRect(origin: .zero, size: totalSize),
+      cornerRadius: effects.cornerRadius,
+      intensity: effects.backgroundStyle != .none ? effects.shadowIntensity : 0,
+      in: context
+    )
 
     if effects.cornerRadius > 0 {
-      let clipRect = NSRect(
-        x: destinationOrigin.x,
-        y: destinationOrigin.y,
-        width: effectiveBounds.width,
-        height: effectiveBounds.height
+      let path = NSBezierPath(
+        roundedRect: imageRect,
+        xRadius: effects.cornerRadius,
+        yRadius: effects.cornerRadius
       )
-      let path = NSBezierPath(roundedRect: clipRect, xRadius: effects.cornerRadius, yRadius: effects.cornerRadius)
       path.addClip()
     }
 
@@ -514,14 +521,26 @@ final class AnnotateExporter {
       destY = 0
     }
 
+    let imageRect = CGRect(
+      x: destX,
+      y: destY,
+      width: effectiveBounds.width,
+      height: effectiveBounds.height
+    )
+    drawCanvasShadow(
+      imageRect: imageRect,
+      canvasRect: CGRect(origin: .zero, size: totalSize),
+      cornerRadius: snapshot.cornerRadius,
+      intensity: snapshot.backgroundStyle != .none ? snapshot.shadowIntensity : 0,
+      in: context
+    )
+
     if snapshot.cornerRadius > 0 {
-      let clipRect = NSRect(
-        x: destX,
-        y: destY,
-        width: effectiveBounds.width,
-        height: effectiveBounds.height
+      let path = NSBezierPath(
+        roundedRect: imageRect,
+        xRadius: snapshot.cornerRadius,
+        yRadius: snapshot.cornerRadius
       )
-      let path = NSBezierPath(roundedRect: clipRect, xRadius: snapshot.cornerRadius, yRadius: snapshot.cornerRadius)
       path.addClip()
     }
 
@@ -590,6 +609,51 @@ final class AnnotateExporter {
     let image = NSImage(size: totalSize)
     image.addRepresentation(bitmapRep)
     return image
+  }
+
+  /// Draw the flat-canvas screenshot shadow without painting beneath the source image.
+  /// The even-odd clip keeps only the blurred pixels outside the rounded silhouette,
+  /// so transparent source pixels and native-resolution screenshot pixels stay untouched.
+  nonisolated private static func drawCanvasShadow(
+    imageRect: CGRect,
+    canvasRect: CGRect,
+    cornerRadius: CGFloat,
+    intensity: CGFloat,
+    in context: CGContext
+  ) {
+    let opacity = min(max(intensity, 0), 1)
+    guard opacity > 0, imageRect.width > 0, imageRect.height > 0 else { return }
+
+    let radius = min(
+      max(cornerRadius, 0),
+      min(imageRect.width, imageRect.height) / 2
+    )
+    let silhouette = CGPath(
+      roundedRect: imageRect,
+      cornerWidth: radius,
+      cornerHeight: radius,
+      transform: nil
+    )
+
+    context.saveGState()
+    let outsideSilhouette = CGMutablePath()
+    outsideSilhouette.addRect(canvasRect)
+    outsideSilhouette.addPath(silhouette)
+    context.addPath(outsideSilhouette)
+    context.clip(using: .evenOdd)
+
+    context.setShadow(
+      offset: CGSize(
+        width: AnnotateCanvasDefaults.shadowOffsetX,
+        height: -AnnotateCanvasDefaults.shadowOffsetY
+      ),
+      blur: AnnotateCanvasDefaults.shadowRadius,
+      color: NSColor.black.withAlphaComponent(opacity).cgColor
+    )
+    context.addPath(silhouette)
+    context.setFillColor(NSColor.black.cgColor)
+    context.fillPath()
+    context.restoreGState()
   }
 
   /// Draw only the source-image portion that intersects the requested canvas bounds.

--- a/SnapzyTests/Features/Annotate/AnnotateExporterTests.swift
+++ b/SnapzyTests/Features/Annotate/AnnotateExporterTests.swift
@@ -6,11 +6,13 @@
 //
 
 import AppKit
+import SwiftUI
 import XCTest
 @testable import Snapzy
 
 @MainActor
 final class AnnotateExporterTests: XCTestCase {
+  private static var retainedAnnotateStates: [AnnotateState] = []
 
   private var tempDir: URL!
 
@@ -106,5 +108,196 @@ final class AnnotateExporterTests: XCTestCase {
     let empty = NSImage(size: NSSize(width: 0, height: 0))
     let data = AnnotateExporter.imageData(from: empty, for: "png")
     XCTAssertNil(data)
+  }
+
+  // MARK: - Canvas shadow rendering
+
+  func testRenderCanvasEffects_rendersRoundedShadowOutsideScreenshot() throws {
+    let sourceImage = try makeSolidImage(width: 80, height: 60, pointSize: CGSize(width: 40, height: 30))
+    let effects = AnnotationCanvasEffects(
+      backgroundStyle: .solidColor(.white),
+      padding: 30,
+      shadowIntensity: 0.8,
+      cornerRadius: 12,
+      aspectRatio: .free
+    )
+
+    let rendered = try XCTUnwrap(AnnotateExporter.renderCanvasEffects(sourceImage: sourceImage, effects: effects))
+    var effectsWithoutShadow = effects
+    effectsWithoutShadow.shadowIntensity = 0
+    let baseline = try XCTUnwrap(
+      AnnotateExporter.renderCanvasEffects(sourceImage: sourceImage, effects: effectsWithoutShadow)
+    )
+
+    let renderedCG = try XCTUnwrap(AnnotateExporter.bestCGImage(from: rendered))
+    let baselineCG = try XCTUnwrap(AnnotateExporter.bestCGImage(from: baseline))
+    let renderedBytes = try rgbaBytes(from: renderedCG)
+    let baselineBytes = try rgbaBytes(from: baselineCG)
+    let screenshotPixelRect = CGRect(x: 60, y: 60, width: 80, height: 60)
+
+    XCTAssertGreaterThan(
+      countDarkenedPixels(
+        renderedBytes,
+        comparedTo: baselineBytes,
+        imageWidth: renderedCG.width,
+        imageHeight: renderedCG.height,
+        outside: screenshotPixelRect
+      ),
+      100
+    )
+
+    let center = rgbaPixel(in: renderedBytes, x: 100, y: 90, width: renderedCG.width)
+    XCTAssertEqual(center, [128, 128, 128, 255])
+
+    let roundedCorner = rgbaPixel(in: renderedBytes, x: 60, y: 60, width: renderedCG.width)
+    XCTAssertNotEqual(roundedCorner, [128, 128, 128, 255])
+  }
+
+  func testRenderCanvasEffects_zeroShadowLeavesBackgroundPixelsUnchanged() throws {
+    let sourceImage = try makeSolidImage(width: 40, height: 30)
+    let effects = AnnotationCanvasEffects(
+      backgroundStyle: .solidColor(.white),
+      padding: 30,
+      shadowIntensity: 0,
+      cornerRadius: 0,
+      aspectRatio: .free
+    )
+
+    let rendered = try XCTUnwrap(AnnotateExporter.renderCanvasEffects(sourceImage: sourceImage, effects: effects))
+    let renderedCG = try XCTUnwrap(AnnotateExporter.bestCGImage(from: rendered))
+    let bytes = try rgbaBytes(from: renderedCG)
+    let screenshotRect = CGRect(x: 30, y: 30, width: 40, height: 30)
+
+    for y in 0..<renderedCG.height {
+      for x in 0..<renderedCG.width where !screenshotRect.contains(CGPoint(x: x, y: y)) {
+        XCTAssertEqual(rgbaPixel(in: bytes, x: x, y: y, width: renderedCG.width), [255, 255, 255, 255])
+      }
+    }
+  }
+
+  func testRenderCanvasEffects_rendersSquareShadowOverGradient() throws {
+    let sourceImage = try makeSolidImage(width: 40, height: 30)
+    let effects = AnnotationCanvasEffects(
+      backgroundStyle: .gradient(.orangeRed),
+      padding: 30,
+      shadowIntensity: 0.8,
+      cornerRadius: 0,
+      aspectRatio: .free
+    )
+
+    let rendered = try XCTUnwrap(AnnotateExporter.renderCanvasEffects(sourceImage: sourceImage, effects: effects))
+    var effectsWithoutShadow = effects
+    effectsWithoutShadow.shadowIntensity = 0
+    let baseline = try XCTUnwrap(
+      AnnotateExporter.renderCanvasEffects(sourceImage: sourceImage, effects: effectsWithoutShadow)
+    )
+    let renderedCG = try XCTUnwrap(AnnotateExporter.bestCGImage(from: rendered))
+    let baselineCG = try XCTUnwrap(AnnotateExporter.bestCGImage(from: baseline))
+
+    XCTAssertGreaterThan(
+      countDarkenedPixels(
+        try rgbaBytes(from: renderedCG),
+        comparedTo: try rgbaBytes(from: baselineCG),
+        imageWidth: renderedCG.width,
+        imageHeight: renderedCG.height,
+        outside: CGRect(x: 30, y: 30, width: 40, height: 30)
+      ),
+      25
+    )
+  }
+
+  func testRenderFinalImage_rendersShadowWithoutSofteningRetinaSource() throws {
+    let sourceCG = try XCTUnwrap(TestImageFactory.verticalEdge(width: 80, height: 60))
+    let sourceImage = NSImage(cgImage: sourceCG, size: CGSize(width: 40, height: 30))
+    let state = AnnotateState()
+    Self.retainedAnnotateStates.append(state)
+    state.loadImage(sourceImage)
+    state.backgroundStyle = .solidColor(.white)
+    state.padding = 30
+    state.shadowIntensity = 0.8
+    state.cornerRadius = 0
+    state.aspectRatio = .free
+
+    let rendered = try XCTUnwrap(AnnotateExporter.renderFinalImage(state: state))
+    let renderedCG = try XCTUnwrap(AnnotateExporter.bestCGImage(from: rendered))
+    let renderedBytes = try rgbaBytes(from: renderedCG)
+    let sourceBytes = try rgbaBytes(from: sourceCG)
+
+    XCTAssertEqual(renderedCG.width, 200)
+    XCTAssertEqual(renderedCG.height, 180)
+    for y in 0..<sourceCG.height {
+      for x in 0..<sourceCG.width {
+        XCTAssertEqual(
+          rgbaPixel(in: renderedBytes, x: x + 60, y: y + 60, width: renderedCG.width),
+          rgbaPixel(in: sourceBytes, x: x, y: y, width: sourceCG.width)
+        )
+      }
+    }
+
+    var intermediateEdgePixels = 0
+    for x in 60..<140 {
+      let red = rgbaPixel(in: renderedBytes, x: x, y: 90, width: renderedCG.width)[0]
+      if red > 0 && red < 255 {
+        intermediateEdgePixels += 1
+      }
+    }
+    XCTAssertEqual(intermediateEdgePixels, 0)
+  }
+
+  private func makeSolidImage(
+    width: Int,
+    height: Int,
+    pointSize: CGSize? = nil
+  ) throws -> NSImage {
+    let cgImage = try XCTUnwrap(TestImageFactory.solidColor(width: width, height: height))
+    return NSImage(cgImage: cgImage, size: pointSize ?? CGSize(width: width, height: height))
+  }
+
+  private func rgbaBytes(from image: CGImage) throws -> [UInt8] {
+    var bytes = [UInt8](repeating: 0, count: image.width * image.height * 4)
+    try bytes.withUnsafeMutableBytes { buffer in
+      let context = try XCTUnwrap(CGContext(
+        data: buffer.baseAddress,
+        width: image.width,
+        height: image.height,
+        bitsPerComponent: 8,
+        bytesPerRow: image.width * 4,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: rgbaBitmapInfo.rawValue
+      ))
+      context.interpolationQuality = .none
+      context.draw(image, in: CGRect(x: 0, y: 0, width: image.width, height: image.height))
+    }
+    return bytes
+  }
+
+  private func rgbaPixel(in bytes: [UInt8], x: Int, y: Int, width: Int) -> [UInt8] {
+    let index = (y * width + x) * 4
+    return Array(bytes[index..<(index + 4)])
+  }
+
+  private func countDarkenedPixels(
+    _ rendered: [UInt8],
+    comparedTo baseline: [UInt8],
+    imageWidth: Int,
+    imageHeight: Int,
+    outside screenshotRect: CGRect
+  ) -> Int {
+    var count = 0
+    for y in 0..<imageHeight {
+      for x in 0..<imageWidth where !screenshotRect.contains(CGPoint(x: x, y: y)) {
+        let index = (y * imageWidth + x) * 4
+        let renderedLuminance = Int(rendered[index]) + Int(rendered[index + 1]) + Int(rendered[index + 2])
+        let baselineLuminance = Int(baseline[index]) + Int(baseline[index + 1]) + Int(baseline[index + 2])
+        if renderedLuminance + 6 < baselineLuminance {
+          count += 1
+        }
+      }
+    }
+    return count
+  }
+
+  private var rgbaBitmapInfo: CGBitmapInfo {
+    CGBitmapInfo.byteOrder32Big.union(CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue))
   }
 }


### PR DESCRIPTION
## Summary

Canvas/preset drop shadows are visible in Annotate but were missing from exported PNGs.

The shadow intensity was preserved correctly through presets and render snapshots. The loss occurred in both normal flat export paths: they drew the canvas background, clipped to the screenshot shape, and drew the source image without first compositing the screenshot shadow.

This change:

- shares the existing Annotate preview shadow radius and offset with export rendering
- composites a Core Graphics shadow from the rounded screenshot silhouette before source clipping
- keeps the shadow outside the screenshot bounds so source pixels remain untouched at native resolution
- covers manual Annotate export and automatically applied preset export
- preserves existing output when shadow intensity is zero
- does not rely on ScreenCaptureKit native window shadows

## Tests

Added pixel-level regression coverage for:

- rounded-corner shadow over a solid background
- zero shadow intensity with unchanged background pixels
- square shadow over a gradient background
- 2x source pixel preservation with no softened edge pixels

Validation:

- AnnotateExporterTests: 12/12 passed
- PostCaptureActionHandlerTests: 20/20 passed
- unsigned Debug build passed
- git diff --check passed

The exact documented signed build/test commands cannot run on this machine because the upstream development signing certificate for team XMHV5GH2Z7 is unavailable. An unsigned full-suite run also exposed unrelated environment/parallel instability, including a multi-display coordinate-space assumption and isolated tests that pass independently.

## Manual verification

The Release-configuration app was installed in /Applications with native window shadow disabled. The user confirmed macOS permissions are detected and the canvas/preset shadow appears in the running app export workflow.
