### PR TITLE
feat: improve area selection dimension label

### DIFF
--- a/Snapzy/Services/Capture/AreaSelectionWindow.swift
+++ b/Snapzy/Services/Capture/AreaSelectionWindow.swift
@@ -3455,7 +3455,10 @@ final class AreaSelectionOverlayView: NSView {
 
   private func refreshDimensionIndicatorAfterPassiveUpdate() {
     guard let localRect = lastVisibleSelectionLocalRect else { return }
-    guard showsDimensionIndicator(forLocalPointer: currentLocalMousePoint()) else {
+    // During an active drag the tap/window path keeps `currentMousePosition` fresh;
+    // `currentLocalMousePoint()` reads `NSEvent.mouseLocation`, which unit/CI hosts
+    // do not update when tests synthesize mouse-moved events.
+    guard showsDimensionIndicator(forLocalPointer: currentMousePosition) else {
       hideSizeIndicator()
       return
     }

--- a/Snapzy/Services/Capture/AreaSelectionWindow.swift
+++ b/Snapzy/Services/Capture/AreaSelectionWindow.swift
@@ -2604,6 +2604,8 @@ final class AreaSelectionOverlayView: NSView {
   private var sizeIndicatorTextLayer: CATextLayer!
   private var lastSizeIndicatorText: String?
   private var lastSizeIndicatorTextSize: CGSize = .zero
+  private var lastVisibleSelectionLocalRect: CGRect?
+  private var lastVisibleSelectionMeasuredSize: CGSize?
   private var modeHintBackgroundLayer: CALayer!
   private var modeHintTextLayer: CATextLayer!
 
@@ -3440,13 +3442,40 @@ final class AreaSelectionOverlayView: NSView {
     return currentMousePosition
   }
 
-  /// Re-evaluates the coordinate indicator after a non-mouse event (layout pass, bounds
-  /// change, selection re-render). `updateCoordinateIndicator(at:)` applies its own guards
-  /// (mouse-over, interaction mode, visible selection rect), so this only restores the label
-  /// where it belongs on screen and keeps it hidden everywhere else — including during a
-  /// drag, where the dimensions label owns the size indicator layers.
+  /// Re-evaluates the size/coordinate indicator after a non-mouse event (layout pass, bounds
+  /// change, selection re-render). During a drag the dimensions label owns the size indicator
+  /// layers; passive updates must refresh that label instead of hiding it via the coordinate path.
   private func refreshCoordinateIndicatorAfterPassiveUpdate() {
+    if hasVisibleSelectionRect {
+      refreshDimensionIndicatorAfterPassiveUpdate()
+      return
+    }
     updateCoordinateIndicator(at: currentLocalMousePoint())
+  }
+
+  private func refreshDimensionIndicatorAfterPassiveUpdate() {
+    guard let localRect = lastVisibleSelectionLocalRect else { return }
+    guard showsDimensionIndicator(forLocalPointer: currentLocalMousePoint()) else {
+      hideSizeIndicator()
+      return
+    }
+    updateSizeIndicator(for: localRect, measuredSize: lastVisibleSelectionMeasuredSize)
+  }
+
+  /// Only the overlay whose bounds contain the active pointer shows the dimensions pill.
+  private func showsDimensionIndicator(forLocalPointer localCurrentPoint: CGPoint?) -> Bool {
+    let pointer = resolvedLocalPointerForDimensionIndicator(from: localCurrentPoint)
+    guard let pointer else { return false }
+    return bounds.contains(pointer)
+  }
+
+  private func resolvedLocalPointerForDimensionIndicator(from localCurrentPoint: CGPoint?) -> CGPoint? {
+    if let localCurrentPoint {
+      return localCurrentPoint
+    }
+    // Window-less unit tests drive the overlay directly and never supply a screen point.
+    guard window == nil else { return nil }
+    return currentMousePosition
   }
 
   /// Update bounds when screen configuration changes
@@ -3580,6 +3609,49 @@ final class AreaSelectionOverlayView: NSView {
     ]
   }
 
+  private var dimensionTextAttributes: [NSAttributedString.Key: Any] {
+    [
+      .font: CoordinateBubbleStyle.dimensionFont,
+      .foregroundColor: CoordinateBubbleStyle.dimensionTextColor,
+    ]
+  }
+
+  private func applyDimensionIndicatorPresentation() {
+    sizeIndicatorBackgroundLayer.backgroundColor = CoordinateBubbleStyle.dimensionBackgroundColor.cgColor
+    sizeIndicatorBackgroundLayer.cornerRadius = CoordinateBubbleStyle.dimensionCornerRadius
+    sizeIndicatorTextLayer.shadowOpacity = 0
+  }
+
+  private func applyCoordinateIndicatorPresentation() {
+    sizeIndicatorBackgroundLayer.backgroundColor = CoordinateBubbleStyle.backgroundColor.cgColor
+    sizeIndicatorBackgroundLayer.cornerRadius = CoordinateBubbleStyle.cornerRadius
+    sizeIndicatorTextLayer.shadowOpacity = CoordinateBubbleStyle.shadowOpacity
+  }
+
+  /// Bottom-right of the selection rect.
+  private func dimensionLabelRect(for selectionRect: CGRect, textSize: CGSize) -> CGRect {
+    let padding: CGFloat = 8
+    var origin = CGPoint(
+      x: selectionRect.maxX + padding,
+      y: selectionRect.minY - textSize.height - padding
+    )
+
+    if origin.y < bounds.minY {
+      origin.y = selectionRect.minY + padding
+    }
+    if origin.x + textSize.width > bounds.maxX {
+      origin.x = selectionRect.maxX - textSize.width - padding
+    }
+    if origin.x < bounds.minX {
+      origin.x = bounds.minX + padding
+    }
+    if origin.y + textSize.height > bounds.maxY {
+      origin.y = bounds.maxY - textSize.height - padding
+    }
+
+    return CGRect(origin: origin, size: textSize)
+  }
+
   private func multiLineTextSize(_ text: String, attributes: [NSAttributedString.Key: Any]) -> CGSize {
     let lines = text.components(separatedBy: "\n")
     let maxWidth = lines.map { $0.size(withAttributes: attributes).width }.max() ?? 0
@@ -3623,6 +3695,8 @@ final class AreaSelectionOverlayView: NSView {
     sizeIndicatorBackgroundLayer.isHidden = true
     sizeIndicatorTextLayer.isHidden = true
     lastSizeIndicatorText = nil
+    lastVisibleSelectionLocalRect = nil
+    lastVisibleSelectionMeasuredSize = nil
   }
 
   func hideMagnifier() {
@@ -3710,42 +3784,38 @@ final class AreaSelectionOverlayView: NSView {
 
   private func updateSizeIndicator(for rect: CGRect, measuredSize: CGSize? = nil) {
     let displayedSize = measuredSize ?? rect.size
-    let sizeText = "\(Int(displayedSize.width))\n\(Int(displayedSize.height))"
-    let attributes = coordinateTextAttributes
+    let sizeText = "\(Int(displayedSize.width)) × \(Int(displayedSize.height))"
+    let attributes = dimensionTextAttributes
     let textSize: CGSize
     // Assigning `CATextLayer.string` re-rasterizes the text even when unchanged, and
     // this runs per pointer tick — so measure and re-assign only on actual changes.
     let textChanged = sizeText != lastSizeIndicatorText
     if textChanged {
-      textSize = multiLineTextSize(sizeText, attributes: attributes)
+      textSize = sizeText.size(withAttributes: attributes)
       lastSizeIndicatorText = sizeText
       lastSizeIndicatorTextSize = textSize
     } else {
       textSize = lastSizeIndicatorTextSize
     }
 
-    let point = currentMousePosition
-    let offset: CGFloat = 12
-    var textRect = CGRect(
-      x: point.x + offset,
-      y: point.y - textSize.height - 4,
-      width: textSize.width,
-      height: textSize.height
-    )
+    lastVisibleSelectionLocalRect = rect
+    lastVisibleSelectionMeasuredSize = displayedSize
 
-    if textRect.maxX > bounds.maxX {
-      textRect.origin.x = point.x - textSize.width - offset
-    }
-    if textRect.minY < bounds.minY {
-      textRect.origin.y = point.y + offset
-    }
+    let textRect = dimensionLabelRect(for: rect, textSize: textSize)
 
     updateTextLayerScales()
-    sizeIndicatorBackgroundLayer.frame = textRect.insetBy(dx: -4, dy: -2)
+    applyDimensionIndicatorPresentation()
+    sizeIndicatorBackgroundLayer.frame = textRect.insetBy(
+      dx: -CoordinateBubbleStyle.dimensionHorizontalInset,
+      dy: -CoordinateBubbleStyle.dimensionVerticalInset
+    )
     sizeIndicatorBackgroundLayer.isHidden = false
 
     if textChanged {
       sizeIndicatorTextLayer.string = sizeText
+      sizeIndicatorTextLayer.font = CoordinateBubbleStyle.dimensionFont as CTFont
+      sizeIndicatorTextLayer.fontSize = CoordinateBubbleStyle.dimensionFont.pointSize
+      sizeIndicatorTextLayer.foregroundColor = CoordinateBubbleStyle.dimensionTextColor.cgColor
     }
     sizeIndicatorTextLayer.frame = textRect
     sizeIndicatorTextLayer.isHidden = false
@@ -3757,8 +3827,11 @@ final class AreaSelectionOverlayView: NSView {
     // which has no indicator of its own and relies on that panel exclusively. Showing this
     // indicator too would just duplicate it, so this one stands down and leaves the panel as
     // the single source once the magnifier takes over.
-    guard isMouseOver, interactionMode == .manualRegion, !hasVisibleSelectionRect,
-          magnifier.zoom <= 1.0 else {
+    if hasVisibleSelectionRect {
+      return
+    }
+
+    guard isMouseOver, interactionMode == .manualRegion, magnifier.zoom <= 1.0 else {
       hideSizeIndicator()
       return
     }
@@ -3795,11 +3868,18 @@ final class AreaSelectionOverlayView: NSView {
     }
 
     updateTextLayerScales()
-    sizeIndicatorBackgroundLayer.frame = textRect.insetBy(dx: -4, dy: -2)
+    applyCoordinateIndicatorPresentation()
+    sizeIndicatorBackgroundLayer.frame = textRect.insetBy(
+      dx: -CoordinateBubbleStyle.horizontalInset,
+      dy: -CoordinateBubbleStyle.verticalInset
+    )
     sizeIndicatorBackgroundLayer.isHidden = false
 
     if textChanged {
       sizeIndicatorTextLayer.string = text
+      sizeIndicatorTextLayer.font = coordinateIndicatorFont as CTFont
+      sizeIndicatorTextLayer.fontSize = coordinateIndicatorFont.pointSize
+      sizeIndicatorTextLayer.foregroundColor = CoordinateBubbleStyle.textColor.cgColor
     }
     sizeIndicatorTextLayer.frame = textRect
     sizeIndicatorTextLayer.isHidden = false
@@ -3912,7 +3992,6 @@ final class AreaSelectionOverlayView: NSView {
     }
 
     let localRect = convertToLocalRect(screenRect).intersection(bounds)
-    let showsCurrentPointer = localCurrentPoint.map { bounds.contains($0) } == true
 
     CATransaction.begin()
     CATransaction.setDisableActions(true)
@@ -3938,7 +4017,7 @@ final class AreaSelectionOverlayView: NSView {
         updateInsideOverlayAppearance(for: localRect)
         insideSelectionOverlayLayer.isHidden = false
       }
-      if showsCurrentPointer {
+      if showsDimensionIndicator(forLocalPointer: localCurrentPoint) {
         updateSizeIndicator(for: localRect, measuredSize: screenRect.size)
       } else {
         hideSizeIndicator()

--- a/Snapzy/Services/Capture/CoordinateBubbleStyle.swift
+++ b/Snapzy/Services/Capture/CoordinateBubbleStyle.swift
@@ -24,4 +24,13 @@ enum CoordinateBubbleStyle {
   static let shadowOffset = CGSize(width: 0.5, height: -0.5)
   static let shadowRadius: CGFloat = 0.1
   static let shadowOpacity: Float = 1.0
+
+  /// Readable pill for selection dimensions. Separate from the coordinate
+  /// indicator so the crosshair/cursor styling stays unchanged.
+  static let dimensionFont = NSFont.monospacedDigitSystemFont(ofSize: 13, weight: .semibold)
+  static let dimensionTextColor = NSColor.white
+  static let dimensionBackgroundColor = NSColor.black.withAlphaComponent(0.72)
+  static let dimensionCornerRadius: CGFloat = 6
+  static let dimensionHorizontalInset: CGFloat = 8
+  static let dimensionVerticalInset: CGFloat = 4
 }

--- a/SnapzyTests/Services/Capture/AreaSelectionOverlayTests.swift
+++ b/SnapzyTests/Services/Capture/AreaSelectionOverlayTests.swift
@@ -2,8 +2,8 @@
 //  AreaSelectionOverlayTests.swift
 //  SnapzyTests
 //
-//  Remaining overlay tests: coordinates indicator visibility and
-//  application-window interaction mode.
+//  Remaining overlay tests: coordinates indicator visibility, dimension label
+//  presentation, and application-window interaction mode.
 //
 
 import XCTest
@@ -97,23 +97,168 @@ final class AreaSelectionOverlayTests: AreaSelectionOverlayTestCase {
   }
 
   /// Once the drag produces a non-empty selection rect, the dimensions label owns the size
-  /// indicator layers — a passive refresh (e.g. layout pass) must not bring the coordinate
-  /// label back over it.
-  func testCoordinateIndicator_staysHiddenWhileSelectionRectVisible() {
-    // GIVEN: an in-progress drag with a non-empty selection rect
+  /// indicator layers — a passive refresh must keep that pill visible and must not swap back
+  /// to the two-line coordinate label.
+  func testDimensionIndicator_survivesLayoutPassWhileSelectionRectVisible() {
     overlayView.setSelectionEnabled(true)
     overlayView.setInteractionMode(.manualRegion, resetSelection: false)
-    overlayView.resetSelection()
+    movePointer(to: CGPoint(x: 400, y: 300))
     overlayView.renderManualSelection(
       screenRect: CGRect(x: 10, y: 10, width: 200, height: 100),
       currentScreenPoint: nil
     )
 
-    // WHEN: a passive re-evaluation happens (layout pass on the overlay)
     overlayView.layout()
 
-    // THEN: the coordinate indicator is not restored over the active selection
-    XCTAssertTrue(overlayView.testSizeIndicatorTextLayer.isHidden, "Coordinate indicator must not reappear while a sized selection rect is visible")
+    XCTAssertEqual(overlayView.testSizeIndicatorTextLayer.string as? String, "200 × 100")
+    XCTAssertFalse(overlayView.testSizeIndicatorTextLayer.isHidden)
+    XCTAssertEqual(
+      overlayView.testSizeIndicatorBackgroundLayer.backgroundColor,
+      CoordinateBubbleStyle.dimensionBackgroundColor.cgColor
+    )
+  }
+
+  func testDimensionIndicator_survivesLayoutPassInHostedWindow() throws {
+    try skipIfRunningInCI("Requires a visible host window which can fail on headless CI runners")
+
+    let hostWindowFrame = CGRect(x: 100, y: 100, width: 800, height: 600)
+    let hostWindow = NSWindow(
+      contentRect: hostWindowFrame,
+      styleMask: .borderless,
+      backing: .buffered,
+      defer: false
+    )
+    hostWindow.contentView = overlayView
+    hostWindow.setIsVisible(true)
+    defer {
+      hostWindow.contentView = nil
+      hostWindow.setIsVisible(false)
+    }
+
+    overlayView.setSelectionEnabled(true)
+    overlayView.setInteractionMode(.manualRegion, resetSelection: false)
+
+    let localPointer = CGPoint(x: 400, y: 300)
+    movePointer(to: localPointer)
+    let screenPointer = hostWindow.convertPoint(toScreen: localPointer)
+    let screenRect = CGRect(
+      x: hostWindowFrame.minX + 10,
+      y: hostWindowFrame.minY + 10,
+      width: 200,
+      height: 100
+    )
+
+    overlayView.renderManualSelection(screenRect: screenRect, currentScreenPoint: screenPointer)
+    overlayView.layout()
+
+    XCTAssertEqual(overlayView.testSizeIndicatorTextLayer.string as? String, "200 × 100")
+    XCTAssertFalse(overlayView.testSizeIndicatorTextLayer.isHidden)
+    XCTAssertEqual(
+      overlayView.testSizeIndicatorBackgroundLayer.backgroundColor,
+      CoordinateBubbleStyle.dimensionBackgroundColor.cgColor
+    )
+  }
+
+  func testDimensionIndicator_showsReadableSingleLineSizeAtSelectionCorner() {
+    overlayView.setSelectionEnabled(true)
+    overlayView.setInteractionMode(.manualRegion, resetSelection: false)
+    movePointer(to: CGPoint(x: 400, y: 300))
+    overlayView.renderManualSelection(
+      screenRect: CGRect(x: 10, y: 10, width: 640, height: 220),
+      currentScreenPoint: nil
+    )
+
+    let text = overlayView.testSizeIndicatorTextLayer.string as? String
+    XCTAssertEqual(text, "640 × 220")
+    XCTAssertFalse(overlayView.testSizeIndicatorTextLayer.isHidden)
+    XCTAssertFalse(overlayView.testSizeIndicatorBackgroundLayer.isHidden)
+    XCTAssertEqual(
+      overlayView.testSizeIndicatorBackgroundLayer.backgroundColor,
+      CoordinateBubbleStyle.dimensionBackgroundColor.cgColor
+    )
+
+    let labelFrame = overlayView.testSizeIndicatorTextLayer.frame
+    let selectionRect = CGRect(x: 10, y: 10, width: 640, height: 220)
+    XCTAssertGreaterThanOrEqual(labelFrame.minX, selectionRect.maxX - 4)
+    XCTAssertGreaterThanOrEqual(labelFrame.minY, selectionRect.minY - 4)
+  }
+
+  func testDimensionIndicator_hiddenWhenPointerOutsideOverlay() {
+    overlayView.setSelectionEnabled(true)
+    overlayView.setInteractionMode(.manualRegion, resetSelection: false)
+    movePointer(to: CGPoint(x: 400, y: 300))
+    overlayView.renderManualSelection(
+      screenRect: CGRect(x: 10, y: 10, width: 200, height: 100),
+      currentScreenPoint: nil
+    )
+    XCTAssertFalse(overlayView.testSizeIndicatorTextLayer.isHidden)
+
+    movePointer(to: CGPoint(x: -20, y: 300))
+    overlayView.renderManualSelection(
+      screenRect: CGRect(x: 10, y: 10, width: 200, height: 100),
+      currentScreenPoint: nil
+    )
+
+    XCTAssertTrue(overlayView.testSizeIndicatorTextLayer.isHidden)
+    XCTAssertTrue(overlayView.testSizeIndicatorBackgroundLayer.isHidden)
+  }
+
+  func testDimensionIndicator_fallsBackInsideSelectionWhenNearBottomRightEdge() {
+    overlayView.setSelectionEnabled(true)
+    overlayView.setInteractionMode(.manualRegion, resetSelection: false)
+    movePointer(to: CGPoint(x: 760, y: 40))
+    overlayView.renderManualSelection(
+      screenRect: CGRect(x: 720, y: 10, width: 70, height: 40),
+      currentScreenPoint: nil
+    )
+
+    let labelFrame = overlayView.testSizeIndicatorTextLayer.frame
+    let selectionRect = CGRect(x: 720, y: 10, width: 70, height: 40)
+    XCTAssertLessThanOrEqual(labelFrame.maxX, overlayView.bounds.maxX)
+    XCTAssertLessThanOrEqual(labelFrame.maxY, overlayView.bounds.maxY)
+    XCTAssertGreaterThanOrEqual(labelFrame.minX, selectionRect.minX)
+    XCTAssertLessThanOrEqual(labelFrame.maxX, selectionRect.maxX)
+  }
+
+  func testCoordinateIndicator_restoresTransparentStyleAfterSelectionEnds() {
+    overlayView.setSelectionEnabled(true)
+    overlayView.setInteractionMode(.manualRegion, resetSelection: false)
+    movePointer(to: CGPoint(x: 120, y: 120))
+    overlayView.renderManualSelection(
+      screenRect: CGRect(x: 10, y: 10, width: 200, height: 100),
+      currentScreenPoint: nil
+    )
+    XCTAssertEqual(
+      overlayView.testSizeIndicatorBackgroundLayer.backgroundColor,
+      CoordinateBubbleStyle.dimensionBackgroundColor.cgColor
+    )
+
+    overlayView.renderManualSelection(screenRect: nil, currentScreenPoint: nil)
+
+    XCTAssertFalse(overlayView.testSizeIndicatorTextLayer.isHidden)
+    XCTAssertEqual(
+      overlayView.testSizeIndicatorBackgroundLayer.backgroundColor,
+      CoordinateBubbleStyle.backgroundColor.cgColor
+    )
+    XCTAssertEqual(overlayView.testSizeIndicatorTextLayer.string as? String, "120\n480")
+  }
+
+  private func movePointer(to point: CGPoint) {
+    guard let event = NSEvent.mouseEvent(
+      with: .mouseMoved,
+      location: point,
+      modifierFlags: [],
+      timestamp: 0,
+      windowNumber: 0,
+      context: nil,
+      eventNumber: 0,
+      clickCount: 0,
+      pressure: 0
+    ) else {
+      XCTFail("Failed to synthesize mouse-moved event")
+      return
+    }
+    overlayView.mouseMoved(with: event)
   }
 
   func testApplicationWindowMode_hasNoManualDragInProgress() {


### PR DESCRIPTION
## Summary

Fixes #431.

Improves the area selection dimension label so the selected width and height remain easy to read while dragging.

- Display dimensions in a single-line `width × height` format
- Use a larger monospaced font with a dark, rounded background
- Position the label near the bottom-right corner of the selection
- Keep the label inside the overlay when the selection approaches screen edges
- Show the label only on the overlay containing the active pointer
- Preserve the dimension label across layout and other passive updates
- Restore the existing coordinate indicator style after the selection ends

## Testing

- Added coverage for dimension formatting, presentation, positioning, and edge fallback
- Added a hosted-window regression test for layout updates
- Verified coordinate indicator style restoration
- Verified existing passthrough cursor and stale-location behavior

## Screenshots

### Before

<img width="1920" height="1080" alt="1affc5290db8b34759b4ef764330b7c4" src="https://github.com/user-attachments/assets/790749f5-5a04-429b-ba29-33ff708f85a7" />

### After

<img width="2275" height="1280" alt="ebd01ea1fbe2158b541ff66edfc8c0b7" src="https://github.com/user-attachments/assets/be120bf0-ec9b-4abb-a593-149a1e5753a0" />